### PR TITLE
feat(ui): tabelas scroláveis, export CSV/PDF e ajustes de comissão

### DIFF
--- a/frontend/src/pages/admin/CommissionsPage.tsx
+++ b/frontend/src/pages/admin/CommissionsPage.tsx
@@ -12,6 +12,7 @@ import {
   Sliders,
   Receipt,
   Download,
+  FileText,
 } from "lucide-react";
 import {
   getCompanies,
@@ -27,6 +28,7 @@ import {
   getSalesCommissions,
   type SaleCommission,
 } from "../../services/commissions.service";
+import { openPrintablePdf } from "../../utils/export";
 
 const brl = (n: number) =>
   n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
@@ -75,6 +77,36 @@ function exportSalesCsv(sales: SaleCommission[]) {
   a.download = "comissoes-por-venda.csv";
   a.click();
   URL.revokeObjectURL(url);
+}
+
+function exportSalesPdf(sales: SaleCommission[]) {
+  const header = [
+    "Produto",
+    "Cliente",
+    "Especialista",
+    "Venda",
+    "Comissão total",
+    "% total",
+    "Especialista (R$)",
+    "Escritório",
+    "Escritório (R$)",
+    "Plataforma (R$)",
+    "Assinado em",
+  ];
+  const rows = sales.map((s) => [
+    s.productLabel,
+    s.clientName,
+    s.specialistName,
+    s.saleValue,
+    s.totalCommission,
+    s.totalCommissionRate,
+    s.specialistValue,
+    s.officeName ?? "",
+    s.officeValue,
+    s.platformValue,
+    s.signedAt ? new Date(s.signedAt).toLocaleDateString("pt-BR") : "",
+  ]);
+  openPrintablePdf("Comissões por venda", header, rows);
 }
 
 type Tab = "config" | "sales";
@@ -151,10 +183,10 @@ export default function CommissionsPage() {
             )}
 
             <div className="mb-6 p-4 bg-slate-50 border border-slate-200 rounded-lg text-sm text-slate-600">
-              No modelo aninhado: o <b>especialista</b> leva uma fatia do total da
-              comissão (o “bolo”); o <b>escritório</b> leva uma fatia do{" "}
-              <b>restante</b>; a <b>plataforma</b> fica automaticamente com o que
-              sobra do restante (não é configurada aqui).
+              No modelo aninhado: o <b>especialista</b> leva uma fatia do total
+              da comissão; o <b>escritório</b> leva uma fatia do <b>restante</b>;
+              e a <b>plataforma</b> fica automaticamente com o que sobra do
+              restante (não é configurada aqui).
             </div>
 
             <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
@@ -203,7 +235,7 @@ export default function CommissionsPage() {
                 Especialistas
               </h2>
               <p className="text-sm text-gray-500 mb-4">
-                Fatia de cada especialista sobre o total da comissão (o “bolo”).
+                Fatia de cada especialista sobre o total da comissão.
               </p>
               <div className="flex flex-col gap-3">
                 {specialists.length === 0 ? (
@@ -297,7 +329,7 @@ function SalesCommissionsTab() {
 
   return (
     <div className="flex flex-col gap-5">
-      <div className="flex justify-end">
+      <div className="flex justify-end gap-2">
         <button
           type="button"
           onClick={() => exportSalesCsv(sales)}
@@ -305,6 +337,14 @@ function SalesCommissionsTab() {
         >
           <Download className="w-4 h-4" />
           Exportar CSV
+        </button>
+        <button
+          type="button"
+          onClick={() => exportSalesPdf(sales)}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+        >
+          <FileText className="w-4 h-4" />
+          Exportar PDF
         </button>
       </div>
       {sales.map((s) => (
@@ -316,7 +356,7 @@ function SalesCommissionsTab() {
 
 function SaleCard({ sale }: { sale: SaleCommission }) {
   const hasOffice = sale.officeValue > 0 || !!sale.officeName;
-  // Fatia do especialista sobre o "bolo"; escritório/plataforma sobre o restante.
+  // Fatia do especialista sobre o total; escritório/plataforma sobre o restante.
   const specialistShareOfPool =
     sale.totalCommission > 0
       ? (sale.specialistValue / sale.totalCommission) * 100
@@ -349,7 +389,7 @@ function SaleCard({ sale }: { sale: SaleCommission }) {
           </span>
           <span className="text-gray-400">
             {" "}
-            ({sale.totalCommissionRate}% da venda) — o “bolo”
+            ({sale.totalCommissionRate}% da venda)
           </span>
         </div>
       </div>
@@ -359,7 +399,7 @@ function SaleCard({ sale }: { sale: SaleCommission }) {
           label="Especialista"
           value={sale.specialistValue}
           share={specialistShareOfPool}
-          shareLabel="do bolo"
+          shareLabel="do total"
           color="bg-emerald-500"
         />
 

--- a/frontend/src/pages/admin/CompaniesPage.tsx
+++ b/frontend/src/pages/admin/CompaniesPage.tsx
@@ -10,10 +10,6 @@ import {
   type CompanyConsultant,
 } from "../../services/companies.service";
 import { adminInviteOffice, officeService, type OfficeClient } from "../../services/office";
-import {
-  getPlatformCompany,
-  type PlatformCompany,
-} from "../../services/platform-company.service";
 import type { PaginationMeta } from "../../types/types";
 import Button from "../../components/ui/button";
 import EditIcon from "../../assets/icons/edit.svg";
@@ -68,7 +64,6 @@ export default function CompaniesPage() {
   const [companies, setCompanies] = useState<Company[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [platformData, setPlatformData] = useState<PlatformCompany | null>(null);
   const [isNewCompanyModalOpen, setIsNewCompanyModalOpen] = useState(false);
   const [companyToEdit, setCompanyToEdit] = useState<Company | null>(null);
   const [companyToDelete, setCompanyToDelete] = useState<Company | null>(null);
@@ -99,12 +94,8 @@ export default function CompaniesPage() {
   const fetchData = useCallback(async () => {
     try {
       setIsLoading(true);
-      const [companiesData, platform] = await Promise.all([
-        getCompanies(),
-        getPlatformCompany().catch(() => null),
-      ]);
+      const companiesData = await getCompanies();
       setCompanies(companiesData);
-      setPlatformData(platform);
       setError(null);
     } catch (err) {
       setError("Não foi possível carregar os escritórios.");
@@ -309,7 +300,6 @@ export default function CompaniesPage() {
     return <p className="text-red-500">{error}</p>;
   }
 
-  const platformRate = platformData?.default_commission_rate ?? null;
 
   return (
     <div className="text-text-main w-full">
@@ -329,10 +319,9 @@ export default function CompaniesPage() {
         </p>
 
         {/* Cabeçalho da Lista */}
-        <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_1fr_auto] gap-5 px-4 py-2 text-base font-normal text-left text-text-secondary">
+        <div className="hidden md:grid grid-cols-[2fr_1fr_1fr_auto] gap-5 px-4 py-2 text-base font-normal text-left text-text-secondary">
           <div>Empresa</div>
-          <div>% Plataforma</div>
-          <div>% Escritório</div>
+          <div>Escritório (% restante)</div>
           <div>Consultores</div>
           <div className="text-right">Ações</div>
         </div>
@@ -358,7 +347,7 @@ export default function CompaniesPage() {
                   className="rounded-lg shadow-sm bg-white overflow-hidden"
                 >
                   {/* Linha principal da empresa */}
-                  <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr_1fr_auto] gap-3 md:gap-5 items-start md:items-center bg-brand-card p-4 md:p-6">
+                  <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr_auto] gap-3 md:gap-5 items-start md:items-center bg-brand-card p-4 md:p-6">
                     <div className="flex items-center gap-3">
                       {/* Botão expand/collapse */}
                       <button
@@ -398,18 +387,7 @@ export default function CompaniesPage() {
                       </div>
                     </div>
 
-                    {/* % Plataforma */}
-                    <div>
-                      {platformRate !== null ? (
-                        <span className="inline-flex items-center gap-1 text-sm font-medium text-blue-700 bg-blue-50 px-2.5 py-1 rounded-full">
-                          {platformRate}%
-                        </span>
-                      ) : (
-                        <span className="text-gray-400 text-sm">—</span>
-                      )}
-                    </div>
-
-                    {/* % Escritório */}
+                    {/* % Escritório (fatia do restante) */}
                     <div>
                       {company.commission_rate != null ? (
                         <span className="inline-flex items-center gap-1 text-sm font-medium text-emerald-700 bg-emerald-50 px-2.5 py-1 rounded-full">

--- a/frontend/src/pages/admin/DatabasePage.tsx
+++ b/frontend/src/pages/admin/DatabasePage.tsx
@@ -6,6 +6,8 @@ import {
   AlertCircle,
   ChevronLeft,
   ChevronRight,
+  Download,
+  FileText,
 } from "lucide-react";
 import {
   getEntities,
@@ -13,6 +15,7 @@ import {
   type EntityInfo,
   type RecordsPage,
 } from "../../services/admin-database.service";
+import { downloadCsv, openPrintablePdf } from "../../utils/export";
 
 const PAGE_SIZE = 20;
 
@@ -64,6 +67,9 @@ export default function DatabasePage() {
   const totalPages = result
     ? Math.max(1, Math.ceil(result.total / result.pageSize))
     : 1;
+  const activeLabel =
+    entities.find((e) => e.key === active)?.label ?? active ?? "";
+  const exportRows = () => rows.map((r) => columns.map((c) => formatCell(r[c])));
 
   return (
     <div className="text-text-main w-full">
@@ -112,9 +118,32 @@ export default function DatabasePage() {
         <p className="text-sm text-gray-400 p-4">Nenhum registro.</p>
       ) : (
         <>
-          <div className="overflow-x-auto border border-gray-200 rounded-lg">
+          <div className="flex justify-end gap-2 mb-3">
+            <button
+              type="button"
+              onClick={() => downloadCsv(`${active}.csv`, columns, exportRows())}
+              className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              <Download className="w-4 h-4" /> CSV
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                openPrintablePdf(
+                  `Base de dados — ${activeLabel}`,
+                  columns,
+                  exportRows(),
+                )
+              }
+              className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
+            >
+              <FileText className="w-4 h-4" /> PDF
+            </button>
+          </div>
+
+          <div className="overflow-auto border border-gray-200 rounded-lg max-h-[65vh]">
             <table className="min-w-full text-sm">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50 sticky top-0 z-10">
                 <tr>
                   {columns.map((c) => (
                     <th

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -1,0 +1,78 @@
+// Utilitários de export client-side (sem dependência externa).
+
+type Cell = string | number;
+
+// CSV com separador ";" e BOM UTF-8 (abre correto no Excel pt-BR).
+export function downloadCsv(
+  filename: string,
+  columns: string[],
+  rows: Cell[][],
+) {
+  const escape = (v: Cell) => {
+    const s = String(v ?? "");
+    return /[";\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const csv = [columns, ...rows]
+    .map((r) => r.map(escape).join(";"))
+    .join("\n");
+  const blob = new Blob(["﻿" + csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// "PDF" via impressão do navegador (Salvar como PDF) — sem lib, num iframe
+// oculto pra não depender de pop-up.
+export function openPrintablePdf(
+  title: string,
+  columns: string[],
+  rows: Cell[][],
+) {
+  const esc = (v: unknown) =>
+    String(v ?? "").replace(
+      /[<>&]/g,
+      (c) => ({ "<": "&lt;", ">": "&gt;", "&": "&amp;" })[c] as string,
+    );
+  const thead = `<tr>${columns.map((c) => `<th>${esc(c)}</th>`).join("")}</tr>`;
+  const tbody = rows
+    .map((r) => `<tr>${r.map((v) => `<td>${esc(v)}</td>`).join("")}</tr>`)
+    .join("");
+  const html = `<!doctype html><html><head><meta charset="utf-8"><title>${esc(
+    title,
+  )}</title><style>
+    body{font-family:system-ui,sans-serif;padding:16px;color:#111}
+    h1{font-size:15px;margin:0 0 12px}
+    table{border-collapse:collapse;width:100%;font-size:10px}
+    th,td{border:1px solid #ccc;padding:3px 6px;text-align:left;vertical-align:top}
+    th{background:#f3f4f6}
+    @page{size:landscape;margin:12mm}
+  </style></head><body><h1>${esc(
+    title,
+  )}</h1><table><thead>${thead}</thead><tbody>${tbody}</tbody></table></body></html>`;
+
+  const iframe = document.createElement("iframe");
+  iframe.style.position = "fixed";
+  iframe.style.right = "0";
+  iframe.style.bottom = "0";
+  iframe.style.width = "0";
+  iframe.style.height = "0";
+  iframe.style.border = "0";
+  document.body.appendChild(iframe);
+
+  const win = iframe.contentWindow;
+  if (!win) {
+    document.body.removeChild(iframe);
+    return;
+  }
+  win.document.open();
+  win.document.write(html);
+  win.document.close();
+  win.focus();
+  setTimeout(() => {
+    win.print();
+    setTimeout(() => document.body.removeChild(iframe), 1000);
+  }, 250);
+}


### PR DESCRIPTION
Tabelas da Base de dados scroláveis (header fixo) + export CSV/PDF; export PDF na aba Comissões por venda; remove jargão "bolo"; corrige a lista de Escritórios (remove coluna "% Plataforma" stale, agora derivada, e alinha o grid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)