### PR TITLE
fix: libera CPF ou CNPJ para especialista no contrato + recarga de processo em erro

### DIFF
--- a/backend/src/features/contracts/contracts.service.ts
+++ b/backend/src/features/contracts/contracts.service.ts
@@ -27,6 +27,7 @@ import {
 import {
   formatCpf,
   formatCnpj,
+  formatDocument,
   formatCep,
   formatRg,
   formatBRL,
@@ -399,17 +400,6 @@ export class ContractsService {
     const specialistRate = specialist.commission_rate
       ? Number(specialist.commission_rate)
       : 0;
-
-    // Especialista é PJ — o campo (coluna cpf, reaproveitada) precisa conter
-    // um CNPJ de 14 dígitos. Especialistas cadastrados antes dessa mudança
-    // ainda têm o CPF pessoal de 11 dígitos gravado ali; bloqueia aqui em vez
-    // de deixar esse valor ser rotulado como CNPJ num contrato real.
-    if (specialist.id && specialist.cpf && specialist.cpf.length !== 14) {
-      throw new BadRequestException(
-        `Especialista ${specialist.id} está com documento desatualizado (${specialist.cpf.length} dígitos). ` +
-          'É necessário atualizar o cadastro do especialista com o CNPJ (14 dígitos) antes de gerar um contrato.',
-      );
-    }
 
     // Dados do especialista para comissão
     const specialistData = specialist.id
@@ -1031,7 +1021,7 @@ export class ContractsService {
       specialist_checking_account: dto.specialist_checking_account || '',
       // NOTE: variável do template usa nome em português/inglês misturado
       especialista_name: dto.specialist_name,
-      specialist_document: formatCnpj(dto.specialist_document),
+      specialist_document: formatDocument(dto.specialist_document),
 
       // Testemunhas (opcionais)
       testimonial1_cpf: dto.testimonial1_cpf

--- a/backend/src/features/specialists/dto/update-specialist.dto.ts
+++ b/backend/src/features/specialists/dto/update-specialist.dto.ts
@@ -1,4 +1,76 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateSpecialistDto } from './create-specialist.dto';
+import {
+  IsString,
+  IsEmail,
+  Matches,
+  IsEnum,
+  IsOptional,
+  IsNumber,
+  Min,
+  Max,
+} from 'class-validator';
+import { SpecialityEnum } from './create-specialist.dto';
 
-export class UpdateSpecialistDto extends PartialType(CreateSpecialistDto) {}
+/**
+ * Não usa PartialType(CreateSpecialistDto): o campo de documento do
+ * especialista precisa aceitar CPF (11) ou CNPJ (14) na atualização —
+ * cadastros antigos ainda têm CPF gravado e não podem ficar bloqueados
+ * ao editar outros campos. PartialType só tornaria opcional a validação
+ * estrita de CreateSpecialistDto (CNPJ de 14 dígitos), sem afrouxá-la.
+ */
+export class UpdateSpecialistDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  surname?: string;
+
+  @IsOptional()
+  @IsEmail({}, { message: 'Email deve ter formato válido' })
+  email?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{11}$|^\d{14}$/, {
+    message: 'Documento deve conter 11 (CPF) ou 14 (CNPJ) dígitos numéricos',
+  })
+  cnpj?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{9,10}$/, { message: 'RG deve conter 9 ou 10 dígitos' })
+  rg?: string;
+
+  @IsOptional()
+  @IsString()
+  password_hash?: string;
+
+  @IsOptional()
+  @IsEnum(SpecialityEnum, {
+    message: 'Especialidade deve ser CAR, BOAT ou AIRCRAFT',
+  })
+  speciality?: SpecialityEnum;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'Taxa de comissão deve ser um número' })
+  @Min(0, { message: 'Taxa de comissão deve ser >= 0' })
+  @Max(100, { message: 'Taxa de comissão deve ser <= 100' })
+  commission_rate?: number;
+
+  @IsOptional()
+  @IsString()
+  bank?: string;
+
+  @IsOptional()
+  @IsString()
+  agency?: string;
+
+  @IsOptional()
+  @IsString()
+  checking_account?: string;
+
+  @IsOptional()
+  @IsString()
+  calendly_url?: string;
+}

--- a/backend/src/shared/utils/format.utils.ts
+++ b/backend/src/shared/utils/format.utils.ts
@@ -40,6 +40,20 @@ export function formatCnpj(value: string): string {
 }
 
 /**
+ * Formata documento (CPF ou CNPJ) para exibição, detectando pelo nº de dígitos
+ * @param value - CPF (11 dígitos) ou CNPJ (14 dígitos), com ou sem formatação
+ * @returns Documento formatado
+ * @example formatDocument('12345678901') => '123.456.789-01'
+ * @example formatDocument('12345678000199') => '12.345.678/0001-99'
+ */
+export function formatDocument(value: string): string {
+  if (!value) return '';
+  const digits = value.replace(/\D/g, '');
+  if (digits.length === 14) return formatCnpj(digits);
+  return formatCpf(digits);
+}
+
+/**
  * Formata CEP para exibição: #####-###
  * @param value - CEP com apenas números (8 dígitos)
  * @returns CEP formatado

--- a/frontend/src/components/processes/ProcessCard.tsx
+++ b/frontend/src/components/processes/ProcessCard.tsx
@@ -226,7 +226,6 @@ export default function ProcessCard({
     try {
       setIsConfirming(true);
       await confirmAppointment(process.id);
-      onStatusUpdated?.();
     } catch (error) {
       console.error("Error confirming appointment:", error);
       alert(
@@ -237,6 +236,10 @@ export default function ProcessCard({
       );
     } finally {
       setIsConfirming(false);
+      // Recarrega a lista mesmo em erro: se o processo já não existe mais
+      // (ex.: cancelado em outra aba/pela outra parte), o card some em vez
+      // de continuar mostrando uma ação que vai sempre falhar.
+      onStatusUpdated?.();
     }
   };
 
@@ -255,7 +258,6 @@ export default function ProcessCard({
     try {
       setIsCancelling(true);
       await cancelAppointment(process.id);
-      onStatusUpdated?.();
     } catch (error) {
       console.error("Error cancelling appointment:", error);
       alert(
@@ -266,6 +268,7 @@ export default function ProcessCard({
       );
     } finally {
       setIsCancelling(false);
+      onStatusUpdated?.();
     }
   };
 


### PR DESCRIPTION
## Summary
- Remove o bloqueio de geração de contrato para especialistas cadastrados antes da migração para CNPJ (ainda com CPF de 11 dígitos no campo de documento). Esse guard tinha sido adicionado propositalmente na revisão de segurança do #185, mas passou a impedir contrato para especialistas antigos — decisão do time: liberar CPF ou CNPJ livremente em vez de exigir backfill manual antes do deploy.
  - `contracts.service.ts`: guard removido.
  - `format.utils.ts`: novo `formatDocument()` formata CPF ou CNPJ conforme o nº de dígitos (antes só formatava CNPJ, deixando CPF sem máscara no PDF).
  - `update-specialist.dto.ts`: reescrito para aceitar CPF ou CNPJ na edição de cadastro pelo admin (mesmo tipo de bloqueio existia aqui via `PartialType(CreateSpecialistDto)`).
- `ProcessCard.tsx`: recarrega a lista de processos mesmo quando confirmar/cancelar agendamento falha (processo pode ter sido cancelado em outra aba).

Sem mudança de schema/migration nesta PR.

## Test plan
- [x] `npm run build` (backend)
- [x] `npm run lint` (backend, arquivos alterados)
- [x] `npx jest contracts.service` (6/6 passando)
- [ ] Validar em produção a geração de contrato para o processo `cb8b0851-3cf9-4e3f-b45f-0e87990cff4b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)