### PR TITLE
feat: consultor pode entrar na reunião do cliente

### DIFF
--- a/backend/src/features/meetings/meetings.service.ts
+++ b/backend/src/features/meetings/meetings.service.ts
@@ -215,7 +215,16 @@ export class MeetingsService {
       include: {
         appointment: true,
         client: {
-          select: { id: true, email: true, name: true, surname: true },
+          select: {
+            id: true,
+            email: true,
+            name: true,
+            surname: true,
+            consultant_id: true,
+            consultant: {
+              select: { id: true, email: true, name: true, surname: true },
+            },
+          },
         },
         specialist: {
           select: { id: true, email: true, name: true, surname: true },
@@ -230,12 +239,14 @@ export class MeetingsService {
 
     const isClient = process.client_id === userId;
     const isSpecialist = process.specialist_id === userId;
+    // Consultor que gerencia o cliente também pode acompanhar a reunião
+    const isConsultant = process.client?.consultant_id === userId;
 
-    if (!isClient && !isSpecialist) {
+    if (!isClient && !isSpecialist && !isConsultant) {
       throw new ForbiddenException('Sem permissão para acessar esta reunião');
     }
 
-    return { process, isClient, isSpecialist };
+    return { process, isClient, isSpecialist, isConsultant };
   }
 
   private buildMeetingResponse(meetingSession: {
@@ -437,6 +448,12 @@ export class MeetingsService {
       );
     }
 
+    const consultant = process.client.consultant;
+    const consultantEmail = consultant?.email;
+    const consultantName = consultant
+      ? `${consultant.name} ${consultant.surname || ''}`.trim()
+      : undefined;
+
     if (
       process.status !== 'SCHEDULING' &&
       process.status !== 'NEGOTIATION' &&
@@ -477,6 +494,8 @@ export class MeetingsService {
           processId: process.id,
           platformMeetingUrl: `${this.frontendUrl}/processes/${process.id}/meeting`,
           meetingLink: jitsiLink,
+          consultantEmail,
+          consultantName,
         };
         const emailMethod = isAdvanced
           ? this.notificationService.sendMeetingAdvancedEmail(emailData)
@@ -540,6 +559,8 @@ export class MeetingsService {
             processId: process.id,
             platformMeetingUrl: `${this.frontendUrl}/processes/${process.id}/meeting`,
             meetingLink: demoLink,
+            consultantEmail,
+            consultantName,
           };
           const emailMethod = isAdvanced
             ? this.notificationService.sendMeetingAdvancedEmail(emailData)
@@ -622,6 +643,8 @@ export class MeetingsService {
         processId: process.id,
         platformMeetingUrl: `${this.frontendUrl}/processes/${process.id}/meeting`,
         meetingLink: meetLink,
+        consultantEmail,
+        consultantName,
       };
       const emailMethod = isAdvanced
         ? this.notificationService.sendMeetingAdvancedEmail(emailData)

--- a/backend/src/features/notifications/dto/notification-email.dto.ts
+++ b/backend/src/features/notifications/dto/notification-email.dto.ts
@@ -41,6 +41,9 @@ export interface MeetingStartedEmailDto {
   processId: string;
   platformMeetingUrl: string;
   meetingLink?: string;
+  // Consultor que gerencia o cliente — recebe cópia quando presente
+  consultantEmail?: string;
+  consultantName?: string;
 }
 
 export interface MeetingAdvancedEmailDto {
@@ -50,6 +53,9 @@ export interface MeetingAdvancedEmailDto {
   processId: string;
   platformMeetingUrl: string;
   meetingLink?: string;
+  // Consultor que gerencia o cliente — recebe cópia quando presente
+  consultantEmail?: string;
+  consultantName?: string;
 }
 
 export interface MeetingReminderEmailDto {

--- a/backend/src/features/notifications/notification.service.ts
+++ b/backend/src/features/notifications/notification.service.ts
@@ -893,6 +893,80 @@ ${
     );
   }
 
+  /**
+   * Envia cópia da notificação de reunião ao consultor que gerencia o cliente.
+   * Só dispara quando o processo possui consultor vinculado (data.consultantEmail).
+   */
+  private async sendMeetingConsultantCopy(
+    data: MeetingStartedEmailDto | MeetingAdvancedEmailDto,
+    variant: 'STARTED' | 'ADVANCED',
+  ): Promise<void> {
+    if (!data.consultantEmail) {
+      return;
+    }
+
+    const consultantName = data.consultantName || 'Consultor';
+    const action = variant === 'ADVANCED' ? 'adiantada' : 'iniciada';
+    const subject = `Reunião do seu cliente ${action} | High-Class Shop`;
+
+    const html = `
+      <!DOCTYPE html>
+      <html>
+      <head><meta charset="UTF-8"></head>
+      <body style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #f5f5f5;">
+        <div style="background-color: #1e293b; color: #fff; padding: 30px; text-align: center;">
+          <h1 style="margin: 0; font-size: 24px; font-weight: 600; letter-spacing: 0.5px;">High-Class Shop</h1>
+        </div>
+        <div style="padding: 40px 30px; background-color: #ffffff;">
+          <h2 style="color: #1e293b; margin-top: 0;">Reunião ${action}</h2>
+          <p style="font-size: 16px; color: #334155;">Olá <strong>${consultantName}</strong>,</p>
+          <p style="font-size: 16px; color: #334155;">
+            A reunião do seu cliente <strong>${data.clientName}</strong> com o especialista
+            <strong>${data.specialistName}</strong> foi ${action}. Você pode acompanhar em nome do cliente.
+          </p>
+          <div style="background-color: #f8fafc; border: 1px solid #e2e8f0; padding: 20px; border-radius: 6px; margin: 25px 0;">
+            <p style="margin: 8px 0; color: #334155;"><strong>Processo:</strong> ${data.processId}</p>
+          </div>
+          <div style="text-align: center; margin: 30px 0;">
+            <a href="${data.platformMeetingUrl}"
+               style="display: inline-block; background-color: #1e293b; color: #fff;
+                      padding: 14px 32px; text-decoration: none; border-radius: 6px;
+                      font-weight: 600; font-size: 16px;">
+              Entrar na Reunião
+            </a>
+          </div>
+          <p style="font-size: 14px; color: #64748b;">Se o botão não funcionar, acesse a plataforma:</p>
+          <p style="font-size: 14px; color: #334155; word-break: break-all;">${data.platformMeetingUrl}</p>
+        </div>
+        <div style="background-color: #f8fafc; padding: 20px; text-align: center; font-size: 13px; color: #64748b; border-top: 1px solid #e2e8f0;">
+          <p style="margin: 0;">High-Class Shop &mdash; Marketplace de Bens de Luxo</p>
+        </div>
+      </body>
+      </html>
+    `;
+
+    const text = `
+High-class Shop - Reunião ${action}
+
+Olá ${consultantName},
+
+A reunião do seu cliente ${data.clientName} com o especialista ${data.specialistName} foi ${action}. Você pode acompanhar em nome do cliente.
+
+Processo: ${data.processId}
+Acesse a reunião em: ${data.platformMeetingUrl}
+
+© 2026 High-class Shop
+    `.trim();
+
+    await this.sendEmailSafely(
+      `MEETING_${variant}_CONSULTANT`,
+      data.consultantEmail,
+      subject,
+      html,
+      text,
+    );
+  }
+
   async sendMeetingStartedEmail(data: MeetingStartedEmailDto): Promise<void> {
     if (!this.notificationsEnabled) {
       this.logger.debug(
@@ -965,6 +1039,8 @@ ${data.meetingLink ? `Link alternativo da sala: ${data.meetingLink}` : ''}
       html,
       text,
     );
+
+    await this.sendMeetingConsultantCopy(data, 'STARTED');
   }
 
   async sendMeetingAdvancedEmail(data: MeetingAdvancedEmailDto): Promise<void> {
@@ -1040,6 +1116,8 @@ ${data.meetingLink ? `Link alternativo da sala: ${data.meetingLink}` : ''}
       html,
       text,
     );
+
+    await this.sendMeetingConsultantCopy(data, 'ADVANCED');
   }
 
   async sendMeetingReminderEmail(data: MeetingReminderEmailDto): Promise<void> {

--- a/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
@@ -13,6 +13,7 @@ import {
   Send,
   User,
   UserCog,
+  Video,
   X,
 } from "lucide-react";
 import {
@@ -25,7 +26,9 @@ import {
   type NegotiationProposal,
 } from "../../services/proposals.service";
 import {
+  getMeetingByProcess,
   getProcessById,
+  type MeetingSession,
   type Process,
 } from "../../services/processes.service";
 import { useAuth } from "../../store/authStateManager";
@@ -116,6 +119,10 @@ export default function ConsultantProcessDetailPage() {
   const [processInfo, setProcessInfo] =
     useState<NegotiationProcessInfo | null>(null);
   const [meta, setMeta] = useState<NegotiationMeta | null>(null);
+  const [meetingSession, setMeetingSession] = useState<MeetingSession | null>(
+    null,
+  );
+  const [isLoadingMeeting, setIsLoadingMeeting] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -138,6 +145,40 @@ export default function ConsultantProcessDetailPage() {
 
       const processData = await getProcessById(processId);
       setProcess(processData);
+
+      // Durante o agendamento não há negociação ainda — só o agendamento e a
+      // reunião. As propostas só são carregadas a partir da negociação.
+      const isScheduling = processData.status === "SCHEDULING";
+      const isAppointmentConfirmed =
+        processData.appointment_status === "SCHEDULED" ||
+        processData.appointment_status === "COMPLETED";
+
+      if (isScheduling) {
+        setProposals([]);
+        setProcessInfo(null);
+        setMeta(null);
+
+        if (isAppointmentConfirmed) {
+          try {
+            setIsLoadingMeeting(true);
+            const meeting = await getMeetingByProcess(processId);
+            setMeetingSession(meeting);
+          } catch (err) {
+            console.warn(
+              "[ConsultantProcessDetailPage] Falha ao carregar reunião",
+              err,
+            );
+            setMeetingSession(null);
+          } finally {
+            setIsLoadingMeeting(false);
+          }
+        } else {
+          setMeetingSession(null);
+        }
+        return;
+      }
+
+      setMeetingSession(null);
 
       const hasProduct = !!processData.product_type && !!processData.product_id;
       if (hasProduct) {
@@ -317,6 +358,10 @@ export default function ConsultantProcessDetailPage() {
   const acceptedProposal = proposals.find((p) => p.status === "ACCEPTED");
   const isAwaitingProduct = !process.product_type || !process.product_id;
   const showCreateForm = canCreateProposal();
+  const isScheduling = process.status === "SCHEDULING";
+  const isAppointmentConfirmed =
+    process.appointment_status === "SCHEDULED" ||
+    process.appointment_status === "COMPLETED";
 
   return (
     <div className="text-text-main w-full">
@@ -420,7 +465,7 @@ export default function ConsultantProcessDetailPage() {
         )}
       </div>
 
-      {processInfo && (
+      {!isScheduling && processInfo && (
         <div className="p-4 rounded-lg shadow bg-white mb-6 flex flex-wrap items-center gap-6 text-sm">
           <div className="flex items-center gap-2">
             <DollarSign size={16} className="text-green-600" />
@@ -453,6 +498,84 @@ export default function ConsultantProcessDetailPage() {
         </div>
       )}
 
+      {isScheduling ? (
+        <div className="p-6 rounded-lg shadow bg-white">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="h2-style">Agendamento</h2>
+          </div>
+
+          <div className="mb-4">
+            {isAppointmentConfirmed ? (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-800 text-xs font-medium rounded-full">
+                <Check size={12} />
+                Agendamento confirmado
+              </span>
+            ) : process.appointment_status === "CANCELLED" ? (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-red-100 text-red-800 text-xs font-medium rounded-full">
+                <X size={12} />
+                Agendamento cancelado
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1 px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-full">
+                <Loader2 size={12} className="animate-spin" />
+                Aguardando confirmação do agendamento
+              </span>
+            )}
+          </div>
+
+          {process.appointment_datetime ? (
+            <div className="flex items-center gap-2 text-sm text-gray-700 mb-4">
+              <Calendar size={16} className="text-gray-400" />
+              Reunião marcada para {formatDate(process.appointment_datetime)}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500 mb-4">
+              Data e horário ainda não definidos.
+            </p>
+          )}
+
+          {isAppointmentConfirmed ? (
+            <div className="p-4 bg-slate-50 border border-slate-200 rounded-lg">
+              {isLoadingMeeting ? (
+                <p className="inline-flex items-center gap-2 text-sm text-gray-600">
+                  <Loader2 size={16} className="animate-spin" />
+                  Verificando reunião...
+                </p>
+              ) : meetingSession && !meetingSession.ended_at ? (
+                <>
+                  <p className="text-sm text-slate-800 mb-3">
+                    O especialista iniciou a reunião. Entre para acompanhar em
+                    nome do cliente.
+                  </p>
+                  <button
+                    onClick={() =>
+                      navigate(`/processes/${process.id}/meeting`)
+                    }
+                    className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-cyan-700 text-white rounded-lg font-medium hover:bg-cyan-800 transition-colors"
+                  >
+                    <Video size={16} />
+                    Entrar na reunião
+                  </button>
+                </>
+              ) : meetingSession?.ended_at ? (
+                <p className="text-sm text-slate-700">
+                  A reunião foi encerrada pelo especialista.
+                </p>
+              ) : (
+                <p className="text-sm text-slate-700">
+                  Aguardando o especialista iniciar a reunião. O acesso aparece
+                  aqui assim que ela começar.
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-600">
+              A reunião ficará disponível assim que o agendamento for
+              confirmado.
+            </div>
+          )}
+        </div>
+      ) : (
       <div className="p-6 rounded-lg shadow bg-white">
         <div className="flex items-center justify-between mb-4">
           <h2 className="h2-style">Histórico de propostas</h2>
@@ -606,6 +729,7 @@ export default function ConsultantProcessDetailPage() {
             </div>
           )}
       </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/meetings/MeetingRoomPage.tsx
+++ b/frontend/src/pages/meetings/MeetingRoomPage.tsx
@@ -368,7 +368,9 @@ export default function MeetingRoomPage() {
               to={
                 user?.role === "SPECIALIST"
                   ? "/specialist/processes"
-                  : "/customer/processes"
+                  : user?.role === "CONSULTANT"
+                    ? "/consultant/processes"
+                    : "/customer/processes"
               }
               className="text-sm text-slate-700 hover:text-slate-900"
             >

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -352,7 +352,7 @@ export default function RouterApp() {
       path: "/processes/:processId/meeting",
       element: (
         <MainLayout>
-          <ProtectedRoute allowedRoles={["CUSTOMER", "SPECIALIST"]}>
+          <ProtectedRoute allowedRoles={["CUSTOMER", "SPECIALIST", "CONSULTANT"]}>
             <MeetingRoomPage />
           </ProtectedRoute>
         </MainLayout>


### PR DESCRIPTION
## O que faz

Habilita o consultor a acompanhar a reunião do cliente que ele gerencia, em nome dele.

## Mudanças

**Backend**
- `meetings.service.ts`: consultor vinculado ao cliente (`client.consultant_id`) ganha permissão de acesso à reunião (`isConsultant`); inclui dados do consultor na query.
- `notification.service.ts` + DTO: envia cópia do e-mail de reunião **iniciada**/**adiantada** ao consultor vinculado, quando existir (`sendMeetingConsultantCopy`).

**Frontend**
- `routes.tsx`: rota `/processes/:processId/meeting` agora aceita `CONSULTANT`.
- `MeetingRoomPage.tsx`: botão de voltar leva o consultor a `/consultant/processes`.
- `ConsultantProcessDetailPage.tsx`: durante o `SCHEDULING`, exibe bloco de agendamento com status e botão **Entrar na reunião** quando o especialista já iniciou a sessão.

## Verificação

- Backend build ✓ · Frontend build ✓
- Backend lint ✓ (0 erros) · Frontend lint ✓ (0 erros)
- Backend tests ✓ (42 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)