### PR TITLE
feat: taxa da plataforma configurável por escritório

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -621,6 +621,9 @@ model Company {
   logo            String?
   description     String?
   commission_rate Decimal? @db.Decimal(5, 2) // Taxa de comissão do escritório (ex: 15.00 = 15%)
+  // Taxa que a PLATAFORMA cobra especificamente deste escritório — sobrepõe
+  // PlatformCompany.default_commission_rate quando definida (null = usa a taxa padrão global)
+  platform_commission_rate Decimal? @db.Decimal(5, 2)
 
   // Dados bancários (opcionais - se preenchidos, são usados no contrato)
   bank             String?

--- a/backend/src/features/companies/companies.service.ts
+++ b/backend/src/features/companies/companies.service.ts
@@ -81,6 +81,9 @@ export class CompaniesService {
         return {
           ...c,
           commission_rate: c.commission_rate ? Number(c.commission_rate) : null,
+          platform_commission_rate: c.platform_commission_rate
+            ? Number(c.platform_commission_rate)
+            : null,
           consultants_count,
           logoUrl,
           _count: undefined,
@@ -151,6 +154,9 @@ export class CompaniesService {
       ...company,
       commission_rate: company.commission_rate
         ? Number(company.commission_rate)
+        : null,
+      platform_commission_rate: company.platform_commission_rate
+        ? Number(company.platform_commission_rate)
         : null,
       logoUrl,
     };

--- a/backend/src/features/companies/dto/create-company.dto.ts
+++ b/backend/src/features/companies/dto/create-company.dto.ts
@@ -37,6 +37,17 @@ export class CreateCompanyDto {
   @Max(100, { message: 'Taxa de comissão deve ser <= 100' })
   commission_rate?: number;
 
+  // Taxa que a plataforma cobra deste escritório especificamente — sobrepõe
+  // a taxa padrão global (PlatformCompany.default_commission_rate) quando definida
+  @IsNumber(
+    {},
+    { message: 'Taxa de comissão da plataforma deve ser um número' },
+  )
+  @IsOptional()
+  @Min(0, { message: 'Taxa de comissão da plataforma deve ser >= 0' })
+  @Max(100, { message: 'Taxa de comissão da plataforma deve ser <= 100' })
+  platform_commission_rate?: number;
+
   // === DADOS BANCÁRIOS (OPCIONAIS) ===
 
   @IsString({ message: 'bank deve ser uma string' })

--- a/backend/src/features/contracts/contracts.service.spec.ts
+++ b/backend/src/features/contracts/contracts.service.spec.ts
@@ -83,6 +83,33 @@ describe('ContractsService — resolveCommissionFromTotal', () => {
     expect(result.specialistRate).toBe(2);
   });
 
+  it('escritório com platform_commission_rate própria: sobrepõe a taxa padrão global da plataforma', async () => {
+    const prisma = mkPrisma();
+    prisma.process.findUnique.mockResolvedValue({
+      specialist: { id: 's1', commission_rate: null, company_id: 'c1' },
+      car: { valor: 100000 },
+      boat: null,
+      aircraft: null,
+      accepted_proposal: null,
+    });
+    prisma.company.findUnique.mockResolvedValue({
+      name: 'Escritório X',
+      cnpj: '11222333000181',
+      bank: null,
+      agency: null,
+      checking_account: null,
+      commission_rate: 8,
+      platform_commission_rate: 5,
+    });
+    const svc = mkSvc(prisma, mkPlatformCompanyService(10));
+
+    const result = await (svc as any).resolveCommissionFromTotal('p1', 20);
+
+    expect(result.platformRate).toBe(5);
+    expect(result.officeRate).toBe(8);
+    expect(result.specialistRate).toBe(7);
+  });
+
   it('total menor que plataforma + escritório → BadRequestException', async () => {
     const prisma = mkPrisma();
     prisma.process.findUnique.mockResolvedValue({

--- a/backend/src/features/contracts/contracts.service.ts
+++ b/backend/src/features/contracts/contracts.service.ts
@@ -342,7 +342,8 @@ export class ContractsService {
    * Calcula as taxas de comissão da plataforma, escritório e especialista separadamente
    *
    * Taxas de comissão:
-   * - Plataforma: sempre usa default_commission_rate da PlatformCompany
+   * - Plataforma: usa company.platform_commission_rate quando o escritório tem uma taxa
+   *   própria configurada; senão cai no default_commission_rate da PlatformCompany
    * - Escritório: usa company.commission_rate (se especialista tiver empresa)
    * - Especialista: usa specialist.commission_rate (taxa individual do especialista)
    *
@@ -383,8 +384,9 @@ export class ContractsService {
       checking_account?: string | null;
     } | null;
   }> {
-    // Taxa da plataforma: sempre vem da PlatformCompany
-    const platformRate = platformCompany?.default_commission_rate ?? 0;
+    // Taxa da plataforma: padrão global da PlatformCompany, sobreposta pela
+    // taxa própria do escritório (Company.platform_commission_rate) quando definida
+    let platformRate = platformCompany?.default_commission_rate ?? 0;
 
     // Taxa do escritório: vem da empresa do especialista
     let officeRate = 0;
@@ -430,6 +432,9 @@ export class ContractsService {
         officeRate = company.commission_rate
           ? Number(company.commission_rate)
           : 0;
+        if (company.platform_commission_rate != null) {
+          platformRate = Number(company.platform_commission_rate);
+        }
       }
     }
 

--- a/frontend/src/pages/admin/CommissionsPage.tsx
+++ b/frontend/src/pages/admin/CommissionsPage.tsx
@@ -61,6 +61,11 @@ export default function CommissionsPage() {
     setCompanies((prev) => prev.map((c) => (c.id === id ? updated : c)));
   };
 
+  const savePlatformRateForCompany = async (id: string, rate: number) => {
+    const updated = await updateCompany(id, { platform_commission_rate: rate });
+    setCompanies((prev) => prev.map((c) => (c.id === id ? updated : c)));
+  };
+
   const saveSpecialistRate = async (id: string, rate: number) => {
     const updated = await updateSpecialist(id, { commission_rate: rate });
     setSpecialists((prev) => prev.map((s) => (s.id === id ? updated : s)));
@@ -111,19 +116,36 @@ export default function CommissionsPage() {
       <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
         <h2 className="text-lg font-semibold text-gray-900 mb-1">Escritórios</h2>
         <p className="text-sm text-gray-500 mb-4">
-          Comissão de cada escritório parceiro.
+          Para cada escritório: quanto a plataforma cobra dele (sobrepõe a taxa
+          padrão global quando definida) e quanto o próprio escritório fica.
         </p>
-        <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-4">
           {companies.length === 0 ? (
             <p className="text-sm text-gray-400">Nenhum escritório cadastrado.</p>
           ) : (
             companies.map((company) => (
-              <RateRow
+              <div
                 key={company.id}
-                label={company.name}
-                initialRate={company.commission_rate ?? 0}
-                onSave={(rate) => saveCompanyRate(company.id, rate)}
-              />
+                className="border border-gray-200 rounded-lg p-3"
+              >
+                <p className="font-medium text-gray-800 mb-2">{company.name}</p>
+                <div className="flex flex-col gap-2">
+                  <RateRow
+                    label="Plataforma sobre este escritório"
+                    initialRate={
+                      company.platform_commission_rate ??
+                      platform?.default_commission_rate ??
+                      0
+                    }
+                    onSave={(rate) => savePlatformRateForCompany(company.id, rate)}
+                  />
+                  <RateRow
+                    label="Taxa do escritório"
+                    initialRate={company.commission_rate ?? 0}
+                    onSave={(rate) => saveCompanyRate(company.id, rate)}
+                  />
+                </div>
+              </div>
             ))
           )}
         </div>

--- a/frontend/src/services/companies.service.ts
+++ b/frontend/src/services/companies.service.ts
@@ -11,6 +11,7 @@ export type Company = {
   description?: string | null;
   logoUrl?: string | null;
   commission_rate?: number | null;
+  platform_commission_rate?: number | null;
   bank?: string | null;
   agency?: string | null;
   checking_account?: string | null;
@@ -39,6 +40,7 @@ type CreateCompanyDto = {
   cnpj: string;
   logo?: string;
   commission_rate?: number;
+  platform_commission_rate?: number;
   bank?: string;
   agency?: string;
   checking_account?: string;


### PR DESCRIPTION
## Summary
- Admin agora define, por escritório, quanto a plataforma cobra especificamente daquele parceiro (`Company.platform_commission_rate`), sobrepondo a taxa padrão global (`PlatformCompany.default_commission_rate`) quando definida. Sem override, comportamento igual ao anterior.
- `contracts.service.ts`: `calculateCommissionSplit` passa a resolver a taxa de plataforma a partir do escritório do especialista (quando existir override) antes de cair no default global.
- Tela **Comissões** (admin): cada escritório ganha 2 campos — "Plataforma sobre este escritório" e "Taxa do escritório" — cada um salvo independentemente.

## ⚠️ Ação manual necessária no deploy
Mudança de schema (`Company.platform_commission_rate`, coluna nova, nullable). Este projeto não roda migration automática no deploy — é preciso rodar `npx prisma db push` no banco de produção depois do merge, antes de considerar o deploy completo (mesma ressalva do #185).

## Test plan
- [x] `npm run build` (backend + frontend)
- [x] `npm run lint` (backend + frontend, arquivos alterados)
- [x] `npx jest contracts.service` (7/7 passando, incluindo novo teste do override por escritório)
- [ ] `npx prisma db push` aplicado no banco antes/no deploy
- [ ] Validar em produção: configurar taxa de plataforma diferente para dois escritórios e gerar contrato pra cada um, conferindo o split correto

🤖 Generated with [Claude Code](https://claude.com/claude-code)