### PR TITLE
fix(security): hardening de autorização + correções de fluxo (processo/contrato/produtos)

### DIFF
--- a/backend/src/features/aircrafts/aircrafts.controller.ts
+++ b/backend/src/features/aircrafts/aircrafts.controller.ts
@@ -27,6 +27,7 @@ import { UserEntity } from 'src/auth/entities/user.entity';
 import {
   assertSpecialistCanCreate,
   assertSpecialistCanModify,
+  assertSpecialistOwnsProduct,
 } from 'src/shared/helpers/specialist-auth.helper';
 import { Public } from 'src/shared/decorators/public.decorator';
 import { ProductImportJobsService } from '../product-import-jobs/product-import-jobs.service';
@@ -145,19 +146,23 @@ export class AircraftsController {
 
   @Patch(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
-  update(
+  async update(
     @Param('id') id: string,
     @Body() updateAircraftDto: UpdateAircraftDto,
     @CurrentUser() user: UserEntity,
   ) {
     assertSpecialistCanModify('AIRCRAFT', user);
+    const existing = await this.aircraftsService.findOne(+id);
+    assertSpecialistOwnsProduct(user, existing?.specialist_id);
     return this.aircraftsService.update(+id, updateAircraftDto);
   }
 
   @Delete(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
-  remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
+  async remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
     assertSpecialistCanModify('AIRCRAFT', user);
+    const existing = await this.aircraftsService.findOne(+id);
+    assertSpecialistOwnsProduct(user, existing?.specialist_id);
     return this.aircraftsService.remove(+id);
   }
 }

--- a/backend/src/features/boats/boats.controller.ts
+++ b/backend/src/features/boats/boats.controller.ts
@@ -27,6 +27,7 @@ import { UserEntity } from 'src/auth/entities/user.entity';
 import {
   assertSpecialistCanCreate,
   assertSpecialistCanModify,
+  assertSpecialistOwnsProduct,
 } from 'src/shared/helpers/specialist-auth.helper';
 import { Public } from 'src/shared/decorators/public.decorator';
 import { ProductImportJobsService } from '../product-import-jobs/product-import-jobs.service';
@@ -145,19 +146,23 @@ export class BoatsController {
 
   @Patch(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
-  update(
+  async update(
     @Param('id') id: string,
     @Body() updateBoatDto: UpdateBoatDto,
     @CurrentUser() user: UserEntity,
   ) {
     assertSpecialistCanModify('BOAT', user);
+    const existing = await this.boatsService.findOne(+id);
+    assertSpecialistOwnsProduct(user, existing?.specialist_id);
     return this.boatsService.update(+id, updateBoatDto);
   }
 
   @Delete(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
-  remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
+  async remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
     assertSpecialistCanModify('BOAT', user);
+    const existing = await this.boatsService.findOne(+id);
+    assertSpecialistOwnsProduct(user, existing?.specialist_id);
     return this.boatsService.remove(+id);
   }
 }

--- a/backend/src/features/cars/cars.controller.ts
+++ b/backend/src/features/cars/cars.controller.ts
@@ -27,6 +27,7 @@ import { UserEntity } from 'src/auth/entities/user.entity';
 import {
   assertSpecialistCanCreate,
   assertSpecialistCanModify,
+  assertSpecialistOwnsProduct,
 } from 'src/shared/helpers/specialist-auth.helper';
 import { Public } from 'src/shared/decorators/public.decorator';
 import { ProductImportJobsService } from '../product-import-jobs/product-import-jobs.service';
@@ -142,7 +143,7 @@ export class CarsController {
 
   @Patch(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
-  update(
+  async update(
     @Param('id') id: number,
     @Body() updateCarDto: UpdateCarDto,
     @CurrentUser() user: UserEntity,
@@ -152,13 +153,17 @@ export class CarsController {
     }
 
     assertSpecialistCanModify('CAR', user);
+    const existing = await this.carsService.findOne(+id);
+    assertSpecialistOwnsProduct(user, existing?.specialist_id);
     return this.carsService.update(+id, updateCarDto);
   }
 
   @Delete(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
-  remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
+  async remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
     assertSpecialistCanModify('CAR', user);
+    const existing = await this.carsService.findOne(+id);
+    assertSpecialistOwnsProduct(user, existing?.specialist_id);
     return this.carsService.remove(+id);
   }
 }

--- a/backend/src/features/companies/companies.controller.ts
+++ b/backend/src/features/companies/companies.controller.ts
@@ -38,6 +38,7 @@ export class CompaniesController {
 
   // Rota para criar um novo escritório.
   @Post()
+  @Roles(UserRole.ADMIN)
   create(@Body() body: CreateCompanyDto) {
     return this.companiesService.create(body);
   }
@@ -64,6 +65,7 @@ export class CompaniesController {
 
   // Rota para atualizar os dados de um escritório.
   @Put(':id')
+  @Roles(UserRole.ADMIN)
   update(@Param('id') id: string, @Body() body: UpdateCompanyDto) {
     return this.companiesService.update(id, body);
   }
@@ -85,6 +87,7 @@ export class CompaniesController {
 
   // Rota para apagar um escritório.
   @Delete(':id')
+  @Roles(UserRole.ADMIN)
   remove(@Param('id') id: string) {
     return this.companiesService.remove(id);
   }

--- a/backend/src/features/consultants/consultants.controller.ts
+++ b/backend/src/features/consultants/consultants.controller.ts
@@ -10,12 +10,17 @@ import {
 import { ConsultantsService } from './consultants.service';
 import { CreateConsultantDto } from './dto/create-consultant.dto';
 import { UpdateConsultantDto } from './dto/update-consultant.dto';
+import { Roles } from 'src/shared/decorators/roles.decorator';
+import { UserRole } from '@prisma/client';
 
 /**
  * Define a rota base para este controlador.
  * Todas as rotas definidas aqui estarão sob o prefixo '/consultants'.
+ * Gestão administrativa de consultores — restrito ao ADMIN.
+ * (O fluxo de escritório usa as rotas /office/consultants.)
  */
 @Controller('consultants')
+@Roles(UserRole.ADMIN)
 export class ConsultantsController {
   /**
    * @param consultantsService - O serviço que contém a lógica de negócio para consultores.

--- a/backend/src/features/consultants/consultants.service.ts
+++ b/backend/src/features/consultants/consultants.service.ts
@@ -187,11 +187,16 @@ export class ConsultantsService {
         }
       }
 
-      // Se está atualizando a senha, faz o hash
-      const updateData = { ...data };
-      if (data.password) {
-        updateData.password_hash = await bcrypt.hash(data.password, 10);
-        delete updateData.password;
+      // Descarta qualquer password_hash vindo do cliente; a senha só entra por `password`
+      // e é sempre re-hasheada aqui.
+      const {
+        password,
+        password_hash: _ignored,
+        ...rest
+      } = data as Record<string, any>;
+      const updateData: Record<string, any> = { ...rest };
+      if (password) {
+        updateData.password_hash = await bcrypt.hash(password, 10);
       }
 
       return await this.prisma.user.update({

--- a/backend/src/features/consultants/dto/update-consultant.dto.ts
+++ b/backend/src/features/consultants/dto/update-consultant.dto.ts
@@ -2,15 +2,13 @@ import { PartialType, OmitType } from '@nestjs/mapped-types';
 import { CreateConsultantDto } from './create-consultant.dto';
 import { IsString, IsOptional } from 'class-validator';
 
-// Remove o campo password do CreateConsultantDto e adiciona password_hash como opcional
+// Remove o campo password do CreateConsultantDto. A senha é recebida em texto puro
+// via `password` e sempre passada por hash no service — `password_hash` NÃO é aceito
+// do cliente para evitar gravação de hash cru / bypass do bcrypt.
 export class UpdateConsultantDto extends PartialType(
   OmitType(CreateConsultantDto, ['password'] as const),
 ) {
   @IsString()
   @IsOptional()
   password?: string;
-
-  @IsString()
-  @IsOptional()
-  password_hash?: string;
 }

--- a/backend/src/features/processes/dto/update-process.dto.ts
+++ b/backend/src/features/processes/dto/update-process.dto.ts
@@ -1,8 +1,9 @@
-import { $Enums } from '@prisma/client';
-import { IsNotEmpty, IsOptional } from 'class-validator';
+import { $Enums, ProcessStatus } from '@prisma/client';
+import { IsEnum, IsNotEmpty, IsOptional } from 'class-validator';
 
 export class UpdateProcessDto {
   @IsNotEmpty()
+  @IsEnum(ProcessStatus)
   status: $Enums.ProcessStatus;
 
   @IsOptional()

--- a/backend/src/features/processes/processes.controller.ts
+++ b/backend/src/features/processes/processes.controller.ts
@@ -189,10 +189,20 @@ export class ProcessesController {
   async update(
     @Param('id', new ParseUUIDPipe()) processId: string,
     @Body() updateProcessDto: UpdateProcessDto,
+    @Req() req: any,
   ): Promise<ApiResponseDto<ProcessWithHistory>> {
+    const userId = req.user?.sub || req.user?.id;
+    const userRole = req.user?.role;
+
+    if (!userId) {
+      throw new UnauthorizedException('Usuário autenticado não identificado');
+    }
+
     const updatedProcess = await this.processesService.update(
       processId,
       updateProcessDto,
+      userId,
+      userRole,
     );
 
     return {

--- a/backend/src/features/processes/processes.service.ts
+++ b/backend/src/features/processes/processes.service.ts
@@ -6,6 +6,7 @@ import {
   NotFoundException,
   Logger,
   ForbiddenException,
+  HttpException,
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { CreateProcessDTO } from './dto/create-process.dto';
@@ -15,7 +16,7 @@ import {
   Product,
 } from './entity/process.response.entity';
 import { QueryDto } from 'src/shared/dto/query.dto';
-import { ProcessStatus, StatusAgendamento } from '@prisma/client';
+import { ProcessStatus, StatusAgendamento, UserRole } from '@prisma/client';
 import { ProcessesByStatus } from 'src/shared/dto/summary.dto';
 import { UpdateProcessDto } from './dto/update-process.dto';
 import { ProcessWithHistory } from './entity/process-history.response';
@@ -761,6 +762,8 @@ export class ProcessesService {
   async update(
     processId: string,
     updateProcessDto: UpdateProcessDto,
+    callerId?: string,
+    callerRole?: UserRole,
   ): Promise<ProcessWithHistory> {
     try {
       // Transction para atualizar o processo, adicionar mais uma linha sobre o histórico de status do processo, e obter o histórico atualizado
@@ -781,6 +784,22 @@ export class ProcessesService {
               aircraft: true,
             },
           });
+
+          // Autorização: apenas participantes do processo (cliente ou especialista)
+          // ou staff (ADMIN/OFFICE) podem alterar o status. Evita que qualquer
+          // usuário autenticado dirija um processo alheio.
+          const isStaff =
+            callerRole === UserRole.ADMIN || callerRole === UserRole.OFFICE;
+          const isParticipant =
+            !!callerId &&
+            (existingProcess.client_id === callerId ||
+              existingProcess.specialist_id === callerId);
+          if (!isStaff && !isParticipant) {
+            throw new ForbiddenException(
+              'Você não tem permissão para alterar este processo',
+            );
+          }
+
           //Verificar se ele já está com o status atualizado
           if (existingProcess.status === updateProcessDto.status) {
             throw new BadRequestException();
@@ -829,11 +848,14 @@ export class ProcessesService {
       };
       // Tratamento de erros
     } catch (err) {
-      if (err.code === 'P2002') {
-        throw new NotFoundException();
+      // Repassa exceções HTTP já tratadas (Forbidden/BadRequest/NotFound) sem
+      // convertê-las em 500.
+      if (err instanceof HttpException) {
+        throw err;
       }
-      if (err.status === 400) {
-        throw new BadRequestException();
+      // findUniqueOrThrow lança P2025 quando o processo não existe
+      if (err.code === 'P2025') {
+        throw new NotFoundException('Processo não encontrado');
       }
       throw new InternalServerErrorException();
     }

--- a/backend/src/features/specialists/specialists.controller.ts
+++ b/backend/src/features/specialists/specialists.controller.ts
@@ -43,6 +43,7 @@ export class SpecialistsController {
 
   // Rota para criar um novo especialista.
   @Post()
+  @Roles(UserRole.ADMIN)
   create(@Body() body: CreateSpecialistDto) {
     return this.specialistsService.create(body);
   }
@@ -76,12 +77,14 @@ export class SpecialistsController {
 
   // Rota para atualizar os dados de um especialista.
   @Put(':id')
+  @Roles(UserRole.ADMIN)
   update(@Param('id') id: string, @Body() body: UpdateSpecialistDto) {
     return this.specialistsService.update(id, body);
   }
 
   // Rota para apagar um especialista.
   @Delete(':id')
+  @Roles(UserRole.ADMIN)
   remove(@Param('id') id: string) {
     return this.specialistsService.remove(id);
   }

--- a/backend/src/providers/docusign/docusign-test.controller.ts
+++ b/backend/src/providers/docusign/docusign-test.controller.ts
@@ -1,8 +1,13 @@
 import { Body, Controller, Post } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
 import { DocuSignClient } from './docusign.client';
 import { CreateEnvelopeDto } from './dto/request/create-envelope.dto';
+import { Roles } from 'src/shared/decorators/roles.decorator';
 
+// Controlador de teste: cria envelopes DocuSign reais. Restrito ao ADMIN.
+// TODO: remover de builds de produção.
 @Controller('test')
+@Roles(UserRole.ADMIN)
 export class TestController {
   constructor(private readonly docuSignClient: DocuSignClient) {}
 

--- a/backend/src/providers/docusign/mappers/envelope-status.mapper.ts
+++ b/backend/src/providers/docusign/mappers/envelope-status.mapper.ts
@@ -17,6 +17,7 @@ export function mapDocusignStatusToProviderStatus(
     case 'voided':
       return ProviderStatus.VOIDED;
     case 'timeout':
+    case 'timedout':
       return ProviderStatus.TIMEDOUT;
     default:
       return ProviderStatus.ERROR;

--- a/backend/src/providers/docusign/webhook/webhook.service.ts
+++ b/backend/src/providers/docusign/webhook/webhook.service.ts
@@ -246,10 +246,10 @@ export class DocuSignWebhookService {
           webhookConfigurationId: payload.configurationId,
           apiVersion: payload.apiVersion,
         },
-        signed_at: new Date(),
       };
 
-      // Apenas atualizar signed_at se completado (evento de assinatura final)
+      // Apenas atualizar signed_at se completado (evento de assinatura final).
+      // Nunca sobrescrever em outros eventos (delivered/voided/etc.) nem se já assinado.
       if (providerStatus === 'COMPLETED' && !contract.signed_at) {
         // Usar data do webhook como signed_at (moment da assinatura)
         updateData.signed_at = new Date(generatedDateTime);

--- a/backend/src/shared/helpers/specialist-auth.helper.ts
+++ b/backend/src/shared/helpers/specialist-auth.helper.ts
@@ -61,3 +61,32 @@ export function assertSpecialistCanModify(
 ): void {
   assertSpecialistCanCreate(productType, user);
 }
+
+/**
+ * Valida autorização a nível de objeto: um SPECIALIST só pode modificar/deletar
+ * produtos que pertencem a ele (product.specialist_id === user.id).
+ * - ADMIN ignora a checagem (pode modificar qualquer produto).
+ *
+ * @throws ForbiddenException se o specialist não for o dono do produto
+ */
+export function assertSpecialistOwnsProduct(
+  user: UserEntity,
+  productSpecialistId: string | null | undefined,
+): void {
+  if (user.role === UserRole.ADMIN) {
+    return;
+  }
+
+  if (user.role === UserRole.SPECIALIST) {
+    if (!productSpecialistId || productSpecialistId !== user.id) {
+      throw new ForbiddenException(
+        'Você só pode modificar produtos sob sua própria responsabilidade.',
+      );
+    }
+    return;
+  }
+
+  throw new ForbiddenException(
+    'Apenas ADMIN e SPECIALIST podem modificar produtos.',
+  );
+}


### PR DESCRIPTION
## Resumo

Lote de correções **aditivas e seguras** levantadas numa revisão geral do repositório. Nenhuma altera contrato de API público nem quebra o comportamento atual do frontend deployado.

## Correções

**Autorização** (root cause: `RolesGuard` é fail-open quando não há `@Roles`)
- `consultants`: CRUD restrito a `ADMIN` (decorator de classe). Sem callers no front — fluxo de escritório usa `/office/consultants`.
- `specialists` / `companies`: `create`/`update`/`remove` restritos a `ADMIN`. Reads e `invite-consultant` (usado por OFFICE) intactos.
- DocuSign `POST /test/envelope`: restrito a `ADMIN` (criava envelopes reais p/ qualquer logado).
- `PATCH /processes/:id/status`: checagem de participante (cliente ou especialista do processo, ou ADMIN/OFFICE) + `@IsEnum(ProcessStatus)`. Antes: qualquer usuário autenticado dirigia qualquer processo a qualquer estado.
- Produtos (object-level): especialista só altera/deleta produto próprio (`specialist_id === user.id`); ADMIN passa. cars/boats/aircrafts.

**Bugs internos** (sem mudança de contrato)
- `UpdateConsultantDto` não aceita mais `password_hash` cru; senha sempre via bcrypt.
- DocuSign webhook: `signed_at` só no evento `COMPLETED` (antes sobrescrito em todo evento).
- Mapper `timedout` → `TIMEDOUT` (antes caía em `ERROR`, processo nunca ia a `REJECTED`).
- `processes.update`: retorna `404` (P2025) em vez de `500`; repassa `HttpException` em vez de virar 500.

## Verificação
- `npm run build` ✅
- `npm run lint` ✅ (0 erros, 50 warnings pré-existentes)
- `npm test` ✅ 50/50

## Fora de escopo (tratar com cuidado depois)
FSM de transições (decisão de produto), fail-open do webhook Calendly, idempotência de webhooks (migration), rawBody na assinatura DocuSign, cascade no rejectProcess, reorder do drive-import, e ajustes de frontend (redirect OFFICE/CUSTOMER, guard do preview-callback, PII em GET /users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)