### PR TITLE
Fix: Validação de RG para 10 dígitos (Task 1.1)

### DIFF
--- a/backend/src/features/consultants/dto/create-consultant.dto.ts
+++ b/backend/src/features/consultants/dto/create-consultant.dto.ts
@@ -21,7 +21,7 @@ export class CreateConsultantDto {
 
   @IsString()
   @IsNotEmpty({ message: 'RG é obrigatório' })
-  @Length(9, 9, { message: 'RG deve ter exatamente 9 dígitos' })
+  @Length(9, 10, { message: 'RG deve ter entre 9 e 10 dígitos' })
   @Matches(/^\d+$/, { message: 'RG deve conter apenas números' })
   rg: string;
 

--- a/backend/src/features/users/dto/update-user.dto.ts
+++ b/backend/src/features/users/dto/update-user.dto.ts
@@ -13,12 +13,12 @@ import {
  * - name: nome do usuário
  * - surname: sobrenome
  * - cpf: CPF (11 dígitos) - único no sistema
- * - rg: RG (até 10 dígitos) - único no sistema
+ * - rg: RG (de 9 a 10 dígitos) - único no sistema
  * - calendly_url: link do Calendly (apenas para especialistas)
  *
  * Validações:
  * - CPF: exatamente 11 dígitos numéricos
- * - RG: até 10 dígitos numéricos
+ * - RG: de 9 a 10 dígitos numéricos
  * - calendly_url: URL válida do Calendly
  */
 export class UpdateUserDto {
@@ -43,7 +43,7 @@ export class UpdateUserDto {
 
   @IsOptional()
   @IsString()
-  @Matches(/^\d{1,10}$/, { message: 'RG deve conter até 10 dígitos numéricos' })
+  @Matches(/^\d{9,10}$/, { message: 'RG deve conter entre 9 e 10 dígitos numéricos' })
   rg?: string;
 
   @IsOptional()

--- a/frontend/src/pages/admin/NewConsultantForm.tsx
+++ b/frontend/src/pages/admin/NewConsultantForm.tsx
@@ -82,11 +82,11 @@ export default function NewConsultantForm({
   };
 
   /**
-   * Valida o formato do RG (apenas números, 9 dígitos)
+   * Valida o formato do RG (apenas números, 9 a 10 dígitos)
    */
   const validateRG = (rg: string): boolean => {
     const cleanRG = rg.replace(/\D/g, '');
-    return cleanRG.length === 9;
+    return cleanRG.length >= 9 && cleanRG.length <= 10;
   };
 
   /**
@@ -130,7 +130,7 @@ export default function NewConsultantForm({
     }
 
     if (!validateRG(rg)) {
-      setError("RG deve conter exatamente 9 dígitos numéricos.");
+      setError("RG deve conter entre 9 e 10 dígitos numéricos.");
       return;
     }
 
@@ -275,13 +275,14 @@ export default function NewConsultantForm({
           id="rg"
           type="text"
           value={rg}
-          onChange={(e) => setRg(e.target.value)}
-          placeholder="123456789"
-          maxLength={9}
+          onChange={(e) => setRg(e.target.value.replace(/\D/g, '').slice(0, 10))}
+          placeholder="1234567890"
+          maxLength={10}
+          inputMode="numeric"
           className="mt-1 block w-full px-3 py-2 border border-brand-border rounded-md shadow-sm focus:outline-none focus:ring-brand-dark focus:border-brand-dark"
           required
         />
-        <p className="text-xs text-gray-500 mt-1">Digite 9 dígitos numéricos</p>
+        <p className="text-xs text-gray-500 mt-1">Digite de 9 a 10 dígitos numéricos</p>
       </div>
 
       <div>


### PR DESCRIPTION
# Changelog

- Altera o limite físico (`maxLength`) de 9 para 10 no campo de RG no formulário `NewConsultantForm.tsx`;
- Ajusta a máscara e a validação de schema no frontend para aceitar a digitação do 10º caractere;
- Atualiza a mensagem de erro (microcopy) na interface para refletir a nova regra de limite de RG;
- Atualiza a validação `@Length` no DTO `create-consultant.dto.ts` para aceitar RGs entre 9 e 10 dígitos no backend;
- Alinha a validação do `update-user.dto.ts` para garantir a consistência da regra na edição de usuários.

closes: [#152 Bug: Frontend bloqueia digitação de RG com 10 dígitos](https://github.com/InteliJR/high-classShop/issues/152), [[TEST][BE] TASK 1.1 — Testar cadastro de RG com 9 e 10 dígitos
](https://github.com/orgs/InteliJR/projects/23/views/1?pane=issue&itemId=189112555).