### PR TITLE
feat: reuniões via Google Meet com OAuth conectável

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -55,12 +55,19 @@ CALENDLY_ACCESS_TOKEN=your-calendly-access-token
 # Chave de API para listar/baixar imagens de pasta pública do Google Drive
 GOOGLE_DRIVE_API_KEY=your-google-drive-api-key
 
-# ===== GOOGLE MEET INTEGRATION (MVP CONTA DA PLATAFORMA) =====
-# Conta de serviço Google com acesso ao Google Calendar para geração automática de Meet
-GOOGLE_MEET_SERVICE_ACCOUNT_EMAIL=service-account@project-id.iam.gserviceaccount.com
-GOOGLE_MEET_SERVICE_ACCOUNT_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----END PRIVATE KEY-----"
-GOOGLE_MEET_CALENDAR_ID=primary
-GOOGLE_MEET_TIMEZONE=America/Sao_Paulo
+# ===== GOOGLE MEET INTEGRATION (OAuth2 conectável via painel admin) =====
+# O admin conecta UMA conta Google Workspace pelo painel (/admin/settings). O refresh token
+# fica criptografado no banco. As reuniões são criadas via Meet REST API (spaces.create) com
+# accessType=OPEN, garantindo que cliente externo/anônimo entre sem sala de espera.
+# Pré-condição: a conta conectada precisa ser Google Workspace (conta @gmail.com comum não cria Meet via API).
+# App OAuth criado no Google Cloud Console (Meet API habilitada). Scopes: meetings.space.created + meetings.space.settings + openid + email.
+GOOGLE_OAUTH_CLIENT_ID=xxxxx.apps.googleusercontent.com
+GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-xxxxx
+GOOGLE_OAUTH_REDIRECT_URI=http://localhost:3000/api/meetings/google/oauth/callback
+# Chave AES-256-GCM (32 bytes UTF-8 ou base64 de 32 bytes) para criptografar os tokens
+GOOGLE_MEET_TOKEN_ENCRYPTION_KEY=change-me-32-bytes-key-rotate-prod
+# OPEN (recomendado: sem sala de espera) | TRUSTED | RESTRICTED
+GOOGLE_MEET_ACCESS_TYPE=OPEN
 MEETING_DEMO_FALLBACK_ENABLED=false
 MEETING_PROVIDER=GOOGLE
 JITSI_BASE_URL=https://meet.jit.si

--- a/backend/prisma/migrations/20260624130000_add_google_meet_connection/migration.sql
+++ b/backend/prisma/migrations/20260624130000_add_google_meet_connection/migration.sql
@@ -1,0 +1,54 @@
+-- Additive migration for Google Meet OAuth integration (plataforma host único)
+-- Safe for existing data: only adds new tables (nenhuma coluna em tabelas existentes)
+
+CREATE TABLE IF NOT EXISTS "GoogleMeetConnection" (
+  "id" UUID NOT NULL,
+  "connected_by_id" UUID,
+  "google_email" TEXT NOT NULL,
+  "access_token_encrypted" TEXT NOT NULL,
+  "refresh_token_encrypted" TEXT NOT NULL,
+  "token_type" TEXT NOT NULL DEFAULT 'Bearer',
+  "scope" TEXT,
+  "expires_at" TIMESTAMP(3),
+  "is_active" BOOLEAN NOT NULL DEFAULT true,
+  "last_error" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "GoogleMeetConnection_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX IF NOT EXISTS "GoogleMeetConnection_is_active_idx"
+  ON "GoogleMeetConnection"("is_active");
+CREATE INDEX IF NOT EXISTS "GoogleMeetConnection_connected_by_id_idx"
+  ON "GoogleMeetConnection"("connected_by_id");
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'GoogleMeetConnection_connected_by_id_fkey'
+  ) THEN
+    ALTER TABLE "GoogleMeetConnection"
+      ADD CONSTRAINT "GoogleMeetConnection_connected_by_id_fkey"
+      FOREIGN KEY ("connected_by_id") REFERENCES "User"("id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS "GoogleMeetOauthState" (
+  "id" UUID NOT NULL,
+  "admin_id" UUID NOT NULL,
+  "state" TEXT NOT NULL,
+  "expires_at" TIMESTAMP(3) NOT NULL,
+  "used_at" TIMESTAMP(3),
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "GoogleMeetOauthState_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "GoogleMeetOauthState_state_key"
+  ON "GoogleMeetOauthState"("state");
+CREATE INDEX IF NOT EXISTS "GoogleMeetOauthState_expires_at_idx"
+  ON "GoogleMeetOauthState"("expires_at");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -480,33 +480,34 @@ model User {
   calendly_user_uri         String?
   calendly_organization_uri String?
 
-  created_at               DateTime              @default(now())
-  updated_at               DateTime              @updatedAt
+  created_at               DateTime               @default(now())
+  updated_at               DateTime               @updatedAt
   cars                     Car[]
   boats                    Boat[]
   aircraft                 Aircraft[]
-  processesAsClient        Process[]             @relation("process_as_client")
-  processesAsSpecialist    Process[]             @relation("process_as_specialist")
-  appointmentsAsClient     Appointment[]         @relation("appointment_as_client")
-  appointmentsAsSpecialist Appointment[]         @relation("appointment_as_specialist")
+  processesAsClient        Process[]              @relation("process_as_client")
+  processesAsSpecialist    Process[]              @relation("process_as_specialist")
+  appointmentsAsClient     Appointment[]          @relation("appointment_as_client")
+  appointmentsAsSpecialist Appointment[]          @relation("appointment_as_specialist")
   car_interests            Car_interest[]
   boat_interests           Boat_interest[]
   aircraft_interests       Aircraft_interest[]
   refreshTokens            RefreshToken[]
-  created_contracts        Contract[]            @relation("contract_created_by")
-  signed_contracts         Contract[]            @relation("contract_signed_by")
+  created_contracts        Contract[]             @relation("contract_created_by")
+  signed_contracts         Contract[]             @relation("contract_signed_by")
   process_rejections       ProcessRejection[]
   // Propostas de negociação enviadas e recebidas pelo usuário
-  proposals_sent           NegotiationProposal[] @relation("proposal_author")
-  proposals_received       NegotiationProposal[] @relation("proposal_recipient")
-  meetings_started         MeetingSession[]      @relation("meeting_started_by")
-  meetings_ended           MeetingSession[]      @relation("meeting_ended_by")
+  proposals_sent           NegotiationProposal[]  @relation("proposal_author")
+  proposals_received       NegotiationProposal[]  @relation("proposal_recipient")
+  meetings_started         MeetingSession[]       @relation("meeting_started_by")
+  meetings_ended           MeetingSession[]       @relation("meeting_ended_by")
   product_import_jobs      ProductImportJob[]
   calendly_connection      CalendlyConnection?
   calendly_oauth_states    CalendlyOauthState[]
-  advisorRelation          CustomerAdvisor?      @relation("CustomerAdvisors")
-  advisorOf                CustomerAdvisor[]     @relation("AdvisorOf")
-  consultant_invite_jobs   ConsultantInviteJob[] @relation("OfficeInviteJobs")
+  google_meet_connections  GoogleMeetConnection[] @relation("google_meet_connected_by")
+  advisorRelation          CustomerAdvisor?       @relation("CustomerAdvisors")
+  advisorOf                CustomerAdvisor[]      @relation("AdvisorOf")
+  consultant_invite_jobs   ConsultantInviteJob[]  @relation("OfficeInviteJobs")
 }
 
 model CalendlyConnection {
@@ -543,6 +544,38 @@ model CalendlyOauthState {
   created_at    DateTime  @default(now())
 
   @@index([user_id])
+  @@index([expires_at])
+}
+
+// GoogleMeetConnection: conta Google Workspace (host único da plataforma) conectada via OAuth
+// para criar salas Meet (Meet REST API spaces.create). Tokens criptografados (AES-256-GCM).
+model GoogleMeetConnection {
+  id                      String    @id @default(uuid()) @db.Uuid
+  connected_by_id         String?   @db.Uuid
+  connected_by            User?     @relation("google_meet_connected_by", fields: [connected_by_id], references: [id], onDelete: SetNull)
+  google_email            String
+  access_token_encrypted  String
+  refresh_token_encrypted String
+  token_type              String    @default("Bearer")
+  scope                   String?
+  expires_at              DateTime?
+  is_active               Boolean   @default(true)
+  last_error              String?
+  created_at              DateTime  @default(now())
+  updated_at              DateTime  @updatedAt
+
+  @@index([is_active])
+  @@index([connected_by_id])
+}
+
+model GoogleMeetOauthState {
+  id         String    @id @default(uuid()) @db.Uuid
+  admin_id   String    @db.Uuid
+  state      String    @unique
+  expires_at DateTime
+  used_at    DateTime?
+  created_at DateTime  @default(now())
+
   @@index([expires_at])
 }
 

--- a/backend/src/features/meetings/google-meet-oauth.controller.ts
+++ b/backend/src/features/meetings/google-meet-oauth.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Query,
+  Request,
+  Res,
+} from '@nestjs/common';
+import { UserRole } from '@prisma/client';
+import type { Response } from 'express';
+import { Public } from 'src/shared/decorators/public.decorator';
+import { Roles } from 'src/shared/decorators/roles.decorator';
+import { GoogleMeetOAuthService } from './google-meet-oauth.service';
+
+/**
+ * Rotas OAuth da conta Google host de reuniões.
+ * Só ADMIN conecta/desconecta. O callback é público (Google redireciona sem Bearer).
+ */
+@Controller('meetings/google/oauth')
+export class GoogleMeetOAuthController {
+  constructor(private readonly service: GoogleMeetOAuthService) {}
+
+  @Get('authorize')
+  @Roles(UserRole.ADMIN)
+  async authorize(@Request() req: any) {
+    const data = await this.service.createAuthorizeUrl(req.user.id);
+    return {
+      success: true,
+      message: 'URL de autorização gerada com sucesso',
+      data,
+    };
+  }
+
+  @Get('status')
+  @Roles(UserRole.ADMIN)
+  async status() {
+    const data = await this.service.getStatus();
+    return { success: true, data };
+  }
+
+  @Post('disconnect')
+  @Roles(UserRole.ADMIN)
+  @HttpCode(HttpStatus.OK)
+  async disconnect() {
+    await this.service.disconnect();
+    return { success: true, message: 'Conta Google desconectada' };
+  }
+
+  @Get('callback')
+  @Public()
+  async callback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Res() res: Response,
+  ) {
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5173';
+    try {
+      await this.service.handleCallback(code, state);
+      return res.redirect(`${frontendUrl}/admin/settings?google=connected`);
+    } catch {
+      return res.redirect(`${frontendUrl}/admin/settings?google=error`);
+    }
+  }
+}

--- a/backend/src/features/meetings/google-meet-oauth.service.spec.ts
+++ b/backend/src/features/meetings/google-meet-oauth.service.spec.ts
@@ -1,0 +1,100 @@
+import {
+  BadRequestException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { GoogleMeetOAuthService } from './google-meet-oauth.service';
+
+function mkPrisma() {
+  return {
+    googleMeetOauthState: {
+      create: jest.fn().mockResolvedValue({}),
+      findUnique: jest.fn(),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    googleMeetConnection: {
+      findFirst: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({}),
+      create: jest.fn().mockResolvedValue({}),
+      update: jest.fn().mockResolvedValue({}),
+    },
+    $transaction: jest.fn().mockResolvedValue([]),
+  } as any;
+}
+
+describe('GoogleMeetOAuthService', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...OLD_ENV,
+      GOOGLE_OAUTH_CLIENT_ID: 'client-id.apps.googleusercontent.com',
+      GOOGLE_OAUTH_CLIENT_SECRET: 'secret',
+      GOOGLE_OAUTH_REDIRECT_URI:
+        'http://localhost:3000/api/meetings/google/oauth/callback',
+      GOOGLE_MEET_TOKEN_ENCRYPTION_KEY: '12345678901234567890123456789012', // 32 bytes
+    };
+  });
+
+  afterAll(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('createAuthorizeUrl monta URL com offline/consent/scopes e grava state', async () => {
+    const prisma = mkPrisma();
+    const svc = new GoogleMeetOAuthService(prisma);
+
+    const { authorize_url } = await svc.createAuthorizeUrl('admin-1');
+
+    expect(prisma.googleMeetOauthState.create).toHaveBeenCalledTimes(1);
+    expect(authorize_url).toContain('access_type=offline');
+    expect(authorize_url).toContain('prompt=consent');
+    expect(authorize_url).toContain('meetings.space.created');
+    expect(authorize_url).toContain('meetings.space.settings');
+    expect(authorize_url).toMatch(/state=[a-f0-9]+/);
+  });
+
+  it('handleCallback rejeita params ausentes', async () => {
+    const svc = new GoogleMeetOAuthService(mkPrisma());
+    await expect(svc.handleCallback(undefined, undefined)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('handleCallback rejeita state inexistente/expirado/usado', async () => {
+    const prisma = mkPrisma();
+    prisma.googleMeetOauthState.findUnique.mockResolvedValue(null);
+    const svc = new GoogleMeetOAuthService(prisma);
+    await expect(svc.handleCallback('code', 'state')).rejects.toThrow(
+      BadRequestException,
+    );
+
+    prisma.googleMeetOauthState.findUnique.mockResolvedValue({
+      id: 's1',
+      admin_id: 'a1',
+      state: 'state',
+      used_at: new Date(),
+      expires_at: new Date(Date.now() + 60000),
+    });
+    await expect(svc.handleCallback('code', 'state')).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('getAccessToken lança quando não há conexão ativa', async () => {
+    const prisma = mkPrisma();
+    prisma.googleMeetConnection.findFirst.mockResolvedValue(null);
+    const svc = new GoogleMeetOAuthService(prisma);
+    await expect(svc.getAccessToken()).rejects.toThrow(
+      ServiceUnavailableException,
+    );
+  });
+
+  it('encrypt/decrypt faz round-trip do token', () => {
+    const svc = new GoogleMeetOAuthService(mkPrisma()) as any;
+    const original = 'refresh-token-secreto-1//abc';
+    const encrypted = svc.encryptToken(original);
+    expect(encrypted.startsWith('v1:')).toBe(true);
+    expect(encrypted).not.toContain(original);
+    expect(svc.decryptToken(encrypted)).toBe(original);
+  });
+});

--- a/backend/src/features/meetings/google-meet-oauth.service.ts
+++ b/backend/src/features/meetings/google-meet-oauth.service.ts
@@ -1,0 +1,309 @@
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { google } from 'googleapis';
+import { createCipheriv, createDecipheriv, randomBytes } from 'crypto';
+import { PrismaService } from 'src/prisma/prisma.service';
+
+/**
+ * GoogleMeetOAuthService
+ *
+ * Gerencia a conexão OAuth2 (a nível de plataforma) com uma conta Google Workspace
+ * usada como host único das reuniões. O admin conecta a conta pelo painel; o refresh
+ * token fica criptografado no banco (AES-256-GCM) e é usado para criar salas Meet via
+ * Meet REST API (spaces.create) com accessType=OPEN.
+ *
+ * Não toca o fluxo de login/cadastro da plataforma — é credencial de integração.
+ */
+@Injectable()
+export class GoogleMeetOAuthService {
+  private readonly logger = new Logger(GoogleMeetOAuthService.name);
+
+  private static readonly SCOPES = [
+    'openid',
+    'email',
+    'https://www.googleapis.com/auth/meetings.space.created',
+    'https://www.googleapis.com/auth/meetings.space.settings',
+  ];
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ── OAuth: gerar URL de autorização ────────────────────────────────────────
+  async createAuthorizeUrl(
+    adminId: string,
+  ): Promise<{ authorize_url: string }> {
+    const state = randomBytes(24).toString('hex');
+    const expiresAt = new Date(Date.now() + 30 * 60 * 1000);
+
+    await this.prisma.googleMeetOauthState.create({
+      data: { admin_id: adminId, state, expires_at: expiresAt },
+    });
+
+    const oauth2 = this.buildBareOAuthClient();
+    const authorizeUrl = oauth2.generateAuthUrl({
+      access_type: 'offline', // obrigatório p/ receber refresh token
+      prompt: 'consent', // força refresh token mesmo em reconsentimento
+      include_granted_scopes: true,
+      scope: GoogleMeetOAuthService.SCOPES,
+      state,
+    });
+
+    return { authorize_url: authorizeUrl };
+  }
+
+  // ── OAuth: callback (troca code por tokens) ─────────────────────────────────
+  async handleCallback(
+    code?: string,
+    state?: string,
+  ): Promise<{ google_email: string }> {
+    if (!code || !state) {
+      throw new BadRequestException(
+        'Parâmetros de callback ausentes (code/state)',
+      );
+    }
+
+    const stateRow = await this.prisma.googleMeetOauthState.findUnique({
+      where: { state },
+    });
+    if (!stateRow || stateRow.used_at || stateRow.expires_at < new Date()) {
+      throw new BadRequestException('State inválido, expirado ou já utilizado');
+    }
+
+    const oauth2 = this.buildBareOAuthClient();
+    const { tokens } = await oauth2.getToken(code);
+
+    if (!tokens.refresh_token) {
+      throw new BadRequestException(
+        'Google não retornou refresh token. Revogue o acesso do app na conta Google e conecte novamente.',
+      );
+    }
+    if (!tokens.access_token) {
+      throw new ServiceUnavailableException(
+        'Falha ao obter access token do Google',
+      );
+    }
+
+    const googleEmail = this.extractEmailFromIdToken(tokens.id_token);
+
+    // 1 conexão ativa por vez (host único): desativa as antigas e cria a nova.
+    await this.prisma.$transaction([
+      this.prisma.googleMeetConnection.updateMany({
+        where: { is_active: true },
+        data: { is_active: false },
+      }),
+      this.prisma.googleMeetConnection.create({
+        data: {
+          connected_by_id: stateRow.admin_id,
+          google_email: googleEmail ?? 'desconhecido',
+          access_token_encrypted: this.encryptToken(tokens.access_token),
+          refresh_token_encrypted: this.encryptToken(tokens.refresh_token),
+          token_type: tokens.token_type ?? 'Bearer',
+          scope: tokens.scope ?? null,
+          expires_at: tokens.expiry_date ? new Date(tokens.expiry_date) : null,
+          is_active: true,
+        },
+      }),
+      this.prisma.googleMeetOauthState.update({
+        where: { id: stateRow.id },
+        data: { used_at: new Date() },
+      }),
+    ]);
+
+    this.logger.log(
+      `[meetings] Conta Google conectada para reuniões: ${googleEmail ?? 'desconhecido'}`,
+    );
+
+    return { google_email: googleEmail ?? 'desconhecido' };
+  }
+
+  // ── Status / desconexão ─────────────────────────────────────────────────────
+  async getStatus(): Promise<{
+    connected: boolean;
+    google_email: string | null;
+    expires_at: Date | null;
+    is_active: boolean;
+    last_error: string | null;
+  }> {
+    const connection = await this.prisma.googleMeetConnection.findFirst({
+      where: { is_active: true },
+      orderBy: { created_at: 'desc' },
+    });
+
+    return {
+      connected: Boolean(connection),
+      google_email: connection?.google_email ?? null,
+      expires_at: connection?.expires_at ?? null,
+      is_active: connection?.is_active ?? false,
+      last_error: connection?.last_error ?? null,
+    };
+  }
+
+  async disconnect(): Promise<void> {
+    await this.prisma.googleMeetConnection.updateMany({
+      where: { is_active: true },
+      data: { is_active: false },
+    });
+  }
+
+  // ── Uso interno: access token válido para a Meet REST API ───────────────────
+  async getAccessToken(): Promise<string> {
+    const connection = await this.prisma.googleMeetConnection.findFirst({
+      where: { is_active: true },
+      orderBy: { created_at: 'desc' },
+    });
+
+    if (!connection) {
+      throw new ServiceUnavailableException(
+        'Conta Google para reuniões não conectada. Conecte uma conta Workspace nas configurações.',
+      );
+    }
+
+    const refreshToken = this.decryptToken(connection.refresh_token_encrypted);
+    const oauth2 = this.buildBareOAuthClient();
+    oauth2.setCredentials({ refresh_token: refreshToken });
+
+    // Persiste o token renovado quando a lib renova automaticamente.
+    oauth2.on('tokens', (tokens) => {
+      const data: Record<string, unknown> = {};
+      if (tokens.access_token) {
+        data.access_token_encrypted = this.encryptToken(tokens.access_token);
+      }
+      if (tokens.refresh_token) {
+        data.refresh_token_encrypted = this.encryptToken(tokens.refresh_token);
+      }
+      if (tokens.expiry_date) {
+        data.expires_at = new Date(tokens.expiry_date);
+      }
+      if (Object.keys(data).length > 0) {
+        this.prisma.googleMeetConnection
+          .update({ where: { id: connection.id }, data })
+          .catch((err) =>
+            this.logger.warn(
+              `[meetings] Falha ao persistir token renovado: ${err.message}`,
+            ),
+          );
+      }
+    });
+
+    try {
+      const { token } = await oauth2.getAccessToken();
+      if (!token) {
+        throw new ServiceUnavailableException(
+          'Falha ao renovar access token do Google',
+        );
+      }
+      return token;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'erro desconhecido';
+      if (message.includes('invalid_grant')) {
+        await this.prisma.googleMeetConnection.update({
+          where: { id: connection.id },
+          data: { is_active: false, last_error: 'invalid_grant' },
+        });
+        throw new ServiceUnavailableException(
+          'A conexão com o Google expirou. Reconecte a conta nas configurações.',
+        );
+      }
+      throw error;
+    }
+  }
+
+  // ── Helpers ─────────────────────────────────────────────────────────────────
+  private buildBareOAuthClient() {
+    const clientId = this.getRequiredEnv('GOOGLE_OAUTH_CLIENT_ID');
+    const clientSecret = this.getRequiredEnv('GOOGLE_OAUTH_CLIENT_SECRET');
+    const redirectUri = this.getRequiredEnv('GOOGLE_OAUTH_REDIRECT_URI');
+    return new google.auth.OAuth2(clientId, clientSecret, redirectUri);
+  }
+
+  private extractEmailFromIdToken(idToken?: string | null): string | null {
+    if (!idToken) return null;
+    try {
+      const payload = idToken.split('.')[1];
+      if (!payload) return null;
+      const decoded = JSON.parse(
+        Buffer.from(payload, 'base64').toString('utf8'),
+      );
+      return typeof decoded.email === 'string' ? decoded.email : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private getRequiredEnv(name: string): string {
+    const value = process.env[name];
+    if (!value) {
+      throw new InternalServerErrorException(
+        `Variável de ambiente obrigatória ausente: ${name}`,
+      );
+    }
+    return value;
+  }
+
+  private getEncryptionKeyBuffer(): Buffer {
+    const raw = process.env.GOOGLE_MEET_TOKEN_ENCRYPTION_KEY;
+    if (!raw) {
+      throw new InternalServerErrorException(
+        'Variável GOOGLE_MEET_TOKEN_ENCRYPTION_KEY não configurada',
+      );
+    }
+
+    const normalizedRaw = raw.trim();
+    const possibleBase64 = Buffer.from(normalizedRaw, 'base64');
+    const normalizedDecoded = possibleBase64
+      .toString('base64')
+      .replace(/=+$/, '');
+    const normalizedInput = normalizedRaw.replace(/=+$/, '');
+
+    if (possibleBase64.length === 32 && normalizedDecoded === normalizedInput) {
+      return possibleBase64;
+    }
+
+    const utf8 = Buffer.from(normalizedRaw, 'utf8');
+    if (utf8.length === 32) {
+      return utf8;
+    }
+
+    throw new InternalServerErrorException(
+      'GOOGLE_MEET_TOKEN_ENCRYPTION_KEY deve ter 32 bytes (UTF-8) ou base64 de 32 bytes',
+    );
+  }
+
+  private encryptToken(value: string): string {
+    const key = this.getEncryptionKeyBuffer();
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([
+      cipher.update(value, 'utf8'),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+    return `v1:${iv.toString('base64')}:${authTag.toString('base64')}:${encrypted.toString('base64')}`;
+  }
+
+  private decryptToken(value: string): string {
+    const [version, ivBase64, authTagBase64, encryptedBase64] =
+      value.split(':');
+    if (version !== 'v1' || !ivBase64 || !authTagBase64 || !encryptedBase64) {
+      throw new InternalServerErrorException(
+        'Formato de token criptografado inválido',
+      );
+    }
+    const key = this.getEncryptionKeyBuffer();
+    const iv = Buffer.from(ivBase64, 'base64');
+    const authTag = Buffer.from(authTagBase64, 'base64');
+    const encrypted = Buffer.from(encryptedBase64, 'base64');
+    const decipher = createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    const decrypted = Buffer.concat([
+      decipher.update(encrypted),
+      decipher.final(),
+    ]);
+    return decrypted.toString('utf8');
+  }
+}

--- a/backend/src/features/meetings/meetings.module.ts
+++ b/backend/src/features/meetings/meetings.module.ts
@@ -4,10 +4,12 @@ import { MeetingsController } from './meetings.controller';
 import { MeetingsService } from './meetings.service';
 import { NotificationModule } from 'src/features/notifications/notification.module';
 import { MeetingReminderService } from './meeting-reminder.service';
+import { GoogleMeetOAuthService } from './google-meet-oauth.service';
+import { GoogleMeetOAuthController } from './google-meet-oauth.controller';
 
 @Module({
   imports: [ConfigModule, NotificationModule],
-  controllers: [MeetingsController],
-  providers: [MeetingsService, MeetingReminderService],
+  controllers: [MeetingsController, GoogleMeetOAuthController],
+  providers: [MeetingsService, MeetingReminderService, GoogleMeetOAuthService],
 })
 export class MeetingsModule {}

--- a/backend/src/features/meetings/meetings.service.spec.ts
+++ b/backend/src/features/meetings/meetings.service.spec.ts
@@ -1,0 +1,143 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import { MeetingsService } from './meetings.service';
+
+function mkProcess(overrides: any = {}) {
+  return {
+    id: 'proc-1',
+    client_id: 'client-1',
+    specialist_id: 'spec-1',
+    status: 'SCHEDULING',
+    meeting_session: null,
+    client: {
+      id: 'client-1',
+      email: 'cliente@externo.com',
+      name: 'Cliente',
+      surname: 'Teste',
+      consultant_id: null,
+      consultant: null,
+    },
+    specialist: {
+      id: 'spec-1',
+      email: 'spec@empresa.com',
+      name: 'Espec',
+      surname: 'Ialista',
+    },
+    ...overrides,
+  };
+}
+
+function mkPrisma(process: any) {
+  return {
+    process: { findUnique: jest.fn().mockResolvedValue(process) },
+    meetingSession: {
+      create: jest.fn().mockImplementation(({ data }: any) =>
+        Promise.resolve({
+          id: 'meet-1',
+          process_id: data.process_id,
+          meet_link: data.meet_link,
+          started_at: data.started_at,
+          ended_at: null,
+        }),
+      ),
+    },
+  } as any;
+}
+
+function mkConfig(accessType = 'OPEN') {
+  return {
+    get: jest.fn((key: string, def?: string) => {
+      if (key === 'GOOGLE_MEET_ACCESS_TYPE') return accessType;
+      if (key === 'MEETING_PROVIDER') return 'GOOGLE';
+      if (key === 'MEETING_DEMO_FALLBACK_ENABLED') return 'false';
+      return def;
+    }),
+  } as any;
+}
+
+const notification = {
+  sendMeetingStartedEmail: jest.fn().mockResolvedValue({}),
+  sendMeetingAdvancedEmail: jest.fn().mockResolvedValue({}),
+} as any;
+
+describe('MeetingsService — criação via Meet REST API', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('cria sala Meet com accessType OPEN e grava meet_link + spaceName', async () => {
+    const process = mkProcess();
+    const prisma = mkPrisma(process);
+    const oauth = {
+      getAccessToken: jest.fn().mockResolvedValue('access-token'),
+    } as any;
+
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: 'spaces/abc123',
+        meetingUri: 'https://meet.google.com/abc-defg-hij',
+      }),
+    });
+    global.fetch = fetchMock as any;
+
+    const svc = new MeetingsService(
+      prisma,
+      mkConfig('OPEN'),
+      notification,
+      oauth,
+    );
+    const result = await svc.startMeetingForProcess('proc-1', 'spec-1');
+
+    // accessType OPEN enviado no body
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.config.accessType).toBe('OPEN');
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://meet.googleapis.com/v2/spaces',
+    );
+
+    expect(result.meet_link).toBe('https://meet.google.com/abc-defg-hij');
+    expect(prisma.meetingSession.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          calendar_event_id: 'spaces/abc123',
+          meet_link: 'https://meet.google.com/abc-defg-hij',
+        }),
+      }),
+    );
+  });
+
+  it('sem conexão ativa → ServiceUnavailableException (sem fallback)', async () => {
+    const process = mkProcess();
+    const prisma = mkPrisma(process);
+    const oauth = {
+      getAccessToken: jest
+        .fn()
+        .mockRejectedValue(new ServiceUnavailableException('não conectado')),
+    } as any;
+
+    const svc = new MeetingsService(
+      prisma,
+      mkConfig('OPEN'),
+      notification,
+      oauth,
+    );
+    await expect(
+      svc.startMeetingForProcess('proc-1', 'spec-1'),
+    ).rejects.toThrow(ServiceUnavailableException);
+  });
+
+  it('só o especialista pode iniciar a reunião', async () => {
+    const process = mkProcess();
+    const prisma = mkPrisma(process);
+    const oauth = { getAccessToken: jest.fn() } as any;
+
+    const svc = new MeetingsService(
+      prisma,
+      mkConfig('OPEN'),
+      notification,
+      oauth,
+    );
+    // cliente tentando iniciar
+    await expect(
+      svc.startMeetingForProcess('proc-1', 'client-1'),
+    ).rejects.toThrow(/especialista/i);
+  });
+});

--- a/backend/src/features/meetings/meetings.service.ts
+++ b/backend/src/features/meetings/meetings.service.ts
@@ -7,22 +7,16 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { google } from 'googleapis';
-import { GaxiosError } from 'gaxios';
 import { randomUUID } from 'crypto';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { NotificationService } from 'src/features/notifications/notification.service';
 import { ProcessStatus, StatusAgendamento } from '@prisma/client';
+import { GoogleMeetOAuthService } from './google-meet-oauth.service';
 
 @Injectable()
 export class MeetingsService {
   private readonly logger = new Logger(MeetingsService.name);
-  private readonly calendarId: string;
-  private readonly timezone: string;
-  private readonly serviceAccountEmail?: string;
-  private readonly serviceAccountPrivateKey?: string;
-  private readonly meetPollingAttempts = 5;
-  private readonly meetPollingIntervalMs = 1000;
+  private readonly meetAccessType: 'OPEN' | 'TRUSTED' | 'RESTRICTED';
   private readonly demoMeetingFallbackEnabled: boolean;
   private readonly meetingProvider: 'GOOGLE' | 'JITSI';
   private readonly jitsiBaseUrl: string;
@@ -32,24 +26,15 @@ export class MeetingsService {
     private readonly prismaService: PrismaService,
     private readonly configService: ConfigService,
     private readonly notificationService: NotificationService,
+    private readonly googleMeetOAuthService: GoogleMeetOAuthService,
   ) {
-    this.calendarId = this.configService.get<string>(
-      'GOOGLE_MEET_CALENDAR_ID',
-      'primary',
-    );
-    this.timezone = this.configService.get<string>(
-      'GOOGLE_MEET_TIMEZONE',
-      'America/Sao_Paulo',
-    );
-    this.serviceAccountEmail = this.configService.get<string>(
-      'GOOGLE_MEET_SERVICE_ACCOUNT_EMAIL',
-    );
-
-    const privateKey = this.configService.get<string>(
-      'GOOGLE_MEET_SERVICE_ACCOUNT_PRIVATE_KEY',
-    );
-
-    this.serviceAccountPrivateKey = privateKey?.replace(/\\n/g, '\n');
+    const accessType = this.configService
+      .get<string>('GOOGLE_MEET_ACCESS_TYPE', 'OPEN')
+      ?.toUpperCase();
+    this.meetAccessType =
+      accessType === 'TRUSTED' || accessType === 'RESTRICTED'
+        ? accessType
+        : 'OPEN';
     this.demoMeetingFallbackEnabled =
       this.configService.get<string>(
         'MEETING_DEMO_FALLBACK_ENABLED',
@@ -76,137 +61,43 @@ export class MeetingsService {
     return `${this.jitsiBaseUrl.replace(/\/$/, '')}/${room}`;
   }
 
-  private getCalendarClient() {
-    if (!this.serviceAccountEmail || !this.serviceAccountPrivateKey) {
-      throw new ServiceUnavailableException(
-        'Integração de reunião não configurada no servidor',
-      );
-    }
+  /**
+   * Cria uma sala Google Meet via Meet REST API (spaces.create) com accessType
+   * configurado (OPEN por padrão → cliente externo/anônimo entra sem sala de espera).
+   * Retorna o nome do space (ex.: "spaces/abc") e o meetingUri.
+   */
+  private async createMeetSpace(): Promise<{
+    spaceName: string;
+    meetingUri: string;
+  }> {
+    const accessToken = await this.googleMeetOAuthService.getAccessToken();
 
-    const auth = new google.auth.JWT({
-      email: this.serviceAccountEmail,
-      key: this.serviceAccountPrivateKey,
-      scopes: ['https://www.googleapis.com/auth/calendar'],
+    const response = await fetch('https://meet.googleapis.com/v2/spaces', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        config: { accessType: this.meetAccessType },
+      }),
     });
 
-    return google.calendar({ version: 'v3', auth });
-  }
-
-  private isInvalidConferenceTypeError(error: unknown): boolean {
-    if (!(error instanceof GaxiosError)) {
-      return false;
-    }
-
-    const message = error.response?.data?.error?.message || error.message || '';
-
-    return (
-      typeof message === 'string' &&
-      message.toLowerCase().includes('invalid conference type value')
-    );
-  }
-
-  private async createCalendarEventWithMeet(
-    calendar: ReturnType<typeof google.calendar>,
-    processId: string,
-    specialistName: string,
-    clientName: string,
-    start: Date,
-    end: Date,
-  ) {
-    const baseRequestBody = {
-      summary: `Reunião High-class Shop - Processo ${processId}`,
-      description: `Reunião entre especialista ${specialistName} e cliente ${clientName}.`,
-      start: {
-        dateTime: start.toISOString(),
-        timeZone: this.timezone,
-      },
-      end: {
-        dateTime: end.toISOString(),
-        timeZone: this.timezone,
-      },
-    };
-
-    try {
-      return await calendar.events.insert({
-        calendarId: this.calendarId,
-        conferenceDataVersion: 1,
-        requestBody: {
-          ...baseRequestBody,
-          conferenceData: {
-            createRequest: {
-              conferenceSolutionKey: { type: 'hangoutsMeet' },
-              requestId: randomUUID(),
-            },
-          },
-        },
-      });
-    } catch (error) {
-      if (!this.isInvalidConferenceTypeError(error)) {
-        throw error;
-      }
-
-      this.logger.warn(
-        `[meetings] Calendar rejeitou conferenceSolutionKey.type=hangoutsMeet para processo ${processId}. Tentando fallback sem conferenceSolutionKey.`,
+    if (!response.ok) {
+      const detail = await response.text();
+      throw new Error(
+        `Meet spaces.create falhou (${response.status}): ${detail}`,
       );
-
-      return calendar.events.insert({
-        calendarId: this.calendarId,
-        conferenceDataVersion: 1,
-        requestBody: {
-          ...baseRequestBody,
-          conferenceData: {
-            createRequest: {
-              requestId: randomUUID(),
-            },
-          },
-        },
-      });
-    }
-  }
-
-  private extractMeetLinkFromEvent(event: any): string | null {
-    return (
-      event?.hangoutLink ||
-      event?.conferenceData?.entryPoints?.find(
-        (entry: any) => entry.entryPointType === 'video',
-      )?.uri ||
-      null
-    );
-  }
-
-  private async waitForMeetLink(
-    calendar: ReturnType<typeof google.calendar>,
-    eventId: string,
-  ): Promise<string | null> {
-    for (let attempt = 1; attempt <= this.meetPollingAttempts; attempt++) {
-      const getEvent: any = await calendar.events.get({
-        calendarId: this.calendarId,
-        eventId,
-      });
-
-      const meetLink = this.extractMeetLinkFromEvent(getEvent.data);
-      if (meetLink) {
-        return meetLink;
-      }
-
-      const conferenceStatus =
-        getEvent.data.conferenceData?.createRequest?.status?.statusCode;
-
-      if (conferenceStatus === 'failure') {
-        this.logger.error(
-          `[meetings] Falha definitiva ao gerar conferência para evento ${eventId}.`,
-        );
-        return null;
-      }
-
-      if (attempt < this.meetPollingAttempts) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, this.meetPollingIntervalMs),
-        );
-      }
     }
 
-    return null;
+    const data: any = await response.json();
+    if (!data?.meetingUri || !data?.name) {
+      throw new Error(
+        'Meet spaces.create retornou resposta sem meetingUri/name',
+      );
+    }
+
+    return { spaceName: data.name, meetingUri: data.meetingUri };
   }
 
   private async getAuthorizedProcess(processId: string, userId: string) {
@@ -513,25 +404,17 @@ export class MeetingsService {
       };
     }
 
-    const calendar = this.getCalendarClient();
-    const now = new Date();
-    const end = new Date(now.getTime() + 60 * 60 * 1000);
-
     const specialistName =
       `${process.specialist.name} ${process.specialist.surname || ''}`.trim();
     const clientName =
       `${process.client.name} ${process.client.surname || ''}`.trim();
 
-    let event;
+    let meetLink: string;
+    let spaceName: string;
     try {
-      event = await this.createCalendarEventWithMeet(
-        calendar,
-        process.id,
-        specialistName,
-        clientName,
-        now,
-        end,
-      );
+      const space = await this.createMeetSpace();
+      meetLink = space.meetingUri;
+      spaceName = space.spaceName;
     } catch (error) {
       if (this.demoMeetingFallbackEnabled) {
         const demoLink = this.buildDemoMeetingLink(process.id);
@@ -546,16 +429,14 @@ export class MeetingsService {
         });
 
         this.logger.warn(
-          `[meetings] Fallback DEMO ativado após falha no Google Calendar. processId=${process.id}`,
+          `[meetings] Fallback DEMO ativado após falha no Google Meet. processId=${process.id}`,
         );
 
         setImmediate(() => {
           const emailData = {
             clientEmail: process.client.email,
-            clientName:
-              `${process.client.name} ${process.client.surname || ''}`.trim(),
-            specialistName:
-              `${process.specialist.name} ${process.specialist.surname || ''}`.trim(),
+            clientName,
+            specialistName,
             processId: process.id,
             platformMeetingUrl: `${this.frontendUrl}/processes/${process.id}/meeting`,
             meetingLink: demoLink,
@@ -578,50 +459,12 @@ export class MeetingsService {
         };
       }
 
-      this.logger.error('Falha ao criar evento no Google Calendar', {
+      this.logger.error('Falha ao criar sala no Google Meet', {
         processId: process.id,
         error: error instanceof Error ? error.message : 'erro desconhecido',
       });
       throw new ServiceUnavailableException(
-        'Não foi possível criar a reunião no provedor configurado. Verifique a configuração da plataforma.',
-      );
-    }
-
-    if (!event.data.id) {
-      this.logger.error('Google Calendar retornou evento sem ID', {
-        processId,
-      });
-      throw new ServiceUnavailableException(
-        'Não foi possível criar o evento de reunião automaticamente.',
-      );
-    }
-
-    let meetLink = this.extractMeetLinkFromEvent(event.data);
-
-    if (!meetLink) {
-      this.logger.warn(
-        `[meetings] Evento criado sem link imediato. Aguardando geração assíncrona do Meet para processId=${processId}.`,
-      );
-
-      meetLink = await this.waitForMeetLink(calendar, event.data.id);
-    }
-
-    if (!meetLink) {
-      if (this.demoMeetingFallbackEnabled) {
-        meetLink = this.buildDemoMeetingLink(process.id);
-        this.logger.warn(
-          `[meetings] Fallback DEMO ativado: evento sem link do Meet. processId=${process.id}, eventId=${event.data.id}`,
-        );
-      }
-    }
-
-    if (!meetLink) {
-      this.logger.error('Google Calendar retornou evento sem link de reunião', {
-        processId,
-        eventId: event.data.id,
-      });
-      throw new ServiceUnavailableException(
-        'O provedor criou o evento, mas não gerou link de reunião para esta configuração.',
+        'Não foi possível criar a reunião no Google Meet. Verifique a conta conectada nas configurações.',
       );
     }
 
@@ -629,7 +472,7 @@ export class MeetingsService {
       data: {
         process_id: process.id,
         started_by_id: userId,
-        calendar_event_id: event.data.id,
+        calendar_event_id: spaceName,
         meet_link: meetLink,
         started_at: new Date(),
       },

--- a/frontend/src/components/meetings/RequireGoogleMeetModal.tsx
+++ b/frontend/src/components/meetings/RequireGoogleMeetModal.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { Video, X } from "lucide-react";
+import { useAuth } from "../../store/authStateManager";
+import {
+  getGoogleMeetStatus,
+  getGoogleMeetAuthorizeUrl,
+} from "../../services/googleMeet.service";
+
+const DISMISS_KEY = "google-meet-modal-dismissed-session";
+
+/**
+ * Pop-up exibido para o ADMIN quando não há conta Google conectada.
+ * Sem a conexão, as reuniões não conseguem gerar link do Google Meet.
+ * Aparece a cada nova sessão de login (dispensável durante a sessão).
+ */
+export default function RequireGoogleMeetModal() {
+  const { user } = useAuth();
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (user?.role !== "ADMIN") return;
+    if (sessionStorage.getItem(DISMISS_KEY) === "1") return;
+
+    let cancelled = false;
+    getGoogleMeetStatus()
+      .then((status) => {
+        if (!cancelled && !status.connected) {
+          setOpen(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setOpen(true);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.id, user?.role]);
+
+  const handleConnect = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const url = await getGoogleMeetAuthorizeUrl();
+      window.location.href = url;
+    } catch (err) {
+      const e = err as { friendlyMessage?: string };
+      setError(e.friendlyMessage || "Erro ao iniciar conexão com o Google.");
+      setLoading(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    sessionStorage.setItem(DISMISS_KEY, "1");
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-lg bg-white rounded-2xl shadow-2xl overflow-hidden">
+        <div className="bg-linear-to-br from-emerald-600 to-teal-600 p-6 text-white relative">
+          <button
+            onClick={handleDismiss}
+            className="absolute top-3 right-3 text-white/80 hover:text-white p-1 rounded-full hover:bg-white/10"
+            aria-label="Fechar"
+          >
+            <X size={20} />
+          </button>
+          <div className="flex items-center gap-3 mb-2">
+            <Video size={28} />
+            <h2 className="text-xl font-bold">Conecte a conta Google Meet</h2>
+          </div>
+          <p className="text-sm text-emerald-50">
+            Para que os especialistas possam criar reuniões no Google Meet,
+            conecte uma conta Google Workspace à plataforma.
+          </p>
+        </div>
+
+        <div className="p-6 space-y-4">
+          <p className="text-sm text-gray-700">
+            Sem uma conta conectada, as reuniões não geram link do Google Meet.
+            A conta precisa ser Google Workspace (contas @gmail.com comuns não
+            criam reunião via API).
+          </p>
+
+          {error && (
+            <div className="bg-red-50 text-red-700 text-sm p-3 rounded-lg border border-red-200">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col sm:flex-row gap-3 pt-2">
+            <button
+              onClick={handleConnect}
+              disabled={loading}
+              className="flex-1 px-4 py-3 bg-gray-900 text-white rounded-lg font-medium hover:bg-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? "Abrindo..." : "Conectar agora"}
+            </button>
+            <button
+              onClick={handleDismiss}
+              className="flex-1 px-4 py-3 bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200 transition-colors"
+            >
+              Lembrar mais tarde
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/layouts/MainLayout.tsx
+++ b/frontend/src/layouts/MainLayout.tsx
@@ -5,6 +5,7 @@
 import { useIsMobile } from "../hooks/use-is-mobile";
   import { AuthContext } from "../contexts/AuthContext";
 import RequireCalendlyModal from "../components/calendly/RequireCalendlyModal";
+import RequireGoogleMeetModal from "../components/meetings/RequireGoogleMeetModal";
 
   interface MainLayoutProps {
     children: React.ReactNode;
@@ -49,6 +50,7 @@ import RequireCalendlyModal from "../components/calendly/RequireCalendlyModal";
               </main>
             </div>
             {user?.role === "SPECIALIST" && <RequireCalendlyModal />}
+            {user?.role === "ADMIN" && <RequireGoogleMeetModal />}
           </div>
       </AppProvider>
     );

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -1,6 +1,12 @@
 import { useState, useEffect } from "react";
-import { Settings, Check, AlertCircle, Save } from "lucide-react";
+import { Settings, Check, AlertCircle, Save, Video } from "lucide-react";
 import { getSettings, updateSetting } from "../../services/settings.service";
+import {
+  getGoogleMeetStatus,
+  getGoogleMeetAuthorizeUrl,
+  disconnectGoogleMeet,
+  type GoogleMeetStatus,
+} from "../../services/googleMeet.service";
 
 /**
  * Admin Settings Page
@@ -16,6 +22,72 @@ export default function SettingsPage() {
   const [minimumProposalEnabled, setMinimumProposalEnabled] = useState(false);
   const [minimumProposalPercentage, setMinimumProposalPercentage] =
     useState("80");
+
+  // Google Meet connection state
+  const [meetStatus, setMeetStatus] = useState<GoogleMeetStatus | null>(null);
+  const [meetBusy, setMeetBusy] = useState(false);
+
+  const loadMeetStatus = async () => {
+    try {
+      const status = await getGoogleMeetStatus();
+      setMeetStatus(status);
+    } catch {
+      // status indisponível não bloqueia a tela de configurações
+      setMeetStatus(null);
+    }
+  };
+
+  const handleConnectMeet = async () => {
+    try {
+      setMeetBusy(true);
+      const url = await getGoogleMeetAuthorizeUrl();
+      window.location.href = url;
+    } catch (err) {
+      setError(
+        (err as any)?.friendlyMessage ||
+          (err instanceof Error ? err.message : "Erro ao iniciar conexão Google"),
+      );
+      setMeetBusy(false);
+    }
+  };
+
+  const handleDisconnectMeet = async () => {
+    try {
+      setMeetBusy(true);
+      await disconnectGoogleMeet();
+      await loadMeetStatus();
+      setSuccessMessage("Conta Google desconectada.");
+      setTimeout(() => setSuccessMessage(null), 3000);
+    } catch (err) {
+      setError(
+        (err as any)?.friendlyMessage ||
+          (err instanceof Error ? err.message : "Erro ao desconectar"),
+      );
+    } finally {
+      setMeetBusy(false);
+    }
+  };
+
+  // Feedback do retorno do callback OAuth (?google=connected|error)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const google = params.get("google");
+    if (google === "connected") {
+      setSuccessMessage("Conta Google conectada para reuniões!");
+      setTimeout(() => setSuccessMessage(null), 4000);
+    } else if (google === "error") {
+      setError(
+        "Falha ao conectar a conta Google. Verifique se é uma conta Workspace e tente novamente.",
+      );
+    }
+    if (google) {
+      window.history.replaceState({}, "", window.location.pathname);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadMeetStatus();
+  }, []);
 
   // Load settings on mount
   useEffect(() => {
@@ -247,6 +319,71 @@ export default function SettingsPage() {
                     </div>
                   </div>
                 )}
+              </div>
+            </div>
+
+            {/* Google Meet Connection Section */}
+            <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
+              <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
+                <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
+                  <Video size={18} className="text-slate-700" />
+                  Reuniões — Conta Google Meet
+                </h2>
+                <p className="text-sm text-gray-600 mt-1">
+                  Conecte uma conta Google Workspace para gerar as salas de
+                  reunião. A conta precisa ser Workspace (contas @gmail.com
+                  comuns não geram link do Meet via API).
+                </p>
+              </div>
+
+              <div className="p-6">
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex-1">
+                    {meetStatus?.connected ? (
+                      <div className="flex items-center gap-2">
+                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700">
+                          <Check size={12} /> Conectado
+                        </span>
+                        <span className="text-sm text-gray-700">
+                          {meetStatus.google_email}
+                        </span>
+                      </div>
+                    ) : (
+                      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                        Nenhuma conta conectada
+                      </span>
+                    )}
+                    {meetStatus?.last_error && (
+                      <p className="text-sm text-red-600 mt-2">
+                        Erro na conexão ({meetStatus.last_error}). Reconecte a
+                        conta.
+                      </p>
+                    )}
+                  </div>
+
+                  {meetStatus?.connected ? (
+                    <button
+                      onClick={handleDisconnectMeet}
+                      disabled={meetBusy}
+                      className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition disabled:opacity-50"
+                    >
+                      Desconectar
+                    </button>
+                  ) : (
+                    <button
+                      onClick={handleConnectMeet}
+                      disabled={meetBusy}
+                      className="inline-flex items-center gap-2 px-4 py-2 bg-slate-700 text-white rounded-lg font-medium hover:bg-slate-800 transition disabled:opacity-50"
+                    >
+                      {meetBusy ? (
+                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                      ) : (
+                        <Video size={16} />
+                      )}
+                      Conectar conta Google
+                    </button>
+                  )}
+                </div>
               </div>
             </div>
 

--- a/frontend/src/services/googleMeet.service.ts
+++ b/frontend/src/services/googleMeet.service.ts
@@ -1,0 +1,40 @@
+import api from "./api";
+
+export interface GoogleMeetStatus {
+  connected: boolean;
+  google_email: string | null;
+  expires_at: string | null;
+  is_active: boolean;
+  last_error: string | null;
+}
+
+interface ApiResponse<T> {
+  success: boolean;
+  message?: string;
+  data: T;
+}
+
+/** Status da conexão da conta Google host de reuniões (ADMIN). */
+export async function getGoogleMeetStatus(): Promise<GoogleMeetStatus> {
+  const response = await api.get<ApiResponse<GoogleMeetStatus>>(
+    "/meetings/google/oauth/status",
+    { withCredentials: true },
+  );
+  return response.data.data;
+}
+
+/** Gera a URL de autorização OAuth do Google (ADMIN). */
+export async function getGoogleMeetAuthorizeUrl(): Promise<string> {
+  const response = await api.get<ApiResponse<{ authorize_url: string }>>(
+    "/meetings/google/oauth/authorize",
+    { withCredentials: true },
+  );
+  return response.data.data.authorize_url;
+}
+
+/** Desconecta a conta Google host de reuniões (ADMIN). */
+export async function disconnectGoogleMeet(): Promise<void> {
+  await api.post("/meetings/google/oauth/disconnect", null, {
+    withCredentials: true,
+  });
+}


### PR DESCRIPTION
## O que muda

Migra a criação de reuniões para **Google Meet** via **Meet REST API** (`spaces.create`) com `accessType=OPEN` — clientes externos/anônimos entram **sem sala de espera** (validado: o default TRUSTED prenderia anônimos no knocking).

A conta host é **conectável pelo admin** via OAuth2 (não service account — service account não cria Meet sem domain-wide delegation/Workspace). Refresh token criptografado (AES-256-GCM) no banco, trocável sem deploy. Padrão espelhado da integração Calendly existente.

## Mudanças

**Backend**
- Models `GoogleMeetConnection` + `GoogleMeetOauthState` (migration aditiva, `db push`-safe).
- `google-meet-oauth.service.ts` + `google-meet-oauth.controller.ts` — `authorize/callback/status/disconnect`, só ADMIN conecta. `access_type=offline` + `prompt=consent`, renovação via `oauth2.on('tokens')`, trata `invalid_grant`.
- `meetings.service.ts` — `createMeetSpace()` substitui o mecanismo Calendar/service-account/polling. `meet_link`=meetingUri, `calendar_event_id`=spaceName. Fallback demo/Jitsi mantido.

**Frontend**
- `RequireGoogleMeetModal` — pop-up no login do admin enquanto não houver conta conectada.
- Seção "Conta Google Meet" em `/admin/settings` (conectar/status/desconectar).

**Testes:** serviço OAuth + criação de sala (accessType OPEN, só-especialista-inicia, fallback).

## Pré-condição
A conta conectada precisa ser **Google Workspace** (conta @gmail.com comum não cria Meet via API). Requer **Google Meet API habilitada** no projeto GCP + consent screen publicado.

## Config necessária (env)
`GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GOOGLE_OAUTH_REDIRECT_URI`, `GOOGLE_MEET_TOKEN_ENCRYPTION_KEY`, `GOOGLE_MEET_ACCESS_TYPE=OPEN`, `MEETING_PROVIDER=GOOGLE`.

## Verificação
- ✅ lint + build + 50 testes verdes (back e front)
- ✅ smoke test: backend sobe, rotas montadas, guards 401/ADMIN, callback redireciona
- ✅ validado end-to-end com conta Workspace real (gera link `meet.google.com`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)