### PR TITLE
feat: consultor pode atuar na negociação em nome do cliente

### DIFF
--- a/backend/src/features/proposals/proposals.service.ts
+++ b/backend/src/features/proposals/proposals.service.ts
@@ -76,6 +76,7 @@ export class ProposalsService {
             name: true,
             surname: true,
             role: true,
+            consultant_id: true,
           },
         },
         specialist: {
@@ -130,11 +131,13 @@ export class ProposalsService {
       });
     }
 
-    // 3. Validar que usuário é participante do processo
+    // 3. Validar que usuário é participante do processo (cliente, especialista ou consultor do cliente)
     const isClient = process.client_id === userId;
     const isSpecialist = process.specialist_id === userId;
+    const isConsultantOfClient = process.client?.consultant_id === userId;
+    const isOnClientSide = isClient || isConsultantOfClient;
 
-    if (!isClient && !isSpecialist) {
+    if (!isClient && !isSpecialist && !isConsultantOfClient) {
       this.logger.warn(
         `[create] Usuário ${userId} não é participante do processo ${dto.process_id}`,
       );
@@ -148,19 +151,23 @@ export class ProposalsService {
       });
     }
 
-    // 4. Validar alternância (não pode enviar 2 propostas seguidas)
+    // 4. Validar alternância por lado (cliente/consultor vs especialista) — não pode dois envios seguidos do mesmo lado
     const lastProposal = process.proposals[0];
-    if (lastProposal && lastProposal.proposed_by.id === userId) {
-      // Só bloqueia se a última proposta está PENDING
-      if (lastProposal.status === ProposalStatus.PENDING) {
+    if (lastProposal && lastProposal.status === ProposalStatus.PENDING) {
+      const lastProposerSide =
+        lastProposal.proposed_by.id === process.specialist_id
+          ? 'SPECIALIST'
+          : 'CLIENT';
+      const userSide = isOnClientSide ? 'CLIENT' : 'SPECIALIST';
+      if (lastProposerSide === userSide) {
         this.logger.warn(
-          `[create] Usuário ${userId} tentou enviar proposta seguida`,
+          `[create] Usuário ${userId} tentou enviar proposta seguida (lado ${userSide})`,
         );
         throw new BadRequestException({
           success: false,
           error: {
             code: 400,
-            message: 'Aguarde a resposta da sua proposta anterior',
+            message: 'Aguarde a resposta da proposta anterior',
             details: {
               last_proposal_id: lastProposal.id,
               last_proposal_status: lastProposal.status,
@@ -255,8 +262,10 @@ export class ProposalsService {
       }
     }
 
-    // 8. Determinar destinatário
-    const proposedToId = isClient ? process.specialist_id : process.client_id;
+    // 8. Determinar destinatário (lado oposto)
+    const proposedToId = isOnClientSide
+      ? process.specialist_id
+      : process.client_id;
 
     // 9. Criar proposta em transação
     const proposal = await this.prisma.$transaction(async (tx) => {
@@ -299,13 +308,13 @@ export class ProposalsService {
 
     // Fire-and-forget: Enviar notificação de nova proposta
     // Reutiliza productValue já calculado acima
-    const recipientName = isClient
+    const recipientName = isOnClientSide
       ? `${process.specialist.name} ${process.specialist.surname || ''}`.trim()
       : `${process.client.name} ${process.client.surname || ''}`.trim();
-    const proposerName = isClient
+    const proposerName = isOnClientSide
       ? `${process.client.name} ${process.client.surname || ''}`.trim()
       : `${process.specialist.name} ${process.specialist.surname || ''}`.trim();
-    const recipientEmail = isClient
+    const recipientEmail = isOnClientSide
       ? process.specialist.email!
       : process.client.email!;
 
@@ -467,10 +476,25 @@ export class ProposalsService {
     );
     const pendingResponseFrom = lastPendingProposal?.proposed_to_id;
 
-    // 5. Verificar se usuário pode criar proposta
+    // 5. Verificar se usuário pode criar proposta (lógica por lado)
+    const userSide: 'CLIENT' | 'SPECIALIST' | null =
+      process.client_id === userId || process.client?.consultant_id === userId
+        ? 'CLIENT'
+        : process.specialist_id === userId
+          ? 'SPECIALIST'
+          : null;
+
+    const lastPendingTargetSide: 'CLIENT' | 'SPECIALIST' | null =
+      lastPendingProposal
+        ? lastPendingProposal.proposed_to_id === process.specialist_id
+          ? 'SPECIALIST'
+          : 'CLIENT'
+        : null;
+
     const canCreateProposal =
+      userSide !== null &&
       process.status === ProcessStatus.NEGOTIATION &&
-      (!lastPendingProposal || lastPendingProposal.proposed_to_id === userId);
+      (!lastPendingProposal || lastPendingTargetSide === userSide);
 
     return {
       proposals: process.proposals.map((p) => this.mapToResponseEntity(p)),
@@ -812,6 +836,7 @@ export class ProposalsService {
             car_id: true,
             boat_id: true,
             aircraft_id: true,
+            client: { select: { consultant_id: true } },
           },
         },
       },
@@ -828,8 +853,13 @@ export class ProposalsService {
       });
     }
 
-    // Validar que é o destinatário
-    if (proposal.proposed_to_id !== userId) {
+    // Validar destinatário — usuário direto ou consultor do cliente quando a proposta é para o cliente
+    const isDirectTarget = proposal.proposed_to_id === userId;
+    const isConsultantOfTargetClient =
+      proposal.process.client?.consultant_id === userId &&
+      proposal.proposed_to_id === proposal.process.client_id;
+
+    if (!isDirectTarget && !isConsultantOfTargetClient) {
       throw new ForbiddenException({
         success: false,
         error: {

--- a/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
@@ -10,12 +10,16 @@ import {
   MessageSquare,
   Package,
   RefreshCw,
+  Send,
   User,
   UserCog,
   X,
 } from "lucide-react";
 import {
+  acceptProposal,
+  createProposal,
   getProcessProposals,
+  rejectProposal,
   type NegotiationMeta,
   type NegotiationProcessInfo,
   type NegotiationProposal,
@@ -24,6 +28,7 @@ import {
   getProcessById,
   type Process,
 } from "../../services/processes.service";
+import { useAuth } from "../../store/authStateManager";
 
 const STATUS_LABELS: Record<string, string> = {
   SCHEDULING: "Agendamento",
@@ -104,6 +109,7 @@ function ProposalStatusBadge({ status }: { status: string }) {
 export default function ConsultantProcessDetailPage() {
   const { processId } = useParams<{ processId: string }>();
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   const [process, setProcess] = useState<Process | null>(null);
   const [proposals, setProposals] = useState<NegotiationProposal[]>([]);
@@ -112,6 +118,14 @@ export default function ConsultantProcessDetailPage() {
   const [meta, setMeta] = useState<NegotiationMeta | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [proposedValue, setProposedValue] = useState<string>("");
+  const [message, setMessage] = useState<string>("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSending, setIsSending] = useState(false);
+  const [pendingActionProposalId, setPendingActionProposalId] = useState<
+    string | null
+  >(null);
 
   const timelineRef = useRef<HTMLDivElement>(null);
 
@@ -166,6 +180,103 @@ export default function ConsultantProcessDetailPage() {
     }
   }, [proposals]);
 
+  const handleValueChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = e.target.value.replace(/\D/g, "");
+    const numeric = parseInt(raw) || 0;
+    const formatted = (numeric / 100).toLocaleString("pt-BR", {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    setProposedValue(formatted);
+  };
+
+  const handleSubmitProposal = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setFormError(null);
+
+    if (!processId || !processInfo) return;
+
+    const value = parseFloat(proposedValue.replace(/\D/g, "")) / 100;
+
+    if (isNaN(value) || value <= 0) {
+      setFormError("Informe um valor válido.");
+      return;
+    }
+
+    if (value < processInfo.minimum_value) {
+      setFormError(
+        `O valor mínimo permitido é ${formatCurrency(processInfo.minimum_value)}.`,
+      );
+      return;
+    }
+
+    const lastPending = proposals.find((p) => p.status === "PENDING");
+
+    try {
+      setIsSending(true);
+      await createProposal({
+        process_id: processId,
+        proposed_value: value,
+        message: message || undefined,
+        counter_to_id: lastPending?.id,
+      });
+      setProposedValue("");
+      setMessage("");
+      await load();
+    } catch (err) {
+      console.error("[ConsultantProcessDetailPage] Erro ao enviar:", err);
+      setFormError(
+        err instanceof Error ? err.message : "Erro ao enviar proposta.",
+      );
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const handleAccept = async (proposalId: string) => {
+    try {
+      setPendingActionProposalId(proposalId);
+      await acceptProposal(proposalId, "Proposta aceita pelo consultor");
+      await load();
+    } catch (err) {
+      console.error("[ConsultantProcessDetailPage] Erro ao aceitar:", err);
+      setError(err instanceof Error ? err.message : "Erro ao aceitar proposta");
+    } finally {
+      setPendingActionProposalId(null);
+    }
+  };
+
+  const handleReject = async (proposalId: string) => {
+    try {
+      setPendingActionProposalId(proposalId);
+      await rejectProposal(proposalId, "Proposta rejeitada pelo consultor");
+      await load();
+    } catch (err) {
+      console.error("[ConsultantProcessDetailPage] Erro ao rejeitar:", err);
+      setError(
+        err instanceof Error ? err.message : "Erro ao rejeitar proposta",
+      );
+    } finally {
+      setPendingActionProposalId(null);
+    }
+  };
+
+  const canCreateProposal = (): boolean => {
+    if (!processInfo || !meta) return false;
+    if (processInfo.status !== "NEGOTIATION") return false;
+    return meta.can_create_proposal;
+  };
+
+  const canRespondToProposal = (proposal: NegotiationProposal): boolean => {
+    if (!user || proposal.status !== "PENDING") return false;
+    if (processInfo?.status !== "NEGOTIATION") return false;
+    // Consultor atua pelo cliente: pode responder quando proposta é destinada ao cliente
+    return (
+      proposal.proposed_to.id === user.id ||
+      proposal.proposed_to.role === "CUSTOMER"
+    );
+  };
+
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24 text-gray-600">
@@ -204,6 +315,8 @@ export default function ConsultantProcessDetailPage() {
     STATUS_COLORS[process.status] ?? "bg-gray-100 text-gray-600";
 
   const acceptedProposal = proposals.find((p) => p.status === "ACCEPTED");
+  const isAwaitingProduct = !process.product_type || !process.product_id;
+  const showCreateForm = canCreateProposal();
 
   return (
     <div className="text-text-main w-full">
@@ -219,8 +332,7 @@ export default function ConsultantProcessDetailPage() {
           <div>
             <h1 className="h1-style">Detalhes do processo</h1>
             <p className="text-sm text-gray-500 mt-1">
-              Visualização somente leitura. A negociação é conduzida entre
-              cliente e especialista.
+              Acompanhe e atue na negociação em nome do cliente.
             </p>
           </div>
         </div>
@@ -346,7 +458,7 @@ export default function ConsultantProcessDetailPage() {
           <h2 className="h2-style">Histórico de propostas</h2>
         </div>
 
-        {!process.product_type || !process.product_id ? (
+        {isAwaitingProduct ? (
           <div className="text-center py-10 text-gray-500 text-sm">
             A negociação ainda não foi iniciada. O especialista precisa
             associar um produto ao processo.
@@ -393,10 +505,106 @@ export default function ConsultantProcessDetailPage() {
                   </p>
                 )}
                 <ProposalStatusBadge status={proposal.status} />
+
+                {canRespondToProposal(proposal) && (
+                  <div className="flex gap-2 mt-3 pt-3 border-t border-gray-100">
+                    <button
+                      onClick={() => handleAccept(proposal.id)}
+                      disabled={pendingActionProposalId !== null}
+                      className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-2 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 transition-colors disabled:opacity-50"
+                    >
+                      {pendingActionProposalId === proposal.id ? (
+                        <Loader2 size={16} className="animate-spin" />
+                      ) : (
+                        <Check size={16} />
+                      )}
+                      Aceitar
+                    </button>
+                    <button
+                      onClick={() => handleReject(proposal.id)}
+                      disabled={pendingActionProposalId !== null}
+                      className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50"
+                    >
+                      {pendingActionProposalId === proposal.id ? (
+                        <Loader2 size={16} className="animate-spin" />
+                      ) : (
+                        <X size={16} />
+                      )}
+                      Rejeitar
+                    </button>
+                  </div>
+                )}
               </div>
             ))}
           </div>
         )}
+
+        {showCreateForm && (
+          <div className="mt-6 pt-4 border-t border-gray-200">
+            <h3 className="text-sm font-semibold text-gray-900 mb-3">
+              Enviar nova proposta
+            </h3>
+            {formError && (
+              <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2 text-sm text-red-700">
+                <AlertCircle size={16} />
+                {formError}
+              </div>
+            )}
+            <form
+              onSubmit={handleSubmitProposal}
+              className="flex flex-col md:flex-row gap-3"
+            >
+              <div className="flex-1 flex flex-col md:flex-row gap-3">
+                <div className="relative flex-1 min-w-0">
+                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <span className="text-gray-500">R$</span>
+                  </div>
+                  <input
+                    type="text"
+                    value={proposedValue}
+                    onChange={handleValueChange}
+                    placeholder="0,00"
+                    className="w-full pl-10 pr-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-slate-500 text-right font-medium"
+                    disabled={isSending}
+                  />
+                </div>
+                <input
+                  type="text"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  placeholder="Mensagem (opcional)"
+                  className="flex-1 px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-slate-500"
+                  disabled={isSending}
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={isSending || !proposedValue}
+                className="inline-flex items-center justify-center gap-2 px-6 py-2.5 bg-slate-700 text-white font-medium rounded-lg hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isSending ? (
+                  <Loader2 size={18} className="animate-spin" />
+                ) : (
+                  <Send size={18} />
+                )}
+                Enviar proposta
+              </button>
+            </form>
+            {processInfo && (
+              <p className="mt-2 text-xs text-gray-500">
+                Valor mínimo aceito: {formatCurrency(processInfo.minimum_value)}
+              </p>
+            )}
+          </div>
+        )}
+
+        {!showCreateForm &&
+          processInfo?.status === "NEGOTIATION" &&
+          !isAwaitingProduct && (
+            <div className="mt-6 p-3 bg-gray-50 border border-gray-200 rounded-lg text-center text-sm text-gray-600">
+              Aguardando resposta do especialista.
+            </div>
+          )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Backend (`ProposalsService`) agora trata o consultor como lado do cliente: pode criar propostas, aceitar e rejeitar quando vinculado via `client.consultant_id`.
- Alternância de propostas migrada de "mesmo usuário" para "mesmo lado" (CLIENT vs SPECIALIST).
- Frontend (`ConsultantProcessDetailPage`) ganha form de nova proposta + botões Aceitar/Rejeitar em propostas pendentes destinadas ao cliente.

## Test plan
- [ ] Consultor abre `/consultant/processes/:id` com status NEGOTIATION → confirma form de proposta visível.
- [ ] Consultor envia proposta → backend grava com `proposed_to_id = specialist_id`.
- [ ] Especialista envia contraproposta → consultor vê botões Aceitar/Rejeitar.
- [ ] Consultor aceita → processo move para DOCUMENTATION.
- [ ] Consultor tenta enviar 2 propostas seguidas (sem resposta do especialista) → bloqueado com "Aguarde a resposta da proposta anterior".
- [ ] Usuário não-consultor tenta endpoint → 403.
- [ ] `npm run lint && npm run build && npm test` no backend.
- [ ] `npm run lint && npm run build` no frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)