### PR TITLE
feat: thumbnail do produto na listagem do especialista

### DIFF
--- a/frontend/src/pages/specialist/ProductsPage.tsx
+++ b/frontend/src/pages/specialist/ProductsPage.tsx
@@ -196,6 +196,7 @@ export default function ProductsPage() {
             <table className="w-full">
               <thead className="border-b">
                 <tr className="text-left">
+                  <th className="pb-3 text-sm font-medium text-gray-600">Foto</th>
                   <th className="pb-3 text-sm font-medium text-gray-600">Marca</th>
                   <th className="pb-3 text-sm font-medium text-gray-600">Modelo</th>
                   <th className="pb-3 text-sm font-medium text-gray-600">Ano</th>
@@ -207,6 +208,23 @@ export default function ProductsPage() {
               <tbody>
                 {filteredProducts.map((product) => (
                   <tr key={product.id} className="border-b hover:bg-gray-50">
+                    <td className="py-3 pr-3">
+                      {product.imageUrl ? (
+                        <img
+                          src={product.imageUrl}
+                          alt={`${product.marca} ${product.modelo}`}
+                          className="w-16 h-16 object-cover rounded-md border border-gray-200"
+                          loading="lazy"
+                          onError={(e) => {
+                            (e.currentTarget as HTMLImageElement).style.display = "none";
+                          }}
+                        />
+                      ) : (
+                        <div className="w-16 h-16 rounded-md border border-gray-200 bg-gray-100 flex items-center justify-center text-gray-400 text-xs">
+                          sem foto
+                        </div>
+                      )}
+                    </td>
                     <td className="py-3">{product.marca}</td>
                     <td className="py-3">{product.modelo}</td>
                     <td className="py-3">{product.ano || "-"}</td>


### PR DESCRIPTION
## Summary
- Adiciona coluna "Foto" na tabela de produtos da página do especialista (`frontend/src/pages/specialist/ProductsPage.tsx`)
- Thumbnail 64x64 com `object-cover` usando `imageUrl` já retornado pelos services de cars/boats/aircrafts
- Fallback "sem foto" quando produto não tem imagem; `onError` esconde thumb quebrado

## Test plan
- [ ] Logar como SPECIALIST e abrir `/specialist/products`
- [ ] Verificar coluna Foto exibindo imagem primária dos produtos
- [ ] Verificar fallback "sem foto" em produto sem imagem
- [ ] Trocar tipo de produto (Carros/Lanchas/Aeronaves) e validar thumbs corretos

🤖 Generated with [Claude Code](https://claude.com/claude-code)