### PR TITLE
feat: sidebar com páginas acessíveis para o usuário OFFICE

### DIFF
--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Building2,
   Users,
   UserCog,
+  UserPlus,
   Car,
   Ship,
   Plane,
@@ -149,6 +150,35 @@ export default function Sidebar() {
           },
           {
             to: "/admin/my-company",
+            label: "Minha Empresa",
+            icon: <Building2 size={20} />,
+          },
+        );
+        break;
+      case "OFFICE":
+        links.push(
+          {
+            to: "/office/dashboard",
+            label: "Dashboard",
+            icon: <LayoutDashboard size={20} />,
+          },
+          {
+            to: "/office/consultants",
+            label: "Consultores",
+            icon: <Users size={20} />,
+          },
+          {
+            to: "/office/clients",
+            label: "Clientes",
+            icon: <UserCog size={20} />,
+          },
+          {
+            to: "/office/invite-batch",
+            label: "Convites em Lote",
+            icon: <UserPlus size={20} />,
+          },
+          {
+            to: "/office/company",
             label: "Minha Empresa",
             icon: <Building2 size={20} />,
           },


### PR DESCRIPTION
## Summary
- `frontend/src/layouts/Sidebar.tsx` não cobria o role `OFFICE`, resultando em sidebar vazia para o gerente
- Adicionado `case "OFFICE"` com links para as rotas já existentes: `/office/dashboard`, `/office/consultants`, `/office/clients`, `/office/invite-batch`, `/office/company`
- Importado ícone `UserPlus` (lucide-react) para a entrada de Convites em Lote

## Test plan
- [ ] Logar como usuário OFFICE
- [ ] Verificar que a sidebar exibe os 5 itens: Dashboard, Consultores, Clientes, Convites em Lote, Minha Empresa
- [ ] Clicar em cada item e confirmar navegação para a rota correta
- [ ] Validar que o item ativo destaca com a cor primária da marca

🤖 Generated with [Claude Code](https://claude.com/claude-code)