### PR TITLE
feat: fundação do design system + piloto (Consultor, Especialista, Admin, Escritório, Customer)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Global setup in `main.ts` + `app.module.ts`:
 
 Feature modules live in `backend/src/features/` — one folder per domain:
 - **Products**: `cars/`, `boats/`, `aircrafts/` — CRUD, CSV import (async job), Google Drive image import
-- **Actors**: `users/`, `consultants/` (admin CRUD), `consultant/` (advisor wallet), `specialists/`, `companies/`
+- **Actors**: `users/`, `consultants/` (admin CRUD), `consultant/` (carteira de clientes do consultor — convite individual/em lote, CRUD de clientes vinculados; **consultor não recebe comissão nesta plataforma**, não confundir com o especialista, que recebe via `Contract.specialist_commission_value`), `specialists/`, `companies/`
 - **Sales flow**: `processes/` → `appointments/` → `proposals/` → `contracts/` → `meetings/`
 - **Support**: `dashboard/`, `settings/`, `platform-company/`, `notifications/`, `product-import-jobs/`
 
@@ -119,6 +119,7 @@ Entry: `main.tsx` → `RouterProvider` wraps everything; `AuthProvider` + `Cooki
 
 - Supabase production DB has schema drift vs migrations — use `prisma db push` for additive changes in prod; never `migrate deploy` against prod without verifying
 - `CustomerAdvisor.customer_id` is `@unique` — one advisor/invite per customer; re-invite uses `upsert`
+- **Consultor não recebe comissão nesta plataforma** — regra de negócio, não lacuna a preencher. Só o especialista é remunerado por venda (`Contract.specialist_commission_value`); não existe `commission_rate`/`consultant_id` em `Process`/`Contract` para o consultor, e não deve ser adicionado sem alinhar antes — já foi mapeado por engano como "feature faltando" em auditoria anterior.
 
 ## Environment setup
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -113,7 +113,7 @@ Inventário completo do `components/ui/` (gerado via shadcn sobre Radix):
 
 | Componente | Situação hoje | Ação |
 |---|---|---|
-| `Button` | existe (`button.tsx`), hardcoda cores fora do token | reescrever com CVA, variantes: solid/light/muted/ghost/danger |
+| `Button` | existe (`button.tsx`), hardcoda cores fora do token | reescrever com CVA, variantes: solid/light/muted/brand/ghost/danger |
 | `StatusBadge` | não existe — 4 mapas de cor duplicados ad hoc | criar: pílula neutra + ponto de cor (ver [Status](#status)), prop única `status` |
 | `Input`/`Select` | reimplementado por página | criar, anel de foco único |
 | `Modal`/`Dialog` | **dois** componentes concorrentes (`ui/Modal.tsx`, `shared/Modal.tsx`) + ~10 modais hand-rolled | consolidar num só, sobre `Dialog` do Radix (título, X, ESC, clique-fora, Cancelar sempre visíveis) |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,174 @@
+# Design System — High Class Shop
+
+Este documento é a especificação visual da plataforma: tokens, componentes, navegação, ícones e layout. Companheiro de `PRODUCT.md` (o *porquê* da marca) e de `CLAUDE.md` (arquitetura de código). Resultado de uma auditoria completa da plataforma (bugs de fluxo, navegação, consistência visual e jornadas por papel) seguida de um brainstorm de design — decisões abaixo já foram validadas, não são propostas em aberto.
+
+## Decisões já fechadas
+
+- Paleta atual mantida (branco suave, preto, cinza) — organizada em tokens semânticos, não substituída por identidade nova.
+- Ação monocromática — sem cor de destaque separada para botão primário/links/foco.
+- Status usa indicador discreto (pílula neutra + ponto de cor), não pílula saturada — ver [Status](#status).
+- Base de componentes: shadcn/ui sobre Radix + CVA + tailwind-merge (mesma base da locpay_full).
+- Só modo claro nesta fase — tokens organizados para permitir dark mode depois, sem implementá-lo agora.
+- Whitelabel por escritório continua intacto para telas do cliente final; Admin/Specialist continuam neutros.
+- Execução: fundação completa + piloto real (fluxo do Consultor + 3 becos sem saída críticos) nesta primeira leva; resto da migração vira plano de rollout separado, fatiado por área.
+
+## Paleta
+
+### Neutros
+
+| Token | Hex | Uso |
+|---|---|---|
+| `--ink` | `#1C1C1C` | título, texto principal, botão primário (hover) |
+| `--ink-soft` | `#3C3C3C` | cabeçalho da página, superfícies escuras |
+| `--action` | `#2C2C2C` | fundo do botão primário |
+| `--muted` | `#6B6B6B` | texto secundário — valor único, substitui a mistura de `gray-500/600/700` |
+| `--subtle` | `#9A9A9A` | placeholder, texto desabilitado |
+| `--border` | `#D9D9D9` | borda de input/card — valor único |
+| `--border-soft` | `#E9E9E9` | divisor sutil |
+| `--bg` | `#F5F5F5` | fundo de página |
+| `--surface` | `#FFFFFF` | card, modal, input |
+| `--focus-ring` | `#1C1C1C` | anel de foco — valor único, substitui preto/azul/slate misturados |
+
+### Status
+
+Mesmas 6 cores que a plataforma já associa a cada etapa do processo — hoje espalhadas em 4 mapas diferentes com tons inconsistentes (700 vs 800, com ou sem borda). Aqui, uma receita única por cor, usada só como **ponto de indicador discreto** (ver [StatusBadge](#componentes)), nunca como pílula saturada de fundo cheio.
+
+| Status | Cor do ponto | Significado |
+|---|---|---|
+| Agendamento (`SCHEDULING`) | `#1D4ED8` (azul) | aguardando reunião |
+| Negociação (`NEGOTIATION`) | `#B45309` (âmbar) | proposta em andamento |
+| Contrato (`PROCESSING_CONTRACT`) | `#C2410C` (laranja) | contrato em preparo/assinatura |
+| Documentação (`DOCUMENTATION`) | `#7E22CE` (roxo) | documentação final |
+| Concluído (`COMPLETED`) / sucesso | `#15803D` (verde) | processo finalizado |
+| Rejeitado (`REJECTED`) / erro | `#B91C1C` (vermelho) | processo encerrado sem sucesso |
+
+Banners/Alert de página (que precisam de mais peso visual que um badge de tabela) usam a mesma cor em fundo claro (`bg-{cor}-50`) + texto forte (`text-{cor}-700`) + borda (`border-{cor}-200`) — a única exceção onde a cor aparece "cheia", porque ali ela é a mensagem principal da tela, não um rótulo de linha de tabela.
+
+### Whitelabel
+
+Sem mudança: telas do `CUSTOMER` continuam lendo `--brand-primary` / `--brand-secondary` / `--brand-primary-fg` / `--brand-secondary-fg`, setados em runtime pelo `ThemeProvider` a partir da cor da concessionária/escritório. `ADMIN` e `SPECIALIST` continuam neutros, usando só os tokens acima.
+
+## Tipografia
+
+Fonte mantida: **Inter** (já é a fonte da plataforma). Regra: nunca mais de 3 pesos por tela (400/600/700).
+
+| Papel | Tamanho | Peso | Entrelinha | Uso |
+|---|---|---|---|---|
+| `display` | 32px | 700 | 1.2 | título de destaque (landing, tela vazia grande) — raro |
+| `h1` | 26px | 700 | 1.25 | título de página (PageHeader) |
+| `h2` | 20px | 600 | 1.3 | título de seção dentro da página |
+| `h3` | 16px | 600 | 1.4 | título de card/subseção |
+| `body` | 15px | 400 | 1.55 | texto padrão de UI, parágrafo, célula de tabela |
+| `body-strong` | 15px | 600 | 1.55 | ênfase inline (ex: nome do cliente numa linha) |
+| `small` | 13px | 400 | 1.5 | texto auxiliar, dica de campo, metadado |
+| `label`/`caption` | 12px | 600 | 1.3 | rótulo de campo, cabeçalho de tabela, eyebrow — sempre uppercase + `letter-spacing: .04em` |
+
+Só `h1`/`display` usam `text-wrap: balance`. Texto de corpo tem largura máxima de ~65 caracteres antes de quebrar em card/coluna.
+
+## Espaço, forma e elevação
+
+**Espaçamento** — grade de 4px, só estes 8 valores (hoje há `p-2`, `p-2.5`, `p-3`, `p-4`, `p-6`, `p-8` todos representando "espaçamento de card" em arquivos diferentes):
+
+`4` micro · `8` inline · `12` campo · `16` padrão · `24` card · `32` seção · `48` bloco · `64` página
+
+**Arredondamento** — 4 valores, cada um com papel fixo (hoje há 5 valores diferentes só pra botão):
+
+| Token | Valor | Uso |
+|---|---|---|
+| `sm` | 6px | input, badge |
+| `md` | 8px | botão, item de lista |
+| `lg` | 12px | card, modal |
+| `full` | 999px | pill, avatar |
+
+**Elevação** — 3 níveis ligados a camada de interface, não a gosto pessoal (hoje o overlay de modal varia de 40% a 85% de opacidade sem critério):
+
+| Nível | Sombra | Uso |
+|---|---|---|
+| 0 · plano | nenhuma (só borda) | linha de tabela, input |
+| 1 · repouso | `0 1px 2px rgba(28,28,28,.06), 0 1px 3px rgba(28,28,28,.08)` | card |
+| 2 · flutuante | `0 4px 12px rgba(28,28,28,.12)` | dropdown, tooltip |
+| 3 · modal | `0 10px 30px rgba(0,0,0,.25)` + overlay fixo em 45% preto | modal/dialog |
+
+## Ícones
+
+Convenção única: **lucide-react** (já é maioria — 43 arquivos). Elimina as outras 3 fontes que convivem hoje: SVG estático em `<img>`, SVG desenhado à mão, emoji/unicode cru (`✕`, `✓`, `✗`, `🔍`).
+
+Regras fixas:
+- `stroke-width` sempre `1.8` (hoje varia 1.5/2/2.5 dependendo do arquivo).
+- Cor sempre `currentColor` (herda do texto), exceto quando o próprio ícone comunica status (check verde, alerta âmbar).
+- Tamanho por contexto, não "o que couber":
+
+| Contexto | Tamanho |
+|---|---|
+| Inline com texto pequeno (badge, link auxiliar) | 14px |
+| Padrão — dentro de botão/rótulo | 16px |
+| Ação de linha de tabela | 18–20px |
+| Nível de página (empty state, cabeçalho de seção) | 24–32px |
+
+Mapa de conceito → ícone (lucide): Voltar `ArrowLeft` · Avançar `ArrowRight` · Editar `Pencil` · Excluir `Trash2` · Adicionar `Plus` · Fechar `X` · Buscar `Search` · Filtrar `Filter` · Exportar `Download` · Importar `Upload` · Calendário `Calendar` · Usuário `User` · Notificação `Bell` · Mais opções `MoreVertical` · Ordenar `ArrowUpDown` · Sucesso `CheckCircle2` · Alerta `AlertTriangle` · Informação `Info`.
+
+## Componentes
+
+Inventário completo do `components/ui/` (gerado via shadcn sobre Radix):
+
+| Componente | Situação hoje | Ação |
+|---|---|---|
+| `Button` | existe (`button.tsx`), hardcoda cores fora do token | reescrever com CVA, variantes: solid/light/muted/ghost/danger |
+| `StatusBadge` | não existe — 4 mapas de cor duplicados ad hoc | criar: pílula neutra + ponto de cor (ver [Status](#status)), prop única `status` |
+| `Input`/`Select` | reimplementado por página | criar, anel de foco único |
+| `Modal`/`Dialog` | **dois** componentes concorrentes (`ui/Modal.tsx`, `shared/Modal.tsx`) + ~10 modais hand-rolled | consolidar num só, sobre `Dialog` do Radix (título, X, ESC, clique-fora, Cancelar sempre visíveis) |
+| `BackButton` | não existe — 4 padrões diferentes em ~15 lugares | criar componente único, ver [Navegação](#navegação) |
+| `Card` | ad hoc, 5 combinações de padding/raio/sombra diferentes | criar, usa tokens de espaço/raio/elevação |
+| `Alert`/banner de página | não existe — cada tela improvisa (`bg-red-50 border-red-200 text-red-700` copiado à mão em vários arquivos) | criar, variantes: success/warning/danger/info |
+| `Tabs` | não existe | criar sobre Radix Tabs |
+| `Dropdown menu` | só o `UserDropdown` ad hoc | criar sobre Radix DropdownMenu, reutilizar em menus de linha de tabela |
+| `EmptyState` | texto solto por página | criar: ícone + frase + ação |
+| Tabela responsiva | 5 de 7 usos já envolvem em `overflow-x-auto`; 2 não (`XlsxImporter.tsx`, `BatchInviteClients.tsx`) | padronizar: toda tabela envolvida em contêiner com rolagem horizontal própria |
+
+## Layout
+
+**Container**: largura máxima de conteúdo 1200px, padding lateral 24px desktop / 16px mobile. Formulários com múltiplos campos usam grid de 2 colunas (nunca 3–4, que é o que quebra sem responsivo hoje), colapsando para 1 coluna abaixo de 768px. Espaço entre seções da página: 32px. Padding interno de card: 24px desktop / 16px mobile.
+
+**Template — página de lista** (ex: Meus Clientes, Processos, Base de dados):
+1. Cabeçalho — `BackButton` (só se aninhada) · Título H1 · ação primária à direita.
+2. Barra de ferramentas — filtros e ações secundárias à esquerda, busca à direita.
+3. Conteúdo — tabela (rolagem horizontal própria) ou grid de cards, paginação ao final.
+
+**Template — página de detalhe** (ex: detalhe de processo, detalhe de produto):
+1. Cabeçalho — `BackButton` · Título H1 + `StatusBadge` · ações no canto.
+2. Corpo em duas colunas (conteúdo principal + painel lateral de resumo/contexto), empilhando em 1 coluna abaixo de 900px.
+
+**Template — formulário**:
+1. Cabeçalho — `BackButton` · Título H1.
+2. Campos agrupados por seção (H2), grid de 2 colunas ≥768px.
+3. Rodapé de ação — Cancelar (light) + Salvar (solid), fixo no rodapé em mobile.
+
+## Navegação
+
+Único componente `BackButton` substitui os 4 padrões hoje espalhados em ~15 lugares (`navigate(-1)` + seta · `navigate(rota fixa)` + seta · `<Link>` em texto puro · botão estilizado pro `/login`) — uma página (`MeetingRoomPage`) hoje usa dois padrões ao mesmo tempo.
+
+Regra: toda tela alcançada por um fluxo (submissão de formulário, visualização de detalhe, modal de página inteira, estado de erro/vazio, wizard de múltiplos passos) precisa de uma saída explícita — nunca só o botão de voltar do navegador. Modais sempre têm Cancelar visível (não só clique-fora).
+
+O piloto desta fundação resolve os 3 becos sem saída críticos mapeados na auditoria:
+1. Callback de sucesso do DocuSign sem nenhum botão (`ContractPreviewCallback.tsx`).
+2. Modal de convite em lote sem nenhum botão durante o processamento (`BatchInviteClients.tsx`).
+3. `/advisor/dashboard` sem entrada em nenhuma navegação persistente.
+
+## Estrutura no código
+
+| Pasta | Conteúdo |
+|---|---|
+| `frontend/src/index.css` | tokens (`@theme`) — paleta, raio, sombra viram variáveis CSS/Tailwind |
+| `frontend/src/components/ui/` | primitivos gerados via shadcn (button, dialog, badge, input, dropdown-menu, tabs, alert) — substitui os 6 arquivos que já existem aqui hoje |
+| `frontend/src/components/patterns/` | composições próprias da plataforma: `BackButton`, `PageHeader`, `EmptyState`, `StatusBadge` — pasta nova |
+| `frontend/src/lib/utils.ts` | `cn()` (clsx + tailwind-merge) — convenção padrão do shadcn, arquivo novo |
+
+As pastas de página (`pages/admin`, `pages/consultant` etc.) não mudam de lugar — só passam a montar as telas com os blocos acima em vez de reimplementar botão/badge/modal à mão.
+
+## Rollout
+
+1. **Fundação** (este ciclo): tokens, `components/ui/` completo, `components/patterns/` completo, convenção de ícone aplicada nos componentes novos.
+2. **Piloto** (este ciclo): fluxo "Meus Clientes" do Consultor (hoje sem nenhuma classe responsiva) + os 3 becos sem saída críticos listados em [Navegação](#navegação), reconstruídos com os componentes novos.
+3. **Rollout do restante** (plano separado, fatiado por área): Admin, Specialist, Customer, Auth — cada fatia pequena o bastante pra revisar e testar sozinha.
+
+Fora de escopo desta spec (viram backlog à parte, não uma spec de design): os bugs de fluxo de negócio (máquina de estados, DocuSign, Calendly, notificações) e as inconsistências pontuais de jornada (ex: consultor sem tela de comissão) mapeados na mesma auditoria.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,41 @@
+# Product
+
+## Register
+
+product
+
+## Platform
+
+web
+
+## Users
+
+Clientes finais (compradores de carros/barcos/aeronaves de alto padrão), Consultores (trazem e acompanham clientes, ganham comissão), Especialistas (conduzem negociação, propostas e contratos) e Administradores (operação da plataforma: escritórios, consultores, especialistas). Quatro papéis, quatro dashboards (`/admin`, `/consultant`, `/specialist`, `/catalog` + `/customer`), um sistema visual só.
+
+## Product Purpose
+
+A High Class Shop é uma plataforma de intermediação para venda de carros, barcos e aeronaves de alto padrão: conecta clientes a especialistas através de um fluxo completo — catálogo, agendamento, negociação, proposta, contrato (assinatura digital via DocuSign) e conclusão. Consultores trazem e acompanham clientes; especialistas conduzem a negociação e fecham o contrato. Sucesso é o processo (`SCHEDULING → NEGOTIATION → PROCESSING_CONTRACT → DOCUMENTATION → COMPLETED | REJECTED`) ficar claro o bastante pra que nenhum papel fique sem saber o que fazer a seguir — e pra nenhuma tela virar um beco sem saída.
+
+## Positioning
+
+Uma central única para o ciclo de venda de bens de alto valor — do primeiro contato à assinatura do contrato — sem depender de planilha, e-mail solto ou processo improvisado por escritório.
+
+## Brand Personality
+
+Discreta e confiável — não "luxuosa" no sentido óbvio (sem dourado, sem grafite-premium, sem gradiente). A confiança vem da consistência e da ausência de ruído visual: poucas cores, hierarquia clara, cada tela sabendo pra onde o usuário deve ir a seguir. É a mesma lógica de quem está fechando um contrato de alto valor: sobriedade em vez de exibição.
+
+## Anti-references
+
+Paleta grafite + dourado foi cogitada e descartada explicitamente — não deve reaparecer em nenhuma tela. Badges de status saturados (verde/vermelho/laranja/roxo/azul cheios, estilo dashboard SaaS genérico) também foram descartados a favor de um indicador discreto (pílula neutra + ponto de cor — ver `DESIGN.md`). Evitar qualquer cor de destaque separada do preto/cinza de ação — a plataforma é deliberadamente monocromática nas ações (botão primário, links, foco).
+
+## Design Principles
+
+- **Sempre existe um caminho de volta** — nenhuma tela é um beco sem saída; todo fluxo (contrato, agendamento, convite em lote) tem uma saída explícita, nunca só o botão de voltar do navegador.
+- **Ação é monocromática** — botão primário, links e foco usam preto/grafite; cor é reservada só pra status (indicador discreto) e pro whitelabel do escritório.
+- **Um sistema, quatro papéis** — Cliente, Consultor, Especialista e Admin compartilham o mesmo vocabulário visual (`DESIGN.md`); diferenças são de conteúdo/permissão, não de estilo.
+- **Whitelabel só onde faz sentido** — telas do cliente final herdam a cor da concessionária/escritório (`ThemeProvider` + `--brand-*`); Admin e Especialista permanecem neutros na marca padrão da plataforma.
+- **Consistência de componente acima de implementação pontual** — um `Button`, um `Modal`, um `StatusBadge`, reaproveitados; não uma versão nova por tela.
+
+## Accessibility & Inclusion
+
+Sem exigência formal de WCAG. Padrão razoável: contraste legível nos tokens definidos em `DESIGN.md`, foco sempre visível (anel único), respeito a `prefers-reduced-motion` nas transições. Sem modo escuro nesta fase — ver `DESIGN.md` para os tokens já preparados pra isso no futuro.

--- a/docs/superpowers/plans/2026-07-21-consultor-rollout-fatia1.md
+++ b/docs/superpowers/plans/2026-07-21-consultor-rollout-fatia1.md
@@ -1,0 +1,1504 @@
+# Rollout do Design System — Fatia 1 (Consultor) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fechar a área do Consultor no rollout do design system: redesenhar `ConsultantDashboard.tsx` como um dashboard de verdade (KPIs, processos vigentes, distribuição por status, clientes recentes, atalhos rápidos) e aplicar os componentes/tokens já existentes em `ConsultantProcessesPage.tsx` e `ConsultantProcessDetailPage.tsx`.
+
+**Architecture:** Reaproveita 100% dos componentes já construídos no piloto (`Button`, `Card`, `Alert`, `Dialog`/`DialogContent`, `PageHeader`, `StatusBadge`, `EmptyState`) — nenhum componente novo de `components/ui/`. Cria só 1 componente novo (`ProposalStatusBadge`, seguindo o mesmo padrão de `StatusBadge`) e centraliza a config de status (label + cor) num único export reaproveitado pelas 3 telas + o gráfico do dashboard, em vez de duplicar o mapa `STATUS_LABELS`/`STATUS_COLORS` uma 4ª vez. **Sem endpoint novo** — `GET /consultant/processes` já retorna `updated_at`, só falta declarar no tipo do frontend.
+
+**Tech Stack:** React 19 + TypeScript + Vite + Tailwind v4 + `recharts` (já instalado, mesma lib do dashboard do Especialista) para o gráfico de distribuição por status.
+
+## Global Constraints
+
+- Nenhum token existente em `frontend/src/index.css` é tocado — só reaproveitados.
+- Import relativo, sem alias `@/`.
+- Frontend sem test runner — verificação é `npx tsc -b` + `npm run build` + `npm run lint`, e QA visual via Playwright mockando `**/api/**` (o backend local **nunca deve ser iniciado nesta máquina** — já crashou 2x; ver memória `feedback_backend_dev_server_crashed_machine`).
+- `Button` mantém as 6 variantes já existentes (`solid/light/muted/brand/ghost/danger`) — nenhuma tarefa aqui deve alterar `components/ui/button.tsx`.
+- Paleta de status (6 cores) já validada com o script de acessibilidade do skill `dataviz` — `#c2410c` (Contrato) e `#b45309` (Negociação) ficam abaixo do piso de separação CVD ideal isoladamente; isso é aceitável **somente** porque todo uso delas nesta plataforma já vem com rótulo de texto direto (nunca só a cor) — nenhuma tarefa deve remover o rótulo textual ao lado de uma cor de status.
+- Consultor não recebe comissão nesta plataforma (ver `CLAUDE.md`) — nenhum widget de comissão/wallet entra nesta fatia.
+
+---
+
+### Task 1: Tipo `updated_at` + centralizar config de status
+
+**Files:**
+- Modify: `frontend/src/services/consultant.service.ts:159-167`
+- Modify: `frontend/src/components/patterns/StatusBadge.tsx`
+
+**Interfaces:**
+- Produces: `ConsultantProcess.updated_at: string`; `export const PROCESS_STATUS_META: ReadonlyArray<{ value: string; label: string; dot: string; hex: string }>` — usado pelas Tasks 3, 4 e 5.
+
+- [ ] **Step 1: Adicionar `updated_at` ao tipo `ConsultantProcess`**
+
+Substituir em `frontend/src/services/consultant.service.ts`:
+
+```ts
+export type ConsultantProcess = {
+  id: string;
+  status: string;
+  product_type: string | null;
+  created_at: string;
+  client_id: string;
+  client: { id: string; name: string; surname: string } | null;
+  specialist: { id: string; name: string; surname: string; speciality: string } | null;
+};
+```
+
+por:
+
+```ts
+export type ConsultantProcess = {
+  id: string;
+  status: string;
+  product_type: string | null;
+  created_at: string;
+  updated_at: string;
+  client_id: string;
+  client: { id: string; name: string; surname: string } | null;
+  specialist: { id: string; name: string; surname: string; speciality: string } | null;
+};
+```
+
+(O backend já retorna esse campo — `GET /api/consultant/processes` não usa `select` no Prisma, então `updated_at` já vem no JSON hoje, só não estava declarado no tipo do frontend.)
+
+- [ ] **Step 2: Ler o `StatusBadge.tsx` atual e substituir pelo conteúdo com a config exportada**
+
+Ler `frontend/src/components/patterns/StatusBadge.tsx` primeiro pra confirmar que o conteúdo abaixo bate com o "antes" (foi criado na fundação do piloto, não deveria ter mudado desde então):
+
+```tsx
+import { cn } from "../../lib/utils";
+
+const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
+  SCHEDULING: { label: "Agendamento", dot: "bg-status-sched" },
+  NEGOTIATION: { label: "Negociação", dot: "bg-status-neg" },
+  PROCESSING_CONTRACT: { label: "Contrato", dot: "bg-status-proc" },
+  DOCUMENTATION: { label: "Documentação", dot: "bg-status-doc" },
+  COMPLETED: { label: "Concluído", dot: "bg-status-ok" },
+  REJECTED: { label: "Rejeitado", dot: "bg-status-bad" },
+};
+
+export function StatusBadge({
+  status,
+  className,
+}: {
+  status: string;
+  className?: string;
+}) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-border-soft px-2.5 py-1 text-xs font-semibold text-ink-soft",
+        className
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config?.dot ?? "bg-subtle")} />
+      {config?.label ?? status}
+    </span>
+  );
+}
+```
+
+Substituir por (mesmo comportamento externo, `STATUS_CONFIG` agora é derivado de um array exportado — `hex` é usado só pelo gráfico do dashboard, que não pode consumir classes Tailwind diretamente):
+
+```tsx
+import { cn } from "../../lib/utils";
+
+// Um único lugar pra label + cor de cada status de processo — StatusBadge,
+// o gráfico do dashboard (Task 3) e os filtros de ConsultantProcessesPage/
+// ConsultantProcessDetailPage (Tasks 4/5) consomem isto em vez de duplicar
+// o mapa. `hex` deve ficar em sincronia com os tokens --color-status-* em
+// frontend/src/index.css — existe só porque bibliotecas de gráfico (SVG)
+// não conseguem ler classes Tailwind, precisam do valor de cor literal.
+export const PROCESS_STATUS_META = [
+  { value: "SCHEDULING", label: "Agendamento", dot: "bg-status-sched", hex: "#1d4ed8" },
+  { value: "NEGOTIATION", label: "Negociação", dot: "bg-status-neg", hex: "#b45309" },
+  { value: "PROCESSING_CONTRACT", label: "Contrato", dot: "bg-status-proc", hex: "#c2410c" },
+  { value: "DOCUMENTATION", label: "Documentação", dot: "bg-status-doc", hex: "#7e22ce" },
+  { value: "COMPLETED", label: "Concluído", dot: "bg-status-ok", hex: "#15803d" },
+  { value: "REJECTED", label: "Rejeitado", dot: "bg-status-bad", hex: "#b91c1c" },
+] as const;
+
+const STATUS_CONFIG: Record<string, (typeof PROCESS_STATUS_META)[number]> =
+  Object.fromEntries(PROCESS_STATUS_META.map((meta) => [meta.value, meta]));
+
+export function StatusBadge({
+  status,
+  className,
+}: {
+  status: string;
+  className?: string;
+}) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-border-soft px-2.5 py-1 text-xs font-semibold text-ink-soft",
+        className
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config?.dot ?? "bg-subtle")} />
+      {config?.label ?? status}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 3: Verificar**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+Expected: sem erro (o único consumidor existente de `StatusBadge`, `ConsultantClientsPage.tsx`, continua passando só `status`/`className` — a mudança é aditiva).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/services/consultant.service.ts frontend/src/components/patterns/StatusBadge.tsx
+git commit -m "feat(design-system): expor PROCESS_STATUS_META e declarar updated_at em ConsultantProcess"
+```
+
+---
+
+### Task 2: Criar `ProposalStatusBadge`
+
+**Files:**
+- Create: `frontend/src/components/patterns/ProposalStatusBadge.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`.
+- Produces: `export function ProposalStatusBadge({ status, className }: { status: string; className?: string })` — retorna `null` se o status não for um dos 4 reconhecidos (mesmo comportamento do componente local que está sendo substituído em `ConsultantProcessDetailPage.tsx`).
+
+- [ ] **Step 1: Criar o arquivo**
+
+```tsx
+import { cn } from "../../lib/utils";
+
+// Status de PROPOSTA (não confundir com status de PROCESSO — StatusBadge).
+// Mesma receita visual (pílula neutra + ponto de cor) por consistência,
+// reaproveitando os mesmos tokens de status já usados no processo:
+// PENDING → âmbar (aguardando, como NEGOTIATION), ACCEPTED → verde (como
+// COMPLETED), REJECTED → vermelho (como REJECTED), COUNTERED → azul (como
+// SCHEDULING) — sem inventar cor nova pra um conceito adjacente.
+const PROPOSAL_STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
+  PENDING: { label: "Aguardando resposta", dot: "bg-status-neg" },
+  ACCEPTED: { label: "Aceita", dot: "bg-status-ok" },
+  REJECTED: { label: "Rejeitada", dot: "bg-status-bad" },
+  COUNTERED: { label: "Contraproposta enviada", dot: "bg-status-sched" },
+};
+
+export function ProposalStatusBadge({
+  status,
+  className,
+}: {
+  status: string;
+  className?: string;
+}) {
+  const config = PROPOSAL_STATUS_CONFIG[status];
+  if (!config) return null;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-border-soft px-2.5 py-1 text-xs font-semibold text-ink-soft",
+        className
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config.dot)} />
+      {config.label}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/patterns/ProposalStatusBadge.tsx
+git commit -m "feat(design-system): criar ProposalStatusBadge (mesma receita do StatusBadge, dominio de proposta)"
+```
+
+---
+
+### Task 3: Redesenhar `ConsultantDashboard.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/consultant/ConsultantDashboard.tsx` (reescrita completa)
+
+**Interfaces:**
+- Consumes: `Button`, `Card`, `Alert`, `Dialog`/`DialogContent`, `PageHeader`, `StatusBadge`, `PROCESS_STATUS_META`, `EmptyState` (Task 1/2 + fundação do piloto); `getClients`/`getAllConsultantProcesses`/`Client`/`ConsultantProcess` de `consultant.service.ts`; `InviteClientForm`/`BatchInviteClients` (componentes já existentes, não tocados).
+
+- [ ] **Step 1: Ler o arquivo atual** (`frontend/src/pages/consultant/ConsultantDashboard.tsx`) pra confirmar que bate com a versão descrita na spec (tabela de clientes reduzida, 3 modais) antes de substituir — se divergir, parar e reportar.
+
+- [ ] **Step 2: Substituir todo o conteúdo do arquivo**
+
+```tsx
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { CheckCircle2, FilePen, Plus, TrendingUp, Users } from "lucide-react";
+import {
+  getAllConsultantProcesses,
+  getClients,
+  type Client,
+  type ConsultantProcess,
+} from "../../services/consultant.service";
+import Button from "../../components/ui/button";
+import { Card } from "../../components/ui/card";
+import { Alert } from "../../components/ui/alert";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge, PROCESS_STATUS_META } from "../../components/patterns/StatusBadge";
+import { EmptyState } from "../../components/patterns/EmptyState";
+import InviteClientForm from "./InviteClientForm";
+import BatchInviteClients from "./BatchInviteClients";
+
+const TERMINAL_STATUSES = ["COMPLETED", "REJECTED"];
+
+function daysSince(dateString: string): number {
+  const diffMs = Date.now() - new Date(dateString).getTime();
+  return Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)));
+}
+
+export default function ConsultantDashboard() {
+  const navigate = useNavigate();
+  const [clients, setClients] = useState<Client[]>([]);
+  const [processes, setProcesses] = useState<ConsultantProcess[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+  const [isBatchModalOpen, setIsBatchModalOpen] = useState(false);
+
+  const fetchData = async () => {
+    try {
+      setIsLoading(true);
+      const [clientsData, processesData] = await Promise.all([
+        getClients(),
+        getAllConsultantProcesses(),
+      ]);
+      setClients(clientsData);
+      setProcesses(processesData);
+      setError(null);
+    } catch {
+      setError("Não foi possível carregar os dados do dashboard.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  const activeProcesses = useMemo(
+    () => processes.filter((p) => !TERMINAL_STATUSES.includes(p.status)),
+    [processes],
+  );
+  const completedCount = useMemo(
+    () => processes.filter((p) => p.status === "COMPLETED").length,
+    [processes],
+  );
+  const rejectedCount = useMemo(
+    () => processes.filter((p) => p.status === "REJECTED").length,
+    [processes],
+  );
+  const conversionRate = useMemo(() => {
+    const finalized = completedCount + rejectedCount;
+    return finalized > 0 ? Math.round((completedCount / finalized) * 100) : 0;
+  }, [completedCount, rejectedCount]);
+
+  const pendingProcesses = useMemo(
+    () =>
+      [...activeProcesses]
+        .sort((a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime())
+        .slice(0, 5),
+    [activeProcesses],
+  );
+
+  const statusDistribution = useMemo(
+    () =>
+      PROCESS_STATUS_META.map((meta) => ({
+        ...meta,
+        count: processes.filter((p) => p.status === meta.value).length,
+      })),
+    [processes],
+  );
+
+  const recentClients = useMemo(
+    () =>
+      [...clients]
+        .sort(
+          (a, b) =>
+            new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+        )
+        .slice(0, 5),
+    [clients],
+  );
+
+  const handleQuickActionSuccess = () => {
+    setIsInviteModalOpen(false);
+    fetchData();
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[400px]">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-12 h-12 border-3 border-border-soft border-t-primary rounded-full animate-spin" />
+          <p className="text-muted">Carregando dashboard...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-text-main w-full">
+      <PageHeader
+        title="Dashboard"
+        actions={
+          <>
+            <Button type="button" variant="light" onClick={() => setIsBatchModalOpen(true)}>
+              Convite em lote
+            </Button>
+            <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
+              <Plus size={16} />
+              Convidar cliente
+            </Button>
+          </>
+        }
+      />
+
+      {error && (
+        <Alert variant="danger" className="mb-4">
+          {error}
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <Users size={14} />
+            Clientes
+          </div>
+          <p className="text-2xl font-bold text-ink">{clients.length}</p>
+        </Card>
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <FilePen size={14} />
+            Processos ativos
+          </div>
+          <p className="text-2xl font-bold text-ink">{activeProcesses.length}</p>
+        </Card>
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <CheckCircle2 size={14} />
+            Concluídos
+          </div>
+          <p className="text-2xl font-bold text-ink">{completedCount}</p>
+        </Card>
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <TrendingUp size={14} />
+            Taxa de conversão
+          </div>
+          <p className="text-2xl font-bold text-ink">{conversionRate}%</p>
+        </Card>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-4">
+        <Card>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-h2 font-semibold text-ink">Processos vigentes</h2>
+            <button
+              type="button"
+              onClick={() => navigate("/consultant/processes")}
+              className="text-sm font-semibold text-ink-soft hover:text-ink"
+            >
+              Ver todos
+            </button>
+          </div>
+          {pendingProcesses.length === 0 ? (
+            <EmptyState
+              icon={FilePen}
+              title="Nenhum processo em andamento"
+              description="Processos ativos dos seus clientes aparecem aqui."
+            />
+          ) : (
+            <div className="flex flex-col gap-2">
+              {pendingProcesses.map((proc) => (
+                <div
+                  key={proc.id}
+                  onClick={() => navigate(`/consultant/processes/${proc.id}`)}
+                  className="flex items-center justify-between gap-3 bg-surface rounded-lg px-4 py-3 border border-border-soft hover:border-border cursor-pointer transition-colors"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <StatusBadge status={proc.status} />
+                    <span className="text-sm text-muted truncate">
+                      {proc.client ? `${proc.client.name} ${proc.client.surname}` : "—"}
+                      {proc.specialist
+                        ? ` • ${proc.specialist.name} ${proc.specialist.surname}`
+                        : ""}
+                    </span>
+                  </div>
+                  <span className="text-xs text-subtle whitespace-nowrap">
+                    {daysSince(proc.updated_at)}d sem atualização
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+
+        <div className="flex flex-col gap-4">
+          <Card>
+            <h2 className="text-h2 font-semibold text-ink mb-4">Distribuição por status</h2>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={statusDistribution} layout="vertical" margin={{ left: 8, right: 16 }}>
+                <XAxis type="number" hide allowDecimals={false} />
+                <YAxis
+                  type="category"
+                  dataKey="label"
+                  width={100}
+                  tick={{ fontSize: 12, fill: "#6b6b6b" }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <Tooltip cursor={{ fill: "#e9e9e9" }} />
+                <Bar dataKey="count" radius={[0, 4, 4, 0]} barSize={16}>
+                  {statusDistribution.map((entry) => (
+                    <Cell key={entry.value} fill={entry.hex} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </Card>
+
+          <Card>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-h2 font-semibold text-ink">Clientes recentes</h2>
+              <button
+                type="button"
+                onClick={() => navigate("/consultant/clients")}
+                className="text-sm font-semibold text-ink-soft hover:text-ink"
+              >
+                Ver todos
+              </button>
+            </div>
+            {recentClients.length === 0 ? (
+              <EmptyState
+                icon={Users}
+                title="Nenhum cliente ainda"
+                description='Clique em "Convidar cliente" para começar.'
+              />
+            ) : (
+              <div className="flex flex-col gap-2">
+                {recentClients.map((client) => (
+                  <div
+                    key={client.id}
+                    className="flex items-center justify-between gap-3 px-1 py-2 border-b border-border-soft last:border-b-0"
+                  >
+                    <span className="text-sm font-medium text-ink truncate">
+                      {client.name} {client.surname}
+                    </span>
+                    <span className="text-xs text-subtle whitespace-nowrap">
+                      {client.created_at
+                        ? new Date(client.created_at).toLocaleDateString("pt-BR")
+                        : "-"}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </Card>
+        </div>
+      </div>
+
+      <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
+        <DialogContent open={isInviteModalOpen} title="Convidar cliente" hideTitle>
+          <InviteClientForm onSuccess={handleQuickActionSuccess} />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isBatchModalOpen} onOpenChange={setIsBatchModalOpen}>
+        <DialogContent open={isBatchModalOpen} title="Convite de clientes em lote" hideTitle>
+          <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verificar tipos**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+Expected: sem erro. Se `recharts` reclamar de tipo em `data={statusDistribution}` (array de objetos com `value/label/dot/hex/count`), confirmar que `dataKey` usados (`"label"`, `"count"`) existem nesses objetos — não ajustar o formato de `PROCESS_STATUS_META` sem checar a Task 1 primeiro.
+
+- [ ] **Step 4: Verificar visualmente**
+
+Sem rodar o backend local (ver Global Constraints) — usar o mesmo padrão de QA do piloto: `npm run dev` (só frontend) + um script Playwright mockando `**/api/**` com `auth/me` (role CONSULTANT), `consultant/clients` e `consultant/processes` retornando alguns registros com `status` variados e `updated_at` diferentes. Confirmar: 4 KPIs corretos, lista de "Processos vigentes" ordenada do mais parado pro mais recente, gráfico de barras renderiza com as 6 cores certas (comparar com os pontos do `StatusBadge` na mesma tela), "Clientes recentes" lista os últimos por data, os 2 modais abrem/fecham corretamente (mesmo `hideTitle` do piloto). Parar o dev server ao final.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/consultant/ConsultantDashboard.tsx
+git commit -m "feat(consultor): redesenhar dashboard com KPIs, processos vigentes, grafico de status e atalhos"
+```
+
+---
+
+### Task 4: Aplicar o sistema em `ConsultantProcessesPage.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/consultant/ConsultantProcessesPage.tsx` (reescrita completa)
+
+**Interfaces:**
+- Consumes: `PageHeader`, `StatusBadge`, `PROCESS_STATUS_META`, `Card` (Task 1 + fundação).
+
+- [ ] **Step 1: Ler o arquivo atual** pra confirmar que bate com a versão já lida nesta sessão (301 linhas, filtro de status/cliente, grid `1.5fr_1.5fr_1fr_1fr_1fr` sem responsividade, paginação) — se divergir, parar e reportar.
+
+- [ ] **Step 2: Substituir todo o conteúdo do arquivo**
+
+```tsx
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { getAllConsultantProcesses, getClients, type ConsultantProcess, type Client } from "../../services/consultant.service";
+import { Loader2, Search, X, ChevronDown } from "lucide-react";
+import { Card } from "../../components/ui/card";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge, PROCESS_STATUS_META } from "../../components/patterns/StatusBadge";
+import { EmptyState } from "../../components/patterns/EmptyState";
+
+const PRODUCT_LABELS: Record<string, string> = {
+  CAR: "Carro",
+  BOAT: "Embarcação",
+  AIRCRAFT: "Aeronave",
+};
+
+const PAGE_SIZE = 15;
+
+export default function ConsultantProcessesPage() {
+  const navigate = useNavigate();
+  const [processes, setProcesses] = useState<ConsultantProcess[]>([]);
+  const [clients, setClients] = useState<Client[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [statusFilter, setStatusFilter] = useState<string>("");
+  const [selectedClient, setSelectedClient] = useState<Client | null>(null);
+  const [clientSearch, setClientSearch] = useState("");
+  const [isClientDropdownOpen, setIsClientDropdownOpen] = useState(false);
+  const [page, setPage] = useState(1);
+
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    getClients().then(setClients).catch(() => setClients([]));
+  }, []);
+
+  const fetchProcesses = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      const data = await getAllConsultantProcesses({
+        status: statusFilter || undefined,
+        clientId: selectedClient?.id,
+      });
+      setProcesses(data);
+      setPage(1);
+      setError(null);
+    } catch {
+      setError("Não foi possível carregar os processos.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [statusFilter, selectedClient]);
+
+  useEffect(() => { fetchProcesses(); }, [fetchProcesses]);
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsClientDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
+  const filteredClients = useMemo(() => {
+    const q = clientSearch.trim().toLowerCase();
+    if (!q) return clients;
+    return clients.filter((c) =>
+      `${c.name} ${c.surname} ${c.email ?? ""}`.toLowerCase().includes(q),
+    );
+  }, [clientSearch, clients]);
+
+  const totalPages = Math.max(1, Math.ceil(processes.length / PAGE_SIZE));
+  const pageProcesses = processes.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const clearFilters = () => {
+    setStatusFilter("");
+    setSelectedClient(null);
+    setClientSearch("");
+  };
+
+  const hasFilters = statusFilter !== "" || selectedClient !== null;
+
+  return (
+    <div className="text-text-main w-full">
+      <PageHeader title="Processos dos Clientes" />
+
+      <Card className="mb-4 flex flex-wrap items-center gap-3 p-4">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-muted uppercase tracking-wider">Status</label>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="text-sm px-3 py-2 border border-border rounded-md bg-surface min-w-[180px]"
+          >
+            <option value="">Todos</option>
+            {PROCESS_STATUS_META.map(({ value, label }) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1 relative" ref={dropdownRef}>
+          <label className="text-xs font-medium text-muted uppercase tracking-wider">Cliente</label>
+          <button
+            type="button"
+            onClick={() => setIsClientDropdownOpen((v) => !v)}
+            className="flex items-center justify-between gap-2 text-sm px-3 py-2 border border-border rounded-md bg-surface min-w-[240px] hover:border-ink-soft"
+          >
+            <span className={selectedClient ? "text-ink" : "text-subtle"}>
+              {selectedClient
+                ? `${selectedClient.name} ${selectedClient.surname}`
+                : "Todos os clientes"}
+            </span>
+            <ChevronDown className="w-4 h-4 text-muted" />
+          </button>
+
+          {isClientDropdownOpen && (
+            <div className="absolute top-full left-0 right-0 mt-1 bg-surface border border-border rounded-md shadow-ds-floating z-20 max-h-72 overflow-hidden flex flex-col">
+              <div className="p-2 border-b border-border-soft">
+                <div className="relative">
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-subtle" />
+                  <input
+                    type="text"
+                    value={clientSearch}
+                    onChange={(e) => setClientSearch(e.target.value)}
+                    placeholder="Buscar cliente..."
+                    className="w-full text-sm pl-8 pr-2 py-1.5 border border-border-soft rounded"
+                    autoFocus
+                  />
+                </div>
+              </div>
+              <div className="overflow-y-auto flex-1">
+                <button
+                  type="button"
+                  onClick={() => {
+                    setSelectedClient(null);
+                    setIsClientDropdownOpen(false);
+                    setClientSearch("");
+                  }}
+                  className="w-full text-left px-3 py-2 text-sm hover:bg-border-soft text-subtle border-b border-border-soft"
+                >
+                  Todos os clientes
+                </button>
+                {filteredClients.length === 0 ? (
+                  <p className="px-3 py-2 text-sm text-subtle">Nenhum cliente.</p>
+                ) : (
+                  filteredClients.map((c) => (
+                    <button
+                      key={c.id}
+                      type="button"
+                      onClick={() => {
+                        setSelectedClient(c);
+                        setIsClientDropdownOpen(false);
+                        setClientSearch("");
+                      }}
+                      className="w-full text-left px-3 py-2 text-sm hover:bg-border-soft"
+                    >
+                      <div className="font-medium text-ink">{c.name} {c.surname}</div>
+                      <div className="text-xs text-subtle">{c.email}</div>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={clearFilters}
+            className="inline-flex items-center gap-1 text-xs text-muted hover:text-ink px-3 py-2 self-end"
+          >
+            <X className="w-3.5 h-3.5" />
+            Limpar filtros
+          </button>
+        )}
+      </Card>
+
+      <Card>
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h2 className="text-h2 font-semibold text-ink">Processos</h2>
+            <p className="text-sm text-muted mt-1">
+              Clique em um processo para ver os detalhes.
+            </p>
+          </div>
+          <span className="text-sm text-muted">
+            {processes.length} {processes.length === 1 ? "processo" : "processos"}
+          </span>
+        </div>
+
+        {error ? (
+          <p className="text-status-bad">{error}</p>
+        ) : isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="flex flex-col items-center gap-3">
+              <Loader2 className="w-8 h-8 animate-spin text-subtle" />
+              <p className="text-sm text-muted">Carregando processos...</p>
+            </div>
+          </div>
+        ) : processes.length === 0 ? (
+          <EmptyState
+            icon={Search}
+            title={hasFilters ? "Nenhum processo com esses filtros" : "Nenhum processo ainda"}
+            description={hasFilters ? undefined : "Crie processos na página de Clientes."}
+          />
+        ) : (
+          <>
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full min-w-[720px] text-sm">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Cliente</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Especialista</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Produto</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Status</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Data</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pageProcesses.map((proc) => (
+                    <tr
+                      key={proc.id}
+                      onClick={() => navigate(`/consultant/processes/${proc.id}`)}
+                      className="border-b border-border-soft hover:bg-border-soft/50 cursor-pointer transition-colors"
+                    >
+                      <td className="px-4 py-3 text-sm font-medium text-ink">
+                        {proc.client ? `${proc.client.name} ${proc.client.surname}` : "—"}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-muted">
+                        {proc.specialist ? `${proc.specialist.name} ${proc.specialist.surname}` : "—"}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-muted">
+                        {PRODUCT_LABELS[proc.product_type ?? ""] ?? proc.product_type ?? "Consultoria"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusBadge status={proc.status} />
+                      </td>
+                      <td className="px-4 py-3 text-xs text-subtle">
+                        {new Date(proc.created_at).toLocaleDateString("pt-BR")}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-4 pt-3 border-t border-border">
+                <span className="text-xs text-muted">
+                  Página {page} de {totalPages}
+                </span>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="px-3 py-1.5 text-sm rounded border border-border hover:bg-border-soft disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    Anterior
+                  </button>
+                  <button
+                    onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={page === totalPages}
+                    className="px-3 py-1.5 text-sm rounded border border-border hover:bg-border-soft disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    Próxima
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}
+```
+
+Nota: o `EmptyState` do estado "sem filtro nenhum" antes dizia "Nenhum processo ainda. Crie processos na página de Clientes." — o componente `EmptyState` já separa `title`/`description`, então isso virou `title="Nenhum processo ainda"` + `description="Crie processos na página de Clientes."`; o estado "com filtro" (`hasFilters`) não tinha uma segunda frase antes, então `description={undefined}` mantém só o título, sem inventar texto novo.
+
+- [ ] **Step 3: Verificar**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+- [ ] **Step 4: Verificar visualmente**
+
+Mesmo padrão de QA da Task 3 (frontend só + Playwright mockando `consultant/processes` e `consultant/clients` com múltiplos registros, incluindo mais de 15 pra ver a paginação). Confirmar: filtro de status usa os mesmos rótulos do `StatusBadge`, tabela rola horizontal em viewport estreita (390px), badges de status com ponto colorido.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/consultant/ConsultantProcessesPage.tsx
+git commit -m "feat(consultor): aplicar StatusBadge/PageHeader/tabela responsiva em ConsultantProcessesPage"
+```
+
+---
+
+### Task 5: Aplicar o sistema em `ConsultantProcessDetailPage.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx`
+
+**Interfaces:**
+- Consumes: `PageHeader` (com `showBack`/`backTo` — primeiro consumidor real dessa branch, ver `DESIGN.md`), `StatusBadge`, `ProposalStatusBadge` (Task 2), `Card`, `Button`.
+
+- [ ] **Step 1: Ler o arquivo atual** (735 linhas) e confirmar que bate com o que foi lido nesta sessão antes de editar.
+
+- [ ] **Step 2: Trocar os imports**
+
+Substituir:
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  AlertCircle,
+  ArrowLeft,
+  Calendar,
+  Check,
+  DollarSign,
+  Loader2,
+  MessageSquare,
+  Package,
+  RefreshCw,
+  Send,
+  User,
+  UserCog,
+  Video,
+  X,
+} from "lucide-react";
+import {
+  acceptProposal,
+  createProposal,
+  getProcessProposals,
+  rejectProposal,
+  type NegotiationMeta,
+  type NegotiationProcessInfo,
+  type NegotiationProposal,
+} from "../../services/proposals.service";
+import {
+  getMeetingByProcess,
+  getProcessById,
+  type MeetingSession,
+  type Process,
+} from "../../services/processes.service";
+import { useAuth } from "../../store/authStateManager";
+
+const STATUS_LABELS: Record<string, string> = {
+  SCHEDULING: "Agendamento",
+  NEGOTIATION: "Negociação",
+  PROCESSING_CONTRACT: "Contrato",
+  DOCUMENTATION: "Documentação",
+  COMPLETED: "Concluído",
+  REJECTED: "Rejeitado",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  SCHEDULING: "bg-blue-100 text-blue-700",
+  NEGOTIATION: "bg-yellow-100 text-yellow-700",
+  PROCESSING_CONTRACT: "bg-orange-100 text-orange-700",
+  DOCUMENTATION: "bg-purple-100 text-purple-700",
+  COMPLETED: "bg-green-100 text-green-700",
+  REJECTED: "bg-red-100 text-red-700",
+};
+
+const PRODUCT_LABELS: Record<string, string> = {
+  CAR: "Carro",
+  BOAT: "Embarcação",
+  AIRCRAFT: "Aeronave",
+};
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(value);
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function ProposalStatusBadge({ status }: { status: string }) {
+  switch (status) {
+    case "PENDING":
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-full">
+          <Loader2 size={12} className="animate-spin" />
+          Aguardando resposta
+        </span>
+      );
+    case "ACCEPTED":
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-800 text-xs font-medium rounded-full">
+          <Check size={12} />
+          Aceita
+        </span>
+      );
+    case "REJECTED":
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-1 bg-red-100 text-red-800 text-xs font-medium rounded-full">
+          <X size={12} />
+          Rejeitada
+        </span>
+      );
+    case "COUNTERED":
+      return (
+        <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 text-xs font-medium rounded-full">
+          <RefreshCw size={12} />
+          Contraproposta enviada
+        </span>
+      );
+    default:
+      return null;
+  }
+}
+```
+
+por (remove os 2 mapas locais e a função `ProposalStatusBadge` local — agora vêm de `StatusBadge`/`ProposalStatusBadge` importados; **`ArrowLeft` continua na lista** — o `PageHeader` desenha a seta de voltar do cabeçalho principal, mas o estado de erro/"processo não encontrado" mais abaixo no arquivo tem seu próprio botão "Voltar para processos" com esse mesmo ícone, tratado no Step 3a):
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  AlertCircle,
+  ArrowLeft,
+  Calendar,
+  Check,
+  DollarSign,
+  Loader2,
+  MessageSquare,
+  Package,
+  RefreshCw,
+  Send,
+  User,
+  UserCog,
+  Video,
+  X,
+} from "lucide-react";
+import {
+  acceptProposal,
+  createProposal,
+  getProcessProposals,
+  rejectProposal,
+  type NegotiationMeta,
+  type NegotiationProcessInfo,
+  type NegotiationProposal,
+} from "../../services/proposals.service";
+import {
+  getMeetingByProcess,
+  getProcessById,
+  type MeetingSession,
+  type Process,
+} from "../../services/processes.service";
+import { useAuth } from "../../store/authStateManager";
+import { Card } from "../../components/ui/card";
+import Button from "../../components/ui/button";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge } from "../../components/patterns/StatusBadge";
+import { ProposalStatusBadge } from "../../components/patterns/ProposalStatusBadge";
+
+const PRODUCT_LABELS: Record<string, string> = {
+  CAR: "Carro",
+  BOAT: "Embarcação",
+  AIRCRAFT: "Aeronave",
+};
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(value);
+}
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+```
+
+- [ ] **Step 3a: Tokenizar o botão do estado de erro ("processo não encontrado")**
+
+Substituir:
+
+```tsx
+  if (error || !process) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <AlertCircle className="text-red-500 mb-3" size={40} />
+        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+          Não foi possível carregar o processo
+        </h2>
+        <p className="text-sm text-gray-600 mb-4">
+          {error ?? "Processo não encontrado."}
+        </p>
+        <button
+          onClick={() => navigate("/consultant/processes")}
+          className="inline-flex items-center gap-2 px-4 py-2 bg-slate-700 text-white rounded-lg hover:bg-slate-800 transition-colors"
+        >
+          <ArrowLeft size={18} />
+          Voltar para processos
+        </button>
+      </div>
+    );
+  }
+```
+
+por:
+
+```tsx
+  if (error || !process) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <AlertCircle className="text-status-bad mb-3" size={40} />
+        <h2 className="text-lg font-semibold text-ink mb-1">
+          Não foi possível carregar o processo
+        </h2>
+        <p className="text-sm text-muted mb-4">
+          {error ?? "Processo não encontrado."}
+        </p>
+        <Button type="button" onClick={() => navigate("/consultant/processes")}>
+          <ArrowLeft size={18} />
+          Voltar para processos
+        </Button>
+      </div>
+    );
+  }
+```
+
+- [ ] **Step 3: Trocar o cabeçalho da página — primeiro uso real de `PageHeader` com `showBack`**
+
+Substituir:
+
+```tsx
+  const productLabel = process.product_type
+    ? PRODUCT_LABELS[process.product_type] ?? process.product_type
+    : "Consultoria";
+  const statusLabel = STATUS_LABELS[process.status] ?? process.status;
+  const statusColor =
+    STATUS_COLORS[process.status] ?? "bg-gray-100 text-gray-600";
+
+  const acceptedProposal = proposals.find((p) => p.status === "ACCEPTED");
+  const isAwaitingProduct = !process.product_type || !process.product_id;
+  const showCreateForm = canCreateProposal();
+  const isScheduling = process.status === "SCHEDULING";
+  const isAppointmentConfirmed =
+    process.appointment_status === "SCHEDULED" ||
+    process.appointment_status === "COMPLETED";
+
+  return (
+    <div className="text-text-main w-full">
+      <div className="flex items-center justify-between mb-6 gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => navigate("/consultant/processes")}
+            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
+            aria-label="Voltar"
+          >
+            <ArrowLeft size={20} className="text-gray-600" />
+          </button>
+          <div>
+            <h1 className="h1-style">Detalhes do processo</h1>
+            <p className="text-sm text-gray-500 mt-1">
+              Acompanhe e atue na negociação em nome do cliente.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={load}
+          className="inline-flex items-center gap-2 px-3 py-2 text-sm border border-gray-200 rounded-lg hover:bg-gray-50"
+        >
+          <RefreshCw size={16} />
+          Atualizar
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+        <div className="p-4 rounded-lg shadow bg-white">
+          <div className="flex items-center gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            <User size={14} />
+            Cliente
+          </div>
+          <p className="text-sm font-medium text-gray-900">
+            {process.client?.name ?? "—"}
+          </p>
+          {process.client?.email && (
+            <p className="text-xs text-gray-500 mt-1">{process.client.email}</p>
+          )}
+        </div>
+
+        <div className="p-4 rounded-lg shadow bg-white">
+          <div className="flex items-center gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            <UserCog size={14} />
+            Especialista
+          </div>
+          <p className="text-sm font-medium text-gray-900">
+            {process.specialist?.name ?? "—"}
+          </p>
+          {process.specialist?.especialidade && (
+            <p className="text-xs text-gray-500 mt-1">
+              {process.specialist.especialidade}
+            </p>
+          )}
+        </div>
+
+        <div className="p-4 rounded-lg shadow bg-white">
+          <div className="flex items-center gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+            <Package size={14} />
+            Produto
+          </div>
+          <p className="text-sm font-medium text-gray-900">{productLabel}</p>
+          {process.product && (
+            <p className="text-xs text-gray-500 mt-1 truncate">
+              {[process.product.marca, process.product.modelo]
+                .filter(Boolean)
+                .join(" ")}
+              {process.product.ano ? ` • ${process.product.ano}` : ""}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="p-4 rounded-lg shadow bg-white mb-6 flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+            Status
+          </span>
+          <span
+            className={`text-xs font-medium px-2 py-1 rounded-full ${statusColor}`}
+          >
+            {statusLabel}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 text-sm text-gray-600">
+          <Calendar size={14} className="text-gray-400" />
+          Criado em {formatDate(process.created_at)}
+        </div>
+        {process.appointment_datetime && (
+          <div className="flex items-center gap-2 text-sm text-gray-600">
+            <Calendar size={14} className="text-gray-400" />
+            Reunião: {formatDate(process.appointment_datetime)}
+          </div>
+        )}
+        {process.rejection_reason && (
+          <div className="flex items-center gap-2 text-sm text-red-600">
+            <AlertCircle size={14} />
+            Motivo da rejeição: {process.rejection_reason}
+          </div>
+        )}
+      </div>
+
+      {!isScheduling && processInfo && (
+        <div className="p-4 rounded-lg shadow bg-white mb-6 flex flex-wrap items-center gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <DollarSign size={16} className="text-green-600" />
+            <span className="text-gray-500">Valor do produto:</span>
+            <span className="font-semibold text-gray-900">
+              {formatCurrency(processInfo.product_value)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            <AlertCircle size={16} className="text-orange-500" />
+            <span className="text-gray-500">Valor mínimo:</span>
+            <span className="font-semibold text-orange-600">
+              {formatCurrency(processInfo.minimum_value)}
+            </span>
+          </div>
+          {acceptedProposal && (
+            <div className="flex items-center gap-2">
+              <Check size={16} className="text-green-600" />
+              <span className="text-gray-500">Valor aceito:</span>
+              <span className="font-semibold text-green-700">
+                {formatCurrency(acceptedProposal.proposed_value)}
+              </span>
+            </div>
+          )}
+          {meta && (
+            <div className="ml-auto text-xs text-gray-400">
+              {meta.total} {meta.total === 1 ? "proposta" : "propostas"}
+            </div>
+          )}
+        </div>
+      )}
+```
+
+por (troca `STATUS_LABELS`/`STATUS_COLORS` por `StatusBadge`; cabeçalho manual por `PageHeader` com `showBack` + `backTo` — esta é a primeira tela da plataforma a exercitar esse branch; os 3 cards viram `Card`; cores tokenizadas; "valor mínimo" em laranja **fica como está de propósito** — não é um dos 6 status de processo, é só um destaque visual de "atenção ao valor", não tokenizar como status):
+
+```tsx
+  const productLabel = process.product_type
+    ? PRODUCT_LABELS[process.product_type] ?? process.product_type
+    : "Consultoria";
+
+  const acceptedProposal = proposals.find((p) => p.status === "ACCEPTED");
+  const isAwaitingProduct = !process.product_type || !process.product_id;
+  const showCreateForm = canCreateProposal();
+  const isScheduling = process.status === "SCHEDULING";
+  const isAppointmentConfirmed =
+    process.appointment_status === "SCHEDULED" ||
+    process.appointment_status === "COMPLETED";
+
+  return (
+    <div className="text-text-main w-full">
+      <PageHeader
+        title="Detalhes do processo"
+        showBack
+        backTo="/consultant/processes"
+        actions={
+          <button
+            onClick={load}
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-lg hover:bg-border-soft"
+          >
+            <RefreshCw size={16} />
+            Atualizar
+          </button>
+        }
+      />
+      <p className="text-sm text-muted -mt-4 mb-6">
+        Acompanhe e atue na negociação em nome do cliente.
+      </p>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wider mb-2">
+            <User size={14} />
+            Cliente
+          </div>
+          <p className="text-sm font-medium text-ink">
+            {process.client?.name ?? "—"}
+          </p>
+          {process.client?.email && (
+            <p className="text-xs text-muted mt-1">{process.client.email}</p>
+          )}
+        </Card>
+
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wider mb-2">
+            <UserCog size={14} />
+            Especialista
+          </div>
+          <p className="text-sm font-medium text-ink">
+            {process.specialist?.name ?? "—"}
+          </p>
+          {process.specialist?.especialidade && (
+            <p className="text-xs text-muted mt-1">
+              {process.specialist.especialidade}
+            </p>
+          )}
+        </Card>
+
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wider mb-2">
+            <Package size={14} />
+            Produto
+          </div>
+          <p className="text-sm font-medium text-ink">{productLabel}</p>
+          {process.product && (
+            <p className="text-xs text-muted mt-1 truncate">
+              {[process.product.marca, process.product.modelo]
+                .filter(Boolean)
+                .join(" ")}
+              {process.product.ano ? ` • ${process.product.ano}` : ""}
+            </p>
+          )}
+        </Card>
+      </div>
+
+      <Card className="mb-6 flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-muted uppercase tracking-wider">
+            Status
+          </span>
+          <StatusBadge status={process.status} />
+        </div>
+        <div className="flex items-center gap-2 text-sm text-muted">
+          <Calendar size={14} className="text-subtle" />
+          Criado em {formatDate(process.created_at)}
+        </div>
+        {process.appointment_datetime && (
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <Calendar size={14} className="text-subtle" />
+            Reunião: {formatDate(process.appointment_datetime)}
+          </div>
+        )}
+        {process.rejection_reason && (
+          <div className="flex items-center gap-2 text-sm text-status-bad">
+            <AlertCircle size={14} />
+            Motivo da rejeição: {process.rejection_reason}
+          </div>
+        )}
+      </Card>
+
+      {!isScheduling && processInfo && (
+        <Card className="mb-6 flex flex-wrap items-center gap-6 text-sm">
+          <div className="flex items-center gap-2">
+            <DollarSign size={16} className="text-status-ok" />
+            <span className="text-muted">Valor do produto:</span>
+            <span className="font-semibold text-ink">
+              {formatCurrency(processInfo.product_value)}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
+            {/* laranja mantido de propósito — destaque de atenção ao valor, não é um dos 6 status de processo */}
+            <AlertCircle size={16} className="text-orange-500" />
+            <span className="text-muted">Valor mínimo:</span>
+            <span className="font-semibold text-orange-600">
+              {formatCurrency(processInfo.minimum_value)}
+            </span>
+          </div>
+          {acceptedProposal && (
+            <div className="flex items-center gap-2">
+              <Check size={16} className="text-status-ok" />
+              <span className="text-muted">Valor aceito:</span>
+              <span className="font-semibold text-status-ok">
+                {formatCurrency(acceptedProposal.proposed_value)}
+              </span>
+            </div>
+          )}
+          {meta && (
+            <div className="ml-auto text-xs text-subtle">
+              {meta.total} {meta.total === 1 ? "proposta" : "propostas"}
+            </div>
+          )}
+        </Card>
+      )}
+```
+
+- [ ] **Step 4: Tokenizar o restante do arquivo (agendamento, histórico de propostas, formulário)**
+
+Aplicar exatamente estas trocas de classe (mesmo texto/estrutura, só cor) nos 2 blocos restantes do `return` (agendamento — linhas originais ~501-577; histórico de propostas — linhas originais ~579-731):
+
+| Onde | Classe antiga | Classe nova |
+|---|---|---|
+| Wrapper `<div className="p-6 rounded-lg shadow bg-white">` (2 ocorrências: agendamento e histórico) | — | Trocar a tag por `<Card>` (sem `p-6`, o `Card` já aplica padding) |
+| `<h2 className="h2-style">` (2 ocorrências) | `h2-style` | `text-h2 font-semibold text-ink` |
+| `text-sm text-gray-700` / `text-sm text-gray-600` (reunião marcada, mensagens de estado) | `text-gray-700` / `text-gray-600` | `text-ink-soft` / `text-muted` |
+| `text-sm text-gray-500` (datas não definidas, textos auxiliares) | `text-gray-500` | `text-muted` |
+| `bg-slate-50 border border-slate-200` (caixa da reunião confirmada) | `bg-slate-50 border-slate-200` | `bg-border-soft border-border` |
+| `text-slate-800` / `text-slate-700` (textos dentro da caixa da reunião) | `text-slate-800` / `text-slate-700` | `text-ink-soft` |
+| `bg-cyan-700 ... hover:bg-cyan-800` (botão "Entrar na reunião") | — | Trocar `<button>` por `<Button type="button">` com `<Video size={16} />` + texto (variante padrão `solid`) |
+| `bg-gray-50 border border-gray-200` (caixa "aguardando confirmação") | `bg-gray-50 border-gray-200` | `bg-border-soft border-border` |
+| `text-gray-300` (ícone de "nenhuma proposta") | `text-gray-300` | `text-subtle` |
+| `border border-gray-200` (card de cada proposta na timeline) | `border-gray-200` | `border-border` |
+| `text-xs font-medium text-gray-500` / `text-gray-400` (remetente/data da proposta) | `text-gray-500` / `text-gray-400` | `text-muted` / `text-subtle` |
+| `text-gray-600` (mensagem da proposta) | `text-gray-600` | `text-muted` |
+| `bg-green-600 hover:bg-green-700` (botão Aceitar) | — | Trocar `<button>` por `<Button type="button" variant="solid">` |
+| `bg-red-600 hover:bg-red-700` (botão Rejeitar) | — | Trocar `<button>` por `<Button type="button" variant="danger">` |
+| `border-t border-gray-100` (separador antes dos botões de ação) | `border-gray-100` | `border-border-soft` |
+| `border-t border-gray-200` (separador antes do form de nova proposta) | `border-gray-200` | `border-border` |
+| `bg-red-50 border border-red-200 ... text-red-700` (erro do formulário) | — | Trocar a `<div>` por `<Alert variant="danger">` (import já adicionado no Step 2 se ainda não estiver) |
+| `border border-gray-300 focus:ring-2 focus:ring-slate-500 focus:border-slate-500` (2 inputs do formulário) | `border-gray-300` / `focus:ring-slate-500 focus:border-slate-500` | `border-border` / `focus:ring-2 focus:ring-focus-ring` |
+| `bg-slate-700 hover:bg-slate-800` (botão "Enviar proposta") | — | Trocar `<button type="submit">` por `<Button type="submit">` |
+| `text-gray-500` (valor mínimo aceito, rodapé do form) | `text-gray-500` | `text-muted` |
+| `bg-gray-50 border border-gray-200 text-gray-600` (aguardando resposta do especialista) | — | `bg-border-soft border-border text-muted` |
+
+Ao trocar `<button>` por `<Button>`, manter exatamente o mesmo `onClick`/`disabled`/conteúdo (ícone + texto) — só a tag e as classes de cor mudam; o `Button` já aplica `inline-flex items-center justify-center gap-2` e o padding, então remover o `className` de padding/flex manual que o botão antigo tinha, mantendo só classes de layout que não sejam cor/padding (ex: `flex-1` nos botões Aceitar/Rejeitar, que devem continuar).
+
+Import `Alert` no topo do arquivo (junto aos outros imports de componentes do Step 2):
+
+```tsx
+import { Alert } from "../../components/ui/alert";
+```
+
+- [ ] **Step 5: Verificar tipos**
+
+```bash
+cd frontend && npx tsc -b
+```
+
+- [ ] **Step 6: Verificar visualmente**
+
+Mesmo padrão de QA (frontend + Playwright mockando `getProcessById`, `getProcessProposals`, e opcionalmente `getMeetingByProcess`). Confirmar especificamente: **o botão de voltar do `PageHeader` aparece e funciona** (primeiro uso real de `showBack`), `StatusBadge`/`ProposalStatusBadge` renderizam com ponto de cor, os 3 cards de Cliente/Especialista/Produto usam a mesma sombra/borda das outras telas já migradas, botões Aceitar/Rejeitar/Enviar proposta usam as variantes certas (`solid`/`danger`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
+git commit -m "feat(consultor): aplicar PageHeader/BackButton/StatusBadge/ProposalStatusBadge em ConsultantProcessDetailPage"
+```
+
+---
+
+### Task 6: Verificação final
+
+**Files:** nenhum (só verificação)
+
+- [ ] **Step 1: Build completo**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: `tsc -b` e `vite build` sem erro.
+
+- [ ] **Step 2: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: sem erro novo introduzido pelas Tasks 1-5 (avisos pré-existentes em outros arquivos continuam, fora de escopo).
+
+- [ ] **Step 3: Checklist manual (frontend + Playwright mockado, backend local NUNCA)**
+
+- [ ] Dashboard: 4 KPIs corretos, "Processos vigentes" ordenado por tempo parado, gráfico de status com as 6 cores certas, "Clientes recentes" correto, os 2 atalhos abrem modal sem título duplicado.
+- [ ] `ConsultantProcessesPage`: filtro de status usa os mesmos rótulos do restante do sistema, tabela responsiva (rola de lado em 390px), paginação funciona.
+- [ ] `ConsultantProcessDetailPage`: botão de voltar do `PageHeader` funciona, `StatusBadge`/`ProposalStatusBadge` corretos, ações (aceitar/rejeitar/enviar proposta) com as variantes certas de `Button`.
+- [ ] Nenhuma tela fora desta fatia mudou (Admin, Especialista, Cliente, Auth, Escritório continuam como estavam).
+
+- [ ] **Step 4: Commit final (se sobrar ajuste do checklist)**
+
+```bash
+git add -A
+git commit -m "chore(consultor): ajustes finais da verificacao manual da fatia 1"
+```
+
+(pular se nada precisou ajustar.)

--- a/docs/superpowers/plans/2026-07-21-design-system-foundation-pilot.md
+++ b/docs/superpowers/plans/2026-07-21-design-system-foundation-pilot.md
@@ -1,0 +1,1674 @@
+# Design System — Fundação + Piloto Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Construir a fundação do novo design system (tokens, componentes `ui/` e `patterns/`) descrita em `DESIGN.md`, e aplicá-la a um piloto real: a página "Meus Clientes" do Consultor + os 3 becos sem saída críticos mapeados na auditoria (callback do DocuSign, modal de convite em lote, `/advisor/dashboard` órfão).
+
+**Architecture:** Tokens novos são **aditivos** em `frontend/src/index.css` (nenhum token existente é removido ou renomeado — o resto da plataforma, fora do piloto, continua usando os tokens antigos até seu próprio ciclo de migração). Componentes novos vivem em `frontend/src/components/ui/` (primitivos sobre Radix + CVA) e `frontend/src/components/patterns/` (composições próprias: `BackButton`, `PageHeader`, `EmptyState`, `StatusBadge`). O `Button` existente (`components/ui/button.tsx`) é reescrito com CVA por dentro, mas mantém exatamente as mesmas variantes e o mesmo import (`import Button from ".../ui/button"`) usados hoje pelos ~18 arquivos que já o consomem — zero mudança visual fora do piloto.
+
+**Tech Stack:** React 19 + TypeScript + Vite + Tailwind CSS v4 (tokens via `@theme` em CSS, sem `tailwind.config.js`) + Radix UI (`@radix-ui/react-dialog`) + `class-variance-authority` (CVA) + `clsx` + `tailwind-merge` + `lucide-react` (já instalado).
+
+## Global Constraints
+
+- Nenhum token existente em `frontend/src/index.css` é removido, renomeado ou tem seu valor alterado — só adição de tokens novos.
+- Todo componente novo usa import relativo (`../../lib/utils`, etc.) — o projeto não usa alias `@/`, não introduzir um agora (fora de escopo).
+- `Button` (`components/ui/button.tsx`) mantém export default, mesma prop `variant` com os mesmos 4 valores existentes (`solid`, `light`, `muted`, `brand`) rendendo pixel-idênticos ao que renderizam hoje — variantes novas (`ghost`, `danger`) são só adição.
+- O frontend **não tem test runner configurado** (sem Jest/Vitest/RTL) — não instalar um agora, isso é fora de escopo desta spec. Verificação de cada tarefa é: `npx tsc -b` (type-check) limpo + checklist manual no navegador (`npm run dev`), conforme convenção já usada neste projeto para mudanças de frontend.
+- `Tabs` e `Dropdown menu` (listados no inventário de componentes do `DESIGN.md`) **não** entram neste plano — nenhuma tela tocada aqui precisa deles; ficam para quando uma tela real os consumir, na fase de rollout do restante.
+- Consolidar os dois `Modal` concorrentes (`components/ui/Modal.tsx` e `components/shared/Modal.tsx`) nas ~14 outras telas que ainda os usam é trabalho da fase de rollout do restante, não desta spec — aqui só o piloto migra para o `Dialog` novo.
+- Sempre rodar os comandos a partir de `frontend/` (`cd frontend` primeiro, ou usar `npm --prefix frontend run ...` a partir da raiz).
+
+---
+
+### Task 1: Instalar dependências novas + criar `cn()`
+
+**Files:**
+- Modify: `frontend/package.json`
+- Create: `frontend/src/lib/utils.ts`
+
+**Interfaces:**
+- Produces: `cn(...inputs: ClassValue[]): string` — usado por toda tarefa seguinte que cria/edita um componente.
+
+- [ ] **Step 1: Instalar as dependências**
+
+Rodar a partir de `frontend/`:
+
+```bash
+cd frontend
+npm install class-variance-authority clsx tailwind-merge @radix-ui/react-dialog
+```
+
+Expected: `package.json` ganha as 4 entradas em `dependencies`; `package-lock.json` atualizado; sem erro.
+
+- [ ] **Step 2: Criar `frontend/src/lib/utils.ts`**
+
+```ts
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+```
+
+- [ ] **Step 3: Verificar**
+
+```bash
+npx tsc -b
+```
+
+Expected: nenhum erro (arquivo novo não é importado por ninguém ainda, só precisa compilar).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/src/lib/utils.ts
+git commit -m "feat(design-system): instalar CVA/Radix Dialog e criar utilitário cn()"
+```
+
+---
+
+### Task 2: Adicionar tokens novos em `index.css`
+
+**Files:**
+- Modify: `frontend/src/index.css`
+
+**Interfaces:**
+- Produces: classes utilitárias Tailwind novas — `bg-ink`, `text-ink`, `bg-ink-soft`, `text-ink-soft`, `bg-action`, `bg-action-hover`, `text-muted`, `text-subtle`, `border-border`, `bg-border-soft`, `border-border-soft`, `bg-surface`, `text-surface`, `ring-focus-ring`, `bg-status-{sched,neg,proc,doc,ok,bad}`, `bg-status-{...}-wash`, `border-status-{...}-line`, `text-status-{...}`, `bg-status-bad-hover`, `shadow-ds-card`, `shadow-ds-floating`, `shadow-ds-modal`, `text-h1`, `text-h2`. Usadas por toda tarefa seguinte.
+
+- [ ] **Step 1: Adicionar o bloco de tokens novos ao final do `@theme` existente**
+
+Editar `frontend/src/index.css` — dentro do bloco `@theme { ... }` já existente (não remover nada do que já está lá), adicionar logo antes do `}` de fechamento (depois da linha `--color-brand-secondary-fg: var(--brand-secondary-fg, #FFFFFF);`):
+
+```css
+  /* Design system v2 (ver DESIGN.md) — tokens novos, aditivos.
+     Os tokens acima continuam intactos até a migração das telas
+     existentes (rollout fatiado por área, fora desta spec). */
+  --color-ink: #1c1c1c;
+  --color-ink-soft: #3c3c3c;
+  --color-action: #2c2c2c;
+  --color-action-hover: #1c1c1c;
+  --color-muted: #6b6b6b;
+  --color-subtle: #9a9a9a;
+  --color-border: #d9d9d9;
+  --color-border-soft: #e9e9e9;
+  --color-surface: #ffffff;
+  --color-focus-ring: #1c1c1c;
+
+  --color-status-sched: #1d4ed8;
+  --color-status-sched-wash: #eff6ff;
+  --color-status-sched-line: #bfdbfe;
+
+  --color-status-neg: #b45309;
+  --color-status-neg-wash: #fffbeb;
+  --color-status-neg-line: #fde68a;
+
+  --color-status-proc: #c2410c;
+  --color-status-proc-wash: #fff7ed;
+  --color-status-proc-line: #fed7aa;
+
+  --color-status-doc: #7e22ce;
+  --color-status-doc-wash: #faf5ff;
+  --color-status-doc-line: #e9d5ff;
+
+  --color-status-ok: #15803d;
+  --color-status-ok-wash: #f0fdf4;
+  --color-status-ok-line: #bbf7d0;
+
+  --color-status-bad: #b91c1c;
+  --color-status-bad-wash: #fef2f2;
+  --color-status-bad-line: #fecaca;
+  --color-status-bad-hover: #941414;
+
+  --shadow-ds-card: 0 1px 2px rgba(28,28,28,.06), 0 1px 3px rgba(28,28,28,.08);
+  --shadow-ds-floating: 0 4px 12px rgba(28,28,28,.12);
+  --shadow-ds-modal: 0 10px 30px rgba(0,0,0,.25);
+
+  /* Tipografia (DESIGN.md § Tipografia) — só os 2 papéis usados no piloto
+     (h1/h2); os demais papéis da tabela (display/h3/body/small/label) ficam
+     para quando uma tela real os consumir, na fase de rollout do restante. */
+  --text-h1: 1.625rem;
+  --text-h1--line-height: 1.25;
+  --text-h2: 1.25rem;
+  --text-h2--line-height: 1.3;
+```
+
+- [ ] **Step 2: Verificar que o dev server sobe sem erro de CSS**
+
+```bash
+npm run dev
+```
+
+Expected: Vite compila sem erro. Abrir `http://localhost:5173`, confirmar visualmente que nada mudou (esses tokens ainda não são usados em lugar nenhum).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/index.css
+git commit -m "feat(design-system): adicionar tokens de cor e sombra do design system (aditivo)"
+```
+
+---
+
+### Task 3: Reescrever `components/ui/button.tsx` com CVA
+
+**Files:**
+- Modify: `frontend/src/components/ui/button.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils` (Task 1).
+- Produces: `export default function Button(props: ButtonProps)` — `ButtonProps` estende `React.ButtonHTMLAttributes<HTMLButtonElement>` com `variant?: "solid" | "light" | "muted" | "brand" | "ghost" | "danger"` (default `"solid"`). Mesma assinatura de antes + 2 variantes novas.
+
+- [ ] **Step 1: Substituir o conteúdo do arquivo**
+
+Conteúdo atual (referência, para conferir que nada de comportamento muda para as 4 variantes antigas):
+
+```tsx
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'solid' | 'light' | 'muted' | 'brand';
+}
+
+export default function Button({
+  children,
+  className,
+  variant = 'solid',
+  ...props
+}: ButtonProps) {
+
+  const buttonStyles = `
+    font-semibold py-2 px-4 rounded-lg
+    cursor-pointer transition-all duration-200
+    focus:outline-none focus:ring-2 focus:ring-brand-dark focus:ring-offset-2
+    disabled:opacity-50 disabled:cursor-not-allowed
+    active:scale-95
+  `;
+
+  const variantStyles = {
+    solid: `
+      bg-button-solid text-white
+      hover:bg-[--color-button-solid-hover]
+      focus:ring-[--color-button-solid]`,
+    light: `
+      bg-white text-gray-900 border border-gray-300
+      hover:bg-gray-100
+      focus:ring-gray-400`,
+    muted: `
+      bg-gray-300 text-gray-900
+      hover:bg-gray-400
+      focus:ring-gray-300`,
+    brand: `
+      bg-brand-primary text-brand-primary-fg
+      hover:opacity-90
+      focus:ring-brand-primary`,
+  };
+
+  return (
+    <button
+      className={`${buttonStyles} ${variantStyles[variant]} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+```
+
+Substituir por (variantes `solid`/`light`/`muted`/`brand` levam exatamente as mesmas classes Tailwind de antes — só `ghost` e `danger` são novas, usando os tokens da Task 2):
+
+```tsx
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const buttonVariants = cva(
+  'font-semibold py-2 px-4 rounded-lg cursor-pointer transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95',
+  {
+    variants: {
+      variant: {
+        solid: 'bg-button-solid text-white hover:bg-[--color-button-solid-hover] focus:ring-[--color-button-solid]',
+        light: 'bg-white text-gray-900 border border-gray-300 hover:bg-gray-100 focus:ring-gray-400',
+        muted: 'bg-gray-300 text-gray-900 hover:bg-gray-400 focus:ring-gray-300',
+        brand: 'bg-brand-primary text-brand-primary-fg hover:opacity-90 focus:ring-brand-primary',
+        ghost: 'bg-transparent text-ink-soft hover:bg-border-soft focus:ring-focus-ring',
+        danger: 'bg-status-bad text-white hover:bg-status-bad-hover focus:ring-status-bad',
+      },
+    },
+    defaultVariants: {
+      variant: 'solid',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+export default function Button({ children, className, variant, ...props }: ButtonProps) {
+  return (
+    <button className={cn(buttonVariants({ variant }), className)} {...props}>
+      {children}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar tipos**
+
+```bash
+npx tsc -b
+```
+
+Expected: sem erro (os ~18 arquivos que importam `Button` continuam passando `variant="solid" | "light" | "muted" | "brand"`, todos ainda válidos).
+
+- [ ] **Step 3: Verificar visualmente que nada mudou fora do piloto**
+
+```bash
+npm run dev
+```
+
+Abrir qualquer tela que já usa `Button` hoje (ex: `/login`) e confirmar que o botão está visualmente idêntico a antes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/ui/button.tsx
+git commit -m "refactor(design-system): reescrever Button com CVA, adicionar variantes ghost e danger"
+```
+
+---
+
+### Task 4: Corrigir beco sem saída — callback do DocuSign
+
+**Files:**
+- Modify: `frontend/src/pages/specialist/ContractPreviewCallback.tsx`
+
+**Interfaces:**
+- Consumes: `Button` de `../../components/ui/button` (Task 3).
+
+- [ ] **Step 1: Adicionar imports**
+
+No topo do arquivo, junto aos imports existentes:
+
+```tsx
+import { useNavigate } from "react-router-dom";
+import Button from "../../components/ui/button";
+```
+
+(o import de `useSearchParams` já existe na linha 2 — adicionar `useNavigate` ao mesmo `import { ... } from "react-router-dom"`, ficando `import { useSearchParams, useNavigate } from "react-router-dom";`)
+
+- [ ] **Step 2: Declarar `navigate` e corrigir `handleClose` para ter um fallback**
+
+Substituir:
+
+```tsx
+  // Tentar fechar a janela/tab se aberta em popup
+  const handleClose = () => {
+    if (window.opener) {
+      window.close();
+    }
+  };
+```
+
+por:
+
+```tsx
+  const navigate = useNavigate();
+
+  // Tentar fechar a janela/tab se aberta em popup; se não for popup
+  // (acesso direto à URL, ou postMessage/iframe falhou), navega de volta
+  // em vez de deixar a tela sem nenhuma saída.
+  const handleClose = () => {
+    if (window.opener) {
+      window.close();
+    } else {
+      navigate("/specialist/processes");
+    }
+  };
+```
+
+- [ ] **Step 3: Trocar os botões `cancelled`/`error` (raw `<button>`) pelo `Button` novo**
+
+Substituir (bloco `status === "cancelled"`):
+
+```tsx
+            <button
+              onClick={handleClose}
+              className="px-6 py-2.5 bg-slate-700 text-white rounded-lg hover:bg-slate-800 transition"
+            >
+              Fechar
+            </button>
+```
+
+por:
+
+```tsx
+            <Button onClick={handleClose}>Fechar</Button>
+```
+
+Substituir o bloco equivalente em `status === "error"` (mesmo trecho, mais abaixo) da mesma forma.
+
+- [ ] **Step 4: Adicionar o botão que faltava no estado de sucesso**
+
+Substituir:
+
+```tsx
+        {status === "success" && (
+          <>
+            <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+            <h1 className="text-xl font-semibold text-slate-800 mb-2">
+              Sucesso!
+            </h1>
+            <p className="text-slate-600 mb-6">{message}</p>
+            <p className="text-sm text-slate-500">
+              Esta janela será fechada automaticamente...
+            </p>
+          </>
+        )}
+```
+
+por:
+
+```tsx
+        {status === "success" && (
+          <>
+            <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+            <h1 className="text-xl font-semibold text-slate-800 mb-2">
+              Sucesso!
+            </h1>
+            <p className="text-slate-600 mb-6">{message}</p>
+            <p className="text-sm text-slate-500 mb-4">
+              Esta janela será fechada automaticamente...
+            </p>
+            <Button variant="light" onClick={() => navigate("/specialist/processes")}>
+              Voltar para processos
+            </Button>
+          </>
+        )}
+```
+
+- [ ] **Step 5: Verificar**
+
+```bash
+npx tsc -b
+npm run dev
+```
+
+Manual: navegar direto (sem popup) para `http://localhost:5173/specialist/contracts/preview-callback?event=send&envelopeId=teste` logado como `SPECIALIST`. Confirmar que aparece o botão "Voltar para processos" e que clicar nele navega para `/specialist/processes` (em vez de travar a tela). Repetir com `?event=cancel` e `?event=error` e confirmar que "Fechar" também navega (não só tenta `window.close()`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/specialist/ContractPreviewCallback.tsx
+git commit -m "fix(navegacao): callback do DocuSign nao fica mais sem saida quando aberto fora de popup"
+```
+
+---
+
+### Task 5: Corrigir navegação órfã do `/advisor/dashboard`
+
+**Files:**
+- Modify: `frontend/src/layouts/Sidebar.tsx`
+
+- [ ] **Step 1: Adicionar `UserCheck` ao import de ícones**
+
+Substituir a linha do import (linhas 1-16):
+
+```tsx
+import {
+  TextAlignJustifyIcon,
+  LayoutDashboard,
+  Building2,
+  Users,
+  UserCog,
+  Car,
+  Ship,
+  Plane,
+  Package,
+  Home,
+  FilePen,
+  Settings,
+  Percent,
+  Database,
+} from "lucide-react";
+```
+
+por:
+
+```tsx
+import {
+  TextAlignJustifyIcon,
+  LayoutDashboard,
+  Building2,
+  Users,
+  UserCog,
+  Car,
+  Ship,
+  Plane,
+  Package,
+  Home,
+  FilePen,
+  Settings,
+  Percent,
+  Database,
+  UserCheck,
+} from "lucide-react";
+```
+
+- [ ] **Step 2: Adicionar o link comum depois do `switch`, antes do `}` que fecha `if (user) {`**
+
+O bloco hoje termina assim (linhas ~163-189):
+
+```tsx
+      case "OFFICE":
+        links.push(
+          {
+            to: "/office/dashboard",
+            label: "Dashboard",
+            icon: <LayoutDashboard size={20} />,
+          },
+          {
+            to: "/office/consultants",
+            label: "Consultores",
+            icon: <Users size={20} />,
+          },
+          {
+            to: "/office/clients",
+            label: "Clientes",
+            icon: <UserCog size={20} />,
+          },
+          {
+            to: "/office/company",
+            label: "Minha Empresa",
+            icon: <Building2 size={20} />,
+          },
+        );
+        break;
+    }
+  }
+```
+
+Substituir por (adiciona o link comum logo após o `switch`, só para quem não é `OFFICE` — rota `/advisor/dashboard` só permite `CUSTOMER`/`CONSULTANT`/`SPECIALIST`/`ADMIN`, conferido em `routes.tsx`):
+
+```tsx
+      case "OFFICE":
+        links.push(
+          {
+            to: "/office/dashboard",
+            label: "Dashboard",
+            icon: <LayoutDashboard size={20} />,
+          },
+          {
+            to: "/office/consultants",
+            label: "Consultores",
+            icon: <Users size={20} />,
+          },
+          {
+            to: "/office/clients",
+            label: "Clientes",
+            icon: <UserCog size={20} />,
+          },
+          {
+            to: "/office/company",
+            label: "Minha Empresa",
+            icon: <Building2 size={20} />,
+          },
+        );
+        break;
+    }
+
+    if (user.role !== "OFFICE") {
+      links.push({
+        to: "/advisor/dashboard",
+        label: "Meus Assessorados",
+        icon: <UserCheck size={20} />,
+      });
+    }
+  }
+```
+
+- [ ] **Step 3: Verificar**
+
+```bash
+npx tsc -b
+npm run dev
+```
+
+Manual: logar como `CUSTOMER` (ou qualquer papel que não seja `OFFICE`), confirmar que "Meus Assessorados" aparece na Sidebar e leva para `/advisor/dashboard`. Logar como usuário com role `OFFICE` (se houver conta de teste) e confirmar que o link **não** aparece (rota não permite esse papel).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/layouts/Sidebar.tsx
+git commit -m "fix(navegacao): adicionar /advisor/dashboard na Sidebar (estava orfao de qualquer nav persistente)"
+```
+
+---
+
+### Task 6: Criar `components/ui/input.tsx`
+
+**Files:**
+- Create: `frontend/src/components/ui/input.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`.
+- Produces: `export const Input` — `forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>`.
+
+- [ ] **Step 1: Criar o arquivo**
+
+```tsx
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    className={cn(
+      "w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-focus-ring",
+      className
+    )}
+    {...props}
+  />
+));
+Input.displayName = "Input";
+```
+
+- [ ] **Step 2: Verificar**
+
+```bash
+npx tsc -b
+```
+
+Expected: sem erro. (Uso visual é verificado holisticamente na Task 12 — piloto.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ui/input.tsx
+git commit -m "feat(design-system): criar componente Input"
+```
+
+---
+
+### Task 7: Criar `components/ui/card.tsx`
+
+**Files:**
+- Create: `frontend/src/components/ui/card.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`.
+- Produces: `export function Card(props: React.HTMLAttributes<HTMLDivElement>)`.
+
+- [ ] **Step 1: Criar o arquivo**
+
+```tsx
+import type { HTMLAttributes } from "react";
+import { cn } from "../../lib/utils";
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "bg-surface border border-border rounded-lg shadow-ds-card p-6",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+```
+
+- [ ] **Step 2: Verificar**
+
+```bash
+npx tsc -b
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ui/card.tsx
+git commit -m "feat(design-system): criar componente Card"
+```
+
+---
+
+### Task 8: Criar `components/ui/alert.tsx`
+
+**Files:**
+- Create: `frontend/src/components/ui/alert.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`.
+- Produces: `export function Alert(props: AlertProps)` — `variant?: "success" | "warning" | "danger" | "info"` (default `"info"`).
+
+- [ ] **Step 1: Criar o arquivo**
+
+```tsx
+import type { HTMLAttributes } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const alertVariants = cva("flex gap-3 items-start rounded-md border px-4 py-3 text-sm", {
+  variants: {
+    variant: {
+      success: "bg-status-ok-wash border-status-ok-line text-status-ok",
+      warning: "bg-status-neg-wash border-status-neg-line text-status-neg",
+      danger: "bg-status-bad-wash border-status-bad-line text-status-bad",
+      info: "bg-status-sched-wash border-status-sched-line text-status-sched",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+  },
+});
+
+export interface AlertProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+export function Alert({ className, variant, ...props }: AlertProps) {
+  return <div role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+}
+```
+
+- [ ] **Step 2: Verificar**
+
+```bash
+npx tsc -b
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ui/alert.tsx
+git commit -m "feat(design-system): criar componente Alert"
+```
+
+---
+
+### Task 9: Criar `components/ui/dialog.tsx` (Radix Dialog)
+
+**Files:**
+- Create: `frontend/src/components/ui/dialog.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`; `@radix-ui/react-dialog` (Task 1).
+- Produces: `export const Dialog` (= `DialogPrimitive.Root`, props `open: boolean`, `onOpenChange: (open: boolean) => void`); `export function DialogContent({ title, children, className }: { title: string; children: ReactNode; className?: string })`.
+
+- [ ] **Step 1: Criar o arquivo**
+
+```tsx
+import type { ReactNode } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+export const Dialog = DialogPrimitive.Root;
+
+export function DialogContent({
+  title,
+  children,
+  className,
+}: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/45" />
+      <DialogPrimitive.Content
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 w-[min(560px,90vw)] max-h-[85vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-lg bg-surface p-6 shadow-ds-modal",
+          className
+        )}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <DialogPrimitive.Title className="text-base font-semibold text-ink">
+            {title}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Close
+            className="text-muted hover:text-ink"
+            aria-label="Fechar"
+          >
+            <X size={18} />
+          </DialogPrimitive.Close>
+        </div>
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar**
+
+```bash
+npx tsc -b
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/ui/dialog.tsx
+git commit -m "feat(design-system): criar componente Dialog sobre Radix (titulo, X, ESC, overlay-click de graca)"
+```
+
+---
+
+### Task 10: Criar `components/patterns/StatusBadge.tsx`
+
+**Files:**
+- Create: `frontend/src/components/patterns/StatusBadge.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`.
+- Produces: `export function StatusBadge({ status, className }: { status: string; className?: string })`.
+
+- [ ] **Step 1: Criar o arquivo**
+
+```tsx
+import { cn } from "../../lib/utils";
+
+const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
+  SCHEDULING: { label: "Agendamento", dot: "bg-status-sched" },
+  NEGOTIATION: { label: "Negociação", dot: "bg-status-neg" },
+  PROCESSING_CONTRACT: { label: "Contrato", dot: "bg-status-proc" },
+  DOCUMENTATION: { label: "Documentação", dot: "bg-status-doc" },
+  COMPLETED: { label: "Concluído", dot: "bg-status-ok" },
+  REJECTED: { label: "Rejeitado", dot: "bg-status-bad" },
+};
+
+export function StatusBadge({
+  status,
+  className,
+}: {
+  status: string;
+  className?: string;
+}) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-border-soft px-2.5 py-1 text-xs font-semibold text-ink-soft",
+        className
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config?.dot ?? "bg-subtle")} />
+      {config?.label ?? status}
+    </span>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar**
+
+```bash
+npx tsc -b
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/patterns/StatusBadge.tsx
+git commit -m "feat(design-system): criar StatusBadge (pilula neutra + ponto de cor, uma so receita)"
+```
+
+---
+
+### Task 11: Criar `components/patterns/EmptyState.tsx`
+
+**Files:**
+- Create: `frontend/src/components/patterns/EmptyState.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`; `LucideIcon` de `lucide-react`.
+- Produces: `export function EmptyState({ icon, title, description, action, className }: EmptyStateProps)`.
+
+- [ ] **Step 1: Criar o arquivo**
+
+```tsx
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+export interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "text-center py-12 px-4 border border-dashed border-border rounded-lg",
+        className
+      )}
+    >
+      <Icon className="mx-auto mb-3 h-8 w-8 text-subtle" />
+      <p className="font-semibold text-ink">{title}</p>
+      {description && <p className="text-sm text-muted mt-1 mb-4">{description}</p>}
+      {action}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar**
+
+```bash
+npx tsc -b
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/patterns/EmptyState.tsx
+git commit -m "feat(design-system): criar EmptyState (icone + frase + acao)"
+```
+
+---
+
+### Task 12: Criar `components/patterns/BackButton.tsx` e `PageHeader.tsx`
+
+**Files:**
+- Create: `frontend/src/components/patterns/BackButton.tsx`
+- Create: `frontend/src/components/patterns/PageHeader.tsx`
+
+**Interfaces:**
+- Consumes: `cn` de `../../lib/utils`; `react-router-dom` (`Link`, `useNavigate`).
+- Produces: `export function BackButton({ to, label, className }: { to?: string; label?: string; className?: string })`; `export function PageHeader({ title, showBack, backTo, actions }: PageHeaderProps)`.
+
+Nota de escopo: o piloto (Task 13) usa `PageHeader` com `showBack` omitido (`false`) — "Meus Clientes" é reachável direto pela Sidebar, então não precisa de volta (regra do template de layout em `DESIGN.md`: "BackButton só se aninhada"). O branch `showBack=true`/`BackButton` é validado quando uma página aninhada (ex: detalhe de processo) migrar, na fase de rollout do restante — aqui a verificação é só `tsc -b` limpo.
+
+- [ ] **Step 1: Criar `BackButton.tsx`**
+
+```tsx
+import { ArrowLeft } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { cn } from "../../lib/utils";
+
+export function BackButton({
+  to,
+  label = "Voltar",
+  className,
+}: {
+  to?: string;
+  label?: string;
+  className?: string;
+}) {
+  const navigate = useNavigate();
+  const classes = cn(
+    "inline-flex items-center gap-1.5 text-sm font-semibold text-ink-soft hover:text-ink w-fit",
+    className
+  );
+
+  if (to) {
+    return (
+      <Link to={to} className={classes}>
+        <ArrowLeft size={16} />
+        {label}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={() => navigate(-1)} className={classes}>
+      <ArrowLeft size={16} />
+      {label}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 2: Criar `PageHeader.tsx`**
+
+```tsx
+import type { ReactNode } from "react";
+import { BackButton } from "./BackButton";
+
+export interface PageHeaderProps {
+  title: string;
+  showBack?: boolean;
+  backTo?: string;
+  actions?: ReactNode;
+}
+
+export function PageHeader({ title, showBack = false, backTo, actions }: PageHeaderProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+      <div className="flex flex-col gap-1">
+        {showBack && <BackButton to={backTo} />}
+        <h1 className="text-h1 font-bold text-ink">{title}</h1>
+      </div>
+      {actions && <div className="flex gap-2">{actions}</div>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Verificar**
+
+```bash
+npx tsc -b
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/patterns/BackButton.tsx frontend/src/components/patterns/PageHeader.tsx
+git commit -m "feat(design-system): criar BackButton e PageHeader (substitui os 4 padroes de voltar espalhados)"
+```
+
+---
+
+### Task 13: Piloto — reescrever `ConsultantClientsPage.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/consultant/ConsultantClientsPage.tsx`
+
+**Interfaces:**
+- Consumes: `PageHeader` (Task 12), `StatusBadge` (Task 10), `EmptyState` (Task 11), `Dialog`/`DialogContent` (Task 9), `Alert` (Task 8), `Card` (Task 7), `Button` (Task 3).
+
+- [ ] **Step 1: Trocar os imports**
+
+Substituir:
+
+```tsx
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  getClients,
+  getClientProcesses,
+  removeClient,
+  type Client,
+} from "../../services/consultant.service";
+import Button from "../../components/ui/button";
+import Modal from "../../components/ui/Modal";
+import InviteClientForm from "./InviteClientForm";
+import BatchInviteClients from "./BatchInviteClients";
+import EditClientForm from "./EditClientForm";
+import { ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import TrashIcon from "../../assets/icons/trash.svg";
+import EditIcon from "../../assets/icons/edit.svg";
+```
+
+por:
+
+```tsx
+import { Fragment, useCallback, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  getClients,
+  getClientProcesses,
+  removeClient,
+  type Client,
+} from "../../services/consultant.service";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { Card } from "../../components/ui/card";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge } from "../../components/patterns/StatusBadge";
+import { EmptyState } from "../../components/patterns/EmptyState";
+import InviteClientForm from "./InviteClientForm";
+import BatchInviteClients from "./BatchInviteClients";
+import EditClientForm from "./EditClientForm";
+import { ChevronDown, ChevronUp, Loader2, Pencil, Trash2, Plus, Users } from "lucide-react";
+```
+
+- [ ] **Step 2: Remover os mapas `STATUS_LABELS`/`STATUS_COLORS` locais**
+
+Remover (linhas 26-42 do arquivo original):
+
+```tsx
+const STATUS_LABELS: Record<string, string> = {
+  SCHEDULING: "Agendamento",
+  NEGOTIATION: "Negociação",
+  PROCESSING_CONTRACT: "Contrato",
+  DOCUMENTATION: "Documentação",
+  COMPLETED: "Concluído",
+  REJECTED: "Rejeitado",
+};
+
+const STATUS_COLORS: Record<string, string> = {
+  SCHEDULING: "bg-blue-100 text-blue-700",
+  NEGOTIATION: "bg-yellow-100 text-yellow-700",
+  PROCESSING_CONTRACT: "bg-orange-100 text-orange-700",
+  DOCUMENTATION: "bg-purple-100 text-purple-700",
+  COMPLETED: "bg-green-100 text-green-700",
+  REJECTED: "bg-red-100 text-red-700",
+};
+```
+
+(o `StatusBadge` importado na Task 10 já cobre o mesmo mapeamento — não precisa mais existir duplicado nesta página.)
+
+- [ ] **Step 3: Trocar o cabeçalho da página pelo `PageHeader`**
+
+Substituir:
+
+```tsx
+  if (error) return <p className="text-red-500">{error}</p>;
+
+  return (
+    <div className="text-text-main w-full">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+        <h1 className="h1-style">Meus Clientes</h1>
+        <div className="flex gap-2">
+          <Button type="button" onClick={() => setIsBatchModalOpen(true)}>
+            Convite em lote
+          </Button>
+          <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
+            + Convidar Cliente
+          </Button>
+        </div>
+      </div>
+
+      <div className="p-6 rounded-lg shadow bg-white">
+        <h2 className="h2-style">Clientes</h2>
+        <p className="text-sm text-gray-500 mt-1 mb-6">
+          Expanda um cliente para ver seus processos. Para criar processo, abra o catálogo e clique em "Iniciar processo para cliente" no produto.
+        </p>
+
+        {clients.length === 0 ? (
+          <div className="text-center py-12 text-gray-500">
+            Nenhum cliente ainda. Clique em "+ Convidar Cliente" para começar.
+          </div>
+        ) : (
+```
+
+por:
+
+```tsx
+  return (
+    <div className="text-text-main w-full">
+      <PageHeader
+        title="Meus Clientes"
+        actions={
+          <>
+            <Button type="button" variant="light" onClick={() => setIsBatchModalOpen(true)}>
+              Convite em lote
+            </Button>
+            <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
+              <Plus size={16} />
+              Convidar cliente
+            </Button>
+          </>
+        }
+      />
+
+      {error && (
+        <Alert variant="danger" className="mb-4">
+          {error}
+        </Alert>
+      )}
+
+      <Card>
+        <h2 className="text-h2 font-semibold text-ink mb-1">Clientes</h2>
+        <p className="text-sm text-muted mb-6">
+          Expanda um cliente para ver seus processos. Para criar processo, abra o catálogo e clique em "Iniciar processo para cliente" no produto.
+        </p>
+
+        {clients.length === 0 ? (
+          <EmptyState
+            icon={Users}
+            title="Nenhum cliente ainda"
+            description='Clique em "Convidar cliente" para começar.'
+            action={
+              <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
+                <Plus size={16} />
+                Convidar cliente
+              </Button>
+            }
+          />
+        ) : (
+```
+
+Note: o `if (error) return <p className="text-red-500">{error}</p>;` que existia antes do `return (` principal foi removido nesta troca — o erro agora renderiza como `Alert` acima do `Card`, sem bloquear o resto da página.
+
+- [ ] **Step 4: Trocar a lista de clientes (grid rígido) por tabela responsiva**
+
+Substituir o bloco (do `<div className="flex flex-col gap-3">` até o `)}` que fecha o `clients.map`):
+
+```tsx
+          <div className="flex flex-col gap-3">
+            {clients.map((client) => {
+              const isExpanded = expandedClient === client.id;
+              const processes = clientProcesses[client.id] ?? [];
+              const isLoadingProc = loadingProcesses === client.id;
+
+              return (
+                <div key={client.id} className="rounded-lg border border-gray-200 overflow-hidden">
+                  {/* Client row */}
+                  <div className="grid grid-cols-[auto_2fr_1.5fr_1fr_auto] gap-4 items-center px-4 py-4 bg-white">
+                    <button
+                      onClick={() => toggleExpand(client.id)}
+                      className="p-1 hover:bg-gray-100 rounded"
+                    >
+                      {isExpanded
+                        ? <ChevronUp className="w-5 h-5 text-gray-500" />
+                        : <ChevronDown className="w-5 h-5 text-gray-500" />
+                      }
+                    </button>
+
+                    <div>
+                      <p className="font-medium text-gray-900">{client.name} {client.surname}</p>
+                      <p className="text-xs text-gray-400">{formatCPF(client.cpf)}</p>
+                    </div>
+
+                    <p className="text-sm text-gray-600 truncate">{client.email}</p>
+
+                    <p className="text-xs text-gray-400">
+                      {client.created_at ? new Date(client.created_at).toLocaleDateString("pt-BR") : "-"}
+                    </p>
+
+                    <div className="flex items-center gap-2">
+                      <button onClick={() => setClientToEdit(client)} className="p-1.5 hover:bg-gray-100 rounded">
+                        <img src={EditIcon} alt="Editar" className="h-4 w-4" />
+                      </button>
+                      <button onClick={() => setClientToDelete(client)} className="p-1.5 hover:bg-red-50 rounded">
+                        <img src={TrashIcon} alt="Remover" className="h-4 w-4" />
+                      </button>
+                    </div>
+                  </div>
+
+                  {/* Expanded: processes */}
+                  {isExpanded && (
+                    <div className="border-t border-gray-100 bg-gray-50 px-6 py-4">
+                      {isLoadingProc ? (
+                        <div className="flex items-center gap-2 text-gray-400 text-sm">
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                          Carregando processos...
+                        </div>
+                      ) : processes.length === 0 ? (
+                        <p className="text-sm text-gray-500">Nenhum processo ainda.</p>
+                      ) : (
+                        <div className="space-y-2">
+                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
+                            Processos ({processes.length})
+                          </p>
+                          {processes.map((proc) => (
+                            <div
+                              key={proc.id}
+                              onClick={() => navigate(`/consultant/processes/${proc.id}`)}
+                              className="flex items-center justify-between bg-white rounded-lg px-4 py-3 border border-gray-100 hover:border-gray-300 cursor-pointer transition-colors"
+                            >
+                              <div className="flex items-center gap-3">
+                                <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_COLORS[proc.status] ?? "bg-gray-100 text-gray-600"}`}>
+                                  {STATUS_LABELS[proc.status] ?? proc.status}
+                                </span>
+                                <span className="text-sm text-gray-600">
+                                  {proc.product_type ?? "Consultoria"} •{" "}
+                                  {proc.specialist ? `${proc.specialist.name} ${proc.specialist.surname}` : "—"}
+                                </span>
+                              </div>
+                              <span className="text-xs text-gray-400">
+                                {new Date(proc.created_at).toLocaleDateString("pt-BR")}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+```
+
+por (tabela dentro de contêiner com rolagem horizontal própria — a página hoje tem zero classes responsivas, mapeado na auditoria):
+
+```tsx
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[640px] text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">
+                    Cliente
+                  </th>
+                  <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">
+                    E-mail
+                  </th>
+                  <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">
+                    Cadastro
+                  </th>
+                  <th className="w-24 px-4 py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {clients.map((client) => {
+                  const isExpanded = expandedClient === client.id;
+                  const processes = clientProcesses[client.id] ?? [];
+                  const isLoadingProc = loadingProcesses === client.id;
+
+                  return (
+                    <Fragment key={client.id}>
+                      <tr className="border-b border-border-soft hover:bg-border-soft/50">
+                        <td className="px-4 py-3">
+                          <button
+                            onClick={() => toggleExpand(client.id)}
+                            className="inline-flex items-center gap-2 font-medium text-ink"
+                          >
+                            {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                            {client.name} {client.surname}
+                          </button>
+                          <p className="text-xs text-subtle mt-0.5 pl-6">{formatCPF(client.cpf)}</p>
+                        </td>
+                        <td className="px-4 py-3 text-muted truncate">{client.email}</td>
+                        <td className="px-4 py-3 text-muted">
+                          {client.created_at ? new Date(client.created_at).toLocaleDateString("pt-BR") : "-"}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-1 justify-end">
+                            <button
+                              onClick={() => setClientToEdit(client)}
+                              className="p-1.5 rounded hover:bg-border-soft text-ink-soft"
+                            >
+                              <Pencil size={16} />
+                            </button>
+                            <button
+                              onClick={() => setClientToDelete(client)}
+                              className="p-1.5 rounded hover:bg-status-bad-wash text-status-bad"
+                            >
+                              <Trash2 size={16} />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <tr>
+                          <td colSpan={4} className="bg-border-soft/40 px-6 py-4">
+                            {isLoadingProc ? (
+                              <div className="flex items-center gap-2 text-subtle text-sm">
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                                Carregando processos...
+                              </div>
+                            ) : processes.length === 0 ? (
+                              <p className="text-sm text-muted">Nenhum processo ainda.</p>
+                            ) : (
+                              <div className="space-y-2">
+                                <p className="text-xs font-semibold text-muted uppercase tracking-wider mb-3">
+                                  Processos ({processes.length})
+                                </p>
+                                {processes.map((proc) => (
+                                  <div
+                                    key={proc.id}
+                                    onClick={() => navigate(`/consultant/processes/${proc.id}`)}
+                                    className="flex items-center justify-between bg-surface rounded-lg px-4 py-3 border border-border-soft hover:border-border cursor-pointer transition-colors"
+                                  >
+                                    <div className="flex items-center gap-3">
+                                      <StatusBadge status={proc.status} />
+                                      <span className="text-sm text-muted">
+                                        {proc.product_type ?? "Consultoria"} •{" "}
+                                        {proc.specialist ? `${proc.specialist.name} ${proc.specialist.surname}` : "—"}
+                                      </span>
+                                    </div>
+                                    <span className="text-xs text-subtle">
+                                      {new Date(proc.created_at).toLocaleDateString("pt-BR")}
+                                    </span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+```
+
+- [ ] **Step 5: Trocar os 4 `Modal` pelo `Dialog`/`DialogContent` novo**
+
+Substituir:
+
+```tsx
+      {/* Modais */}
+      <Modal isOpen={isInviteModalOpen} onClose={() => setIsInviteModalOpen(false)}>
+        <InviteClientForm onSuccess={() => { setIsInviteModalOpen(false); fetchClients(); }} />
+      </Modal>
+
+      <Modal isOpen={isBatchModalOpen} onClose={() => setIsBatchModalOpen(false)}>
+        <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
+      </Modal>
+
+      <Modal isOpen={!!clientToEdit} onClose={() => setClientToEdit(null)}>
+        {clientToEdit && (
+          <EditClientForm client={clientToEdit} onSuccess={() => { setClientToEdit(null); fetchClients(); }} />
+        )}
+      </Modal>
+
+      <Modal isOpen={!!clientToDelete} onClose={() => setClientToDelete(null)}>
+        <div className="text-center">
+          <h2 className="h2-style mb-4">Confirmar Remoção</h2>
+          <p className="text-text-secondary mb-8">
+            Remover <strong>{clientToDelete?.name} {clientToDelete?.surname}</strong>? O cliente não será apagado, apenas desvinculado.
+          </p>
+          <div className="flex justify-center gap-4">
+            <Button onClick={() => setClientToDelete(null)}>Cancelar</Button>
+            <Button onClick={handleDelete}>Confirmar</Button>
+          </div>
+        </div>
+      </Modal>
+
+    </div>
+  );
+}
+```
+
+por:
+
+```tsx
+      {/* Modais */}
+      <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
+        <DialogContent title="Convidar cliente">
+          <InviteClientForm onSuccess={() => { setIsInviteModalOpen(false); fetchClients(); }} />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={isBatchModalOpen} onOpenChange={setIsBatchModalOpen}>
+        <DialogContent title="Convite de clientes em lote">
+          <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!clientToEdit} onOpenChange={(open) => !open && setClientToEdit(null)}>
+        <DialogContent title="Editar cliente">
+          {clientToEdit && (
+            <EditClientForm client={clientToEdit} onSuccess={() => { setClientToEdit(null); fetchClients(); }} />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={!!clientToDelete} onOpenChange={(open) => !open && setClientToDelete(null)}>
+        <DialogContent title="Confirmar remoção">
+          <div>
+            <p className="text-muted mb-6">
+              Remover <strong className="text-ink">{clientToDelete?.name} {clientToDelete?.surname}</strong>? O cliente não será apagado, apenas desvinculado.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="light" onClick={() => setClientToDelete(null)}>Cancelar</Button>
+              <Button variant="danger" onClick={handleDelete}>Confirmar</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Verificar tipos**
+
+```bash
+npx tsc -b
+```
+
+Expected: sem erro.
+
+- [ ] **Step 7: Verificar visualmente**
+
+```bash
+npm run dev
+```
+
+Logar como `CONSULTANT`, ir em "Meus Clientes":
+- Confirmar que a tabela aparece com Cliente/E-mail/Cadastro/ações.
+- Redimensionar a janela do navegador para largura de celular (ou abrir DevTools em modo responsivo) e confirmar que a tabela rola horizontalmente dentro da própria caixa, sem quebrar o layout da página.
+- Expandir um cliente com processos e confirmar que o `StatusBadge` aparece (pílula cinza + ponto colorido) em vez do badge saturado antigo.
+- Abrir os 4 modais (Convidar cliente, Convite em lote, Editar, Excluir) e confirmar: título aparece, X fecha, ESC fecha, clique fora fecha, e o modal de exclusão tem Cancelar (light) + Confirmar (danger, vermelho).
+- Confirmar que uma lista vazia de clientes (se houver conta de teste sem clientes) mostra o `EmptyState` com ícone, texto e botão de ação.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/pages/consultant/ConsultantClientsPage.tsx
+git commit -m "feat(piloto): reescrever Meus Clientes com PageHeader, StatusBadge, Dialog, EmptyState e tabela responsiva"
+```
+
+---
+
+### Task 14: Piloto — corrigir beco sem saída do `BatchInviteClients.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/consultant/BatchInviteClients.tsx`
+
+**Interfaces:**
+- Consumes: `Button` (Task 3).
+
+- [ ] **Step 1: Trocar o import do ícone de upload e adicionar ícones de status**
+
+Substituir:
+
+```tsx
+import { Loader2, Upload } from "lucide-react";
+```
+
+por:
+
+```tsx
+import { Loader2, Upload, CheckCircle2, XCircle, RefreshCw } from "lucide-react";
+```
+
+- [ ] **Step 2: Trocar o botão "Cancelar" bruto pelo `Button` novo, e tokenizar o input de arquivo**
+
+Substituir:
+
+```tsx
+      <input
+        type="file"
+        accept=".csv"
+        onChange={(e) => {
+          setFile(e.target.files?.[0] ?? null);
+          setJob(null);
+          setError(null);
+        }}
+        className="block w-full text-sm mb-4 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border file:border-gray-300 file:bg-gray-50 file:text-sm"
+      />
+
+      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+
+      {!job && (
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50"
+          >
+            Cancelar
+          </button>
+          <Button type="button" onClick={upload} disabled={!file || uploading}>
+            {uploading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Upload className="w-4 h-4" />
+            )}
+            Enviar
+          </Button>
+        </div>
+      )}
+```
+
+por:
+
+```tsx
+      <input
+        type="file"
+        accept=".csv"
+        onChange={(e) => {
+          setFile(e.target.files?.[0] ?? null);
+          setJob(null);
+          setError(null);
+        }}
+        className="block w-full text-sm mb-4 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border file:border-border file:bg-border-soft file:text-sm"
+      />
+
+      {error && (
+        <p className="text-sm text-status-bad mb-3">{error}</p>
+      )}
+
+      {!job && (
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="light" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={upload} disabled={!file || uploading}>
+            {uploading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Upload className="w-4 h-4" />
+            )}
+            Enviar
+          </Button>
+        </div>
+      )}
+```
+
+- [ ] **Step 3: Corrigir o beco sem saída — adicionar botão "Fechar" visível durante o processamento**
+
+Este é o achado da auditoria: hoje, entre o momento em que `job` existe e o momento em que `job.done` vira verdadeiro, **nenhum botão é renderizado** — a única saída é clicar na área escura do modal, sem nenhuma pista visual. Substituir:
+
+```tsx
+      {job && (
+        <div>
+          <div className="flex flex-wrap gap-4 text-sm mb-3">
+            <span className="text-green-700">✓ {job.successItems} enviados</span>
+            <span className="text-red-600">✗ {job.failedItems} falhas</span>
+            <span className="text-gray-500">
+              ↻ {job.duplicateItems} duplicados
+            </span>
+            {!job.done && (
+              <span className="flex items-center gap-1 text-gray-500">
+                <Loader2 className="w-4 h-4 animate-spin" /> processando…
+              </span>
+            )}
+          </div>
+```
+
+por:
+
+```tsx
+      {job && (
+        <div>
+          <div className="flex flex-wrap items-center gap-4 text-sm mb-3">
+            <span className="flex items-center gap-1 text-status-ok">
+              <CheckCircle2 className="w-4 h-4" /> {job.successItems} enviados
+            </span>
+            <span className="flex items-center gap-1 text-status-bad">
+              <XCircle className="w-4 h-4" /> {job.failedItems} falhas
+            </span>
+            <span className="flex items-center gap-1 text-muted">
+              <RefreshCw className="w-4 h-4" /> {job.duplicateItems} duplicados
+            </span>
+            {!job.done && (
+              <span className="flex items-center gap-1 text-muted">
+                <Loader2 className="w-4 h-4 animate-spin" /> processando…
+              </span>
+            )}
+            {!job.done && (
+              <Button type="button" variant="light" onClick={onClose} className="ml-auto">
+                Fechar (continua em segundo plano)
+              </Button>
+            )}
+          </div>
+```
+
+- [ ] **Step 4: Tokenizar a cor da mensagem de erro por linha**
+
+Substituir:
+
+```tsx
+                    <td className="px-2 py-1 text-xs text-red-500">
+                      {it.error_message ?? ""}
+                    </td>
+```
+
+por:
+
+```tsx
+                    <td className="px-2 py-1 text-xs text-status-bad">
+                      {it.error_message ?? ""}
+                    </td>
+```
+
+(o botão "Fechar" de quando `job.done` é verdadeiro já usa `Button` hoje — não precisa mudar.)
+
+- [ ] **Step 5: Verificar**
+
+```bash
+npx tsc -b
+npm run dev
+```
+
+Manual: logar como `CONSULTANT`, abrir "Convite em lote", subir um CSV válido com várias linhas. Durante o intervalo de processamento (antes de `job.done` virar verdadeiro), confirmar que agora existe um botão "Fechar (continua em segundo plano)" visível — antes desse fix, essa janela de tempo não tinha nenhum botão.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/consultant/BatchInviteClients.tsx
+git commit -m "fix(navegacao): convite em lote nao fica mais sem botao durante o processamento do CSV"
+```
+
+---
+
+### Task 15: Verificação final
+
+**Files:** nenhum (só verificação)
+
+- [ ] **Step 1: Build completo**
+
+```bash
+cd frontend
+npm run build
+```
+
+Expected: `tsc -b` e `vite build` terminam sem erro.
+
+- [ ] **Step 2: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: sem erro (avisos pré-existentes no restante do código, fora do escopo deste plano, podem continuar aparecendo — não introduzir novos).
+
+- [ ] **Step 3: Checklist manual de navegação, com o dev server rodando (`npm run dev`)**
+
+- [ ] `/login` → botão continua com a mesma aparência de antes (Task 3 não deveria ter mudado nada visualmente fora do piloto).
+- [ ] Logado como `CONSULTANT` → "Meus Clientes": tabela responsiva, badges com ponto de cor, modais com título/X/ESC/Cancelar, empty state se não houver clientes.
+- [ ] Logado como `CONSULTANT` → "Convite em lote" com um CSV grande o bastante para ver o estado intermediário: botão "Fechar (continua em segundo plano)" aparece durante o processamento.
+- [ ] Acessar `/specialist/contracts/preview-callback?event=send` direto pela URL (sem popup), logado como `SPECIALIST`: botão "Voltar para processos" aparece e funciona.
+- [ ] Logado como qualquer papel não-`OFFICE`: "Meus Assessorados" aparece na Sidebar e leva para `/advisor/dashboard`.
+- [ ] Nenhuma outra tela (Admin, Specialist, Customer, Auth) mudou visualmente — são telas fora do piloto e devem continuar exatamente como estavam.
+
+- [ ] **Step 4: Commit final (se sobrar algum ajuste do checklist manual)**
+
+```bash
+git add -A
+git commit -m "chore(design-system): ajustes finais da verificacao manual da fundacao + piloto"
+```
+
+(pular este commit se nada precisou ser ajustado.)

--- a/docs/superpowers/plans/2026-07-21-rollout-fatias-2-a-7.md
+++ b/docs/superpowers/plans/2026-07-21-rollout-fatias-2-a-7.md
@@ -1,0 +1,50 @@
+# Rollout do Design System — Fatias 2-7 (checklist, não exaustivo)
+
+> Plano leve, de propósito — não transcreve código linha a linha como o da Fatia 1. Cada item é "arquivo → o que muda", usando a **tabela canônica de tokenização** e os componentes já existentes (`Button`, `Card`, `Alert`, `Dialog`/`DialogContent`, `PageHeader`, `StatusBadge`, `EmptyState`) documentados em `docs/superpowers/specs/2026-07-21-rollout-completo-design-system.md`. Quem for implementar: abrir o arquivo, aplicar a tabela de tokenização + trocar botão/modal cru pelo componente certo, verificar com `tsc -b` + `build` + `lint` + screenshot real (Playwright mockando API, nunca o backend local nesta máquina).
+
+## Fatia 2 — Especialista
+
+- [ ] `ProcessesPage.tsx` — `PageHeader`; os 10 botões crus viram `Button`/ícone tokenizado conforme a tabela canônica; não tocar em `ProcessCard.tsx` (fora de escopo).
+- [ ] `ProductsPage.tsx` — ícones editar/excluir (SVG à mão) → `Pencil`/`Trash2`; resolver a mistura `text-text-primary` + cinza cru, tudo pros tokens novos.
+- [ ] `CreateContractPage.tsx` — **não dividir o arquivo** nesta fatia; só tokenizar (o padrão de campo repetido ~35x é uma troca de string só); 4 botões crus → `Button`.
+- [ ] `ContractPreviewCallback.tsx` — só falta tokenizar ~11 classes `slate-*` ao redor dos 3 usos de `Button` já corretos (não mexer neles).
+- [ ] `RequireCalendlyModal.tsx` / `RequireGoogleMeetModal.tsx` — migrar pro `Dialog`/`DialogContent`; **gradiente sai** (vira ícone + título normal, ver spec); comportamento do "Lembrar mais tarde" não muda.
+
+## Fatia 3 — Admin
+
+- [ ] `DashboardPage.tsx` — `PageHeader`; 6 stat cards → `Card`; gráficos recharts mantidos, só moldura vira `Card`; **adicionar** 3 atalhos rápidos (`ActionCard` tokenizado, mesmo padrão do `OfficeDashboardPage.tsx`) pra Escritórios/Especialistas/Configurações.
+- [ ] `CompaniesPage.tsx` + `SpecialistsPage.tsx` — migrar as `Modal` (`ui/Modal.tsx`) existentes pro `Dialog`; `EditIcon`/`TrashIcon` → `Pencil`/`Trash2`; `alert()` de erro de exclusão fica como está.
+- [ ] `CommissionsPage.tsx` — tokenizar `TabButton`; **não mexer** em `SplitBar`'s cores (paleta categórica própria, não é status); `RateRow` usa `text-status-ok`/`text-status-bad`; botões CSV/PDF → `Button variant="light"`.
+- [ ] `DatabasePage.tsx` — reskin (tabs, botões, tabela); **sem cross-link** de linha pro CRUD nesta fatia (fica pra depois).
+- [ ] `SettingsPage.tsx` + `MyCompanyPage.tsx` — remover o shell de página próprio do `SettingsPage` (normalizar pro padrão das outras); banners de erro/sucesso → `Alert`; toggle switch só tokeniza (não vira componente novo, só 1 consumidor).
+- [ ] `Sidebar.tsx` — adicionar `{ to: "/office/consultants", label: "Consultores", icon: <Users size={20} /> }` no `case "ADMIN":` (rota já permite, sem rota nova).
+
+## Fatia 4 — Escritório
+
+- [ ] `OfficeConsultantsPage.tsx` — avaliar reaproveitar o `Dialog`+fluxo de convite em lote do Consultor em vez de manter a implementação duplicada; se não der por dependências diferentes, ao menos tokenizar + usar `Dialog` em vez do `window.confirm()` nativo (achado da auditoria original).
+- [ ] `OfficeDashboardPage.tsx` — já usa o padrão `ActionCard`; só tokenizar cores (`bg-gray-900`→`Button`, `border-gray-100`→`border-border-soft`, etc).
+- [ ] `OfficeClientsPage.tsx`, `OfficeCompanySettingsPage.tsx` — tabela canônica de tokenização; checar responsividade (grids fixos sem breakpoint apontados na auditoria original).
+
+## Fatia 5 — Cliente
+
+- [ ] `CatalogPage.tsx` — **implementar filtro real** (decisão confirmada — não só remover o botão); definir campos de filtro com base no que já existe no produto (marca/modelo/ano/preço); tokenizar o resto da página.
+- [ ] `ProductPage.tsx` + `ConsultoriaPage.tsx` — **unificar a lógica de agendamento num hook compartilhado** (decisão confirmada) antes/junto do reskin, corrigindo o bug de agendamento órfão (popup fechado sem limpeza) no processo; `PageHeader` no lugar do botão de voltar solto.
+- [ ] `CustomerProcessesPage.tsx`, `CustomerHomePage.tsx` — tabela canônica de tokenização + `StatusBadge` onde houver status de processo cru.
+
+## Fatia 6 — Auth
+
+- [ ] `RegisterConsultantPage.tsx`, `RegisterOfficePage.tsx`, `RegisterSpecialistPage.tsx` — tela de "convite expirado/inválido" ganha o mesmo botão que `RegisterPage.tsx` já tem (achado de beco sem saída da auditoria original — replicar a correção 3x).
+- [ ] `LoginPage.tsx`, `ForgotPasswordPage.tsx`, `ResetPasswordPage.tsx` — tabela canônica de tokenização; já usam bastante classe responsiva (auditoria original não achou problema de responsividade aqui, só cor crua).
+
+## Fatia 7 — Consolidação transversal (só depois de 2-6 completas)
+
+- [ ] Grep por consumidores restantes de `components/ui/Modal.tsx` e `components/shared/Modal.tsx` — se zero, apagar os 2 arquivos.
+- [ ] Grep por `STATUS_LABELS`/`STATUS_COLORS` locais restantes — trocar por `StatusBadge`/`PROCESS_STATUS_META`.
+- [ ] Migrar `NegotiationPage.tsx` pro `ProposalStatusBadge` (criado na Fatia 1).
+- [ ] Só agora avaliar se algum consumidor real justifica criar `Tabs`/`Dropdown menu` — senão, deixar pra próxima vez que surgir.
+
+## Fora de escopo (não implementar sem alinhar antes)
+
+- Comissão de consultor (não existe, ver `CLAUDE.md`).
+- Dashboards enriquecidos (Admin/Especialista/Escritório) além do reskin simples — brainstorm próprio depois.
+- Cross-link de `DatabasePage`, divisão de `CreateContractPage` em componentes menores — mencionados nas fatias acima como "fica pra depois", não implementar junto.

--- a/docs/superpowers/specs/2026-07-21-rollout-completo-design-system.md
+++ b/docs/superpowers/specs/2026-07-21-rollout-completo-design-system.md
@@ -1,0 +1,108 @@
+# Rollout completo do Design System — Especificação
+
+Spec de handoff: cobre o que falta pra aplicar o design system (`DESIGN.md`) em **toda a plataforma**, depois que a fundação + o piloto (Consultor → Meus Clientes) já foram implementados, revisados e verificados com screenshot real. Escrita pra outra sessão/agente conseguir pegar e virar plano de implementação por fatia, sem precisar reconstruir o contexto da auditoria original.
+
+## O que já existe (não refazer)
+
+- **`DESIGN.md`** (raiz do repo) — tokens, componentes (`components/ui/`: button/input/card/alert/dialog; `components/patterns/`: StatusBadge/EmptyState/BackButton/PageHeader), convenção de ícone, layout, navegação. Implementado e commitado na branch `design-system-foundation-pilot`.
+- **`PRODUCT.md`** (raiz) — contexto de marca: discreta, monocromática, sem dourado/grafite, sem cor de destaque separada da ação.
+- **Piloto**: `frontend/src/pages/consultant/ConsultantClientsPage.tsx` reescrito, `BatchInviteClients.tsx` e `ContractPreviewCallback.tsx` corrigidos (becos sem saída), `Sidebar.tsx` com `/advisor/dashboard` linkado. Todos os 8 componentes têm pelo menos 1 consumidor real. Validado com screenshots reais (Playwright + mock de API — **nunca rodar o backend local nesta máquina**, ver seção de lições abaixo).
+- **`Tabs` e `Dropdown menu`** (citados no `DESIGN.md`) — deliberadamente **não construídos ainda**, sem consumidor real. Construir só quando uma fatia abaixo precisar de fato.
+
+## Lições do piloto (aplicar em toda fatia nova)
+
+1. **Título duplicado ao envolver um form existente em `DialogContent`**: se o componente já renderiza seu próprio `<h2>`, usar `hideTitle` no `DialogContent` (já suportado). Achado real no piloto (3 de 4 modais), só pego com screenshot real, não com revisão de código.
+2. **Largura duplicada ao aninhar**: um componente que já tinha seu próprio wrapper `w-[...]` (de quando era usado como modal standalone) vira `w-full` ao ser aninhado dentro de `DialogContent` (que já controla a largura) — senão o conteúdo estoura a caixa. Achado real no `BatchInviteClients.tsx`.
+3. **`.map()` com múltiplos elementos-irmãos** precisa de `<Fragment key={...}>` explícito — o shorthand `<>` não aceita `key`.
+4. **Ambiente de dev nesta máquina**: `nest start --watch` (backend) **crashou a máquina duas vezes**. Nunca rodar o backend local aqui. QA visual = só `npm run dev` do frontend (leve, seguro) + Playwright com `page.route('**/api/**', ...)` mockando toda resposta necessária. Ver memória `feedback_backend_dev_server_crashed_machine`.
+5. **Sem test runner no frontend** (nem Jest nem Vitest) — verificação de cada fatia é `npx tsc -b` + `npm run build` + `npm run lint` + screenshot real via Playwright mockado. Não introduzir um test runner novo como parte do rollout.
+6. **Botão compartilhado (`Button`)**: variantes antigas (`solid/light/muted/brand`) têm que continuar pixel-idênticas em qualquer arquivo ainda não migrado — nunca alterar o valor de uma variante existente "de passagem" numa fatia que mexe em outra coisa.
+7. **Consultor não recebe comissão nesta plataforma** — regra de negócio confirmada, não é lacuna. Não incluir "wallet/comissão de consultor" em nenhuma fatia sem alinhar antes (ver `CLAUDE.md`).
+
+## Ordem do rollout (decidida com o cliente)
+
+Por área, começando pelo Consultor — cada fatia pequena o bastante pra revisar e testar sozinha, na mesma linha do piloto.
+
+1. Consultor (fechar o que sobrou)
+2. Especialista
+3. Admin
+4. Escritório
+5. Cliente
+6. Auth
+7. Consolidação transversal (só depois de 1-6 completas)
+
+---
+
+## Fatia 1 — Consultor (a mais detalhada, pronta pra virar plano)
+
+### 1a. `ConsultantDashboard.tsx` — redesign completo (aprovado nesta sessão)
+
+Hoje é uma segunda "Meus Clientes" reduzida (mesma tabela, sem convite em lote, sem expandir processos) — duplicação apontada na auditoria original. Vira um dashboard de verdade:
+
+- **Arquitetura**: busca `getClients()` + `getAllConsultantProcesses()` uma vez ao montar; todo o resto (KPIs, agrupamento por status, ordenação) é derivado client-side. **Sem endpoint novo** — `GET /consultant/processes` já retorna `updated_at` no JSON (a query Prisma não usa `select`), só o tipo `ConsultantProcess` no frontend não declara o campo; adicionar `updated_at: string` ao tipo é suficiente.
+- **Widgets**:
+  1. Faixa de KPIs (topo, 4 cards): Clientes totais · Processos ativos · Concluídos · Taxa de conversão.
+  2. **Processos vigentes** (coluna principal): processos não-finalizados (status ≠ COMPLETED/REJECTED), ordenados por `updated_at` ascendente (mais tempo parado primeiro — sinaliza o que precisa de atenção sem precisar de dado novo). Cada linha: `StatusBadge`, cliente, especialista, "há X dias sem atualização". Link "Ver todos" → `/consultant/processes`.
+  3. **Distribuição por status** (coluna lateral): gráfico com `recharts` (já instalado, mesma lib do dashboard do Especialista) — usar as mesmas 6 cores do `StatusBadge`, não uma paleta nova. **Antes de implementar este widget, ler a skill `dataviz`** (guia de forma/cor/acessibilidade pra qualquer gráfico novo).
+  4. **Clientes recentes** (coluna lateral): últimos 3-5 por `created_at` desc, link "Ver todos" → `/consultant/clients`.
+  5. **Atalhos rápidos**: os mesmos modais "Convidar cliente" / "Convite em lote" (reaproveitar `InviteClientForm`/`BatchInviteClients` + `Dialog` novo) direto no dashboard — sem duplicar a tabela de clientes que já vive em Meus Clientes.
+- **Erros/loading**: um loading só pro fetch inicial; erro vira `Alert` (não bloqueia a página); cada widget sem dado mostra seu próprio `EmptyState` pequeno.
+- **Layout**: usa o template de "página de detalhe" do `DESIGN.md` (`PageHeader` sem back — é raiz de Sidebar — + corpo em 2 colunas, empilha abaixo de 900px).
+
+### 1b. `ConsultantProcessesPage.tsx` — aplicar o sistema
+
+- Trocar `STATUS_LABELS`/`STATUS_COLORS` locais (duplicados do que já foi resolvido no piloto) por `StatusBadge`.
+- `PageHeader` no lugar do cabeçalho manual.
+- A lista de processos usa `grid-cols-[1.5fr_1.5fr_1fr_1fr_1fr]` sem nenhuma classe responsiva — mesmo padrão de problema já corrigido em `ConsultantClientsPage`: virar tabela real dentro de `overflow-x-auto`, ou pelo menos adicionar breakpoint pra empilhar em mobile.
+- Filtro de status/cliente (select + dropdown de busca) — tokenizar cores (`border-gray-300`→`border-border` etc.), considerar `Input` novo pro campo de busca do dropdown de cliente.
+- Paginação e "limpar filtros" — só tokenizar cores, sem mudança de comportamento.
+
+### 1c. `ConsultantProcessDetailPage.tsx` — aplicar o sistema + primeiro uso real do `BackButton`
+
+- 735 linhas — é a página aninhada (chegada só a partir de Meus Clientes/Processos, não linkada na Sidebar) que finalmente justifica `PageHeader` com `showBack=true` — fecha a lacuna documentada no piloto ("branch `showBack=true` não exercida ainda").
+- Mesmos `STATUS_LABELS`/`STATUS_COLORS` duplicados → `StatusBadge`.
+- `ProposalStatusBadge` local (4 estados: PENDING/ACCEPTED/REJECTED/COUNTERED, JSX duplicado verbatim também em `NegotiationPage.tsx` por fora desta fatia) — criar `components/patterns/ProposalStatusBadge.tsx` seguindo o mesmo padrão do `StatusBadge` (pílula neutra + ponto de cor), consumir aqui; **não** migrar `NegotiationPage.tsx` ainda (fora do escopo desta fatia — mas o componente já fica pronto pra quando chegar a vez).
+- Botões de ação (aceitar/rejeitar proposta, criar contrato) → `Button` com as variantes corretas (`danger` pra rejeitar, `solid` pra aceitar/avançar).
+
+---
+
+## Fatias futuras — nível macro (o que a auditoria já mapeou, sem detalhar componente-a-componente ainda)
+
+### Fatia 2 — Especialista
+- `ProcessesPage.tsx`, `ProductsPage.tsx`: mesmo padrão (StatusBadge, PageHeader, tokens, ícones só lucide — `ProductsPage` hoje tem SVG desenhado à mão pra editar/excluir).
+- `CreateContractPage.tsx` — **maior arquivo da plataforma (1835 linhas)**, maior risco da fatia. Considerar dividir em componentes menores como parte da migração (não só reskin).
+- `ContractPreviewCallback.tsx` já teve o beco sem saída corrigido no piloto — só falta aplicar tokens/Button de forma completa (hoje mistura `Button` novo com classes `bg-slate-700` cruas nos estados não tocados).
+- Modal do Especialista (`RequireCalendlyModal`/`RequireGoogleMeetModal`) — migrar pro `Dialog` novo.
+
+### Fatia 3 — Admin
+- `DashboardPage.tsx` sem atalhos de ação rápida (Office tem `ActionCard`, Admin não) — mesma oportunidade de enriquecimento que o Consultor ganhou nesta sessão; desenhar depois, com brainstorm próprio (dados/permissões diferentes: visão cross-role, Base de Dados).
+- `CompaniesPage`/`SpecialistsPage` já usam modal de confirmação estilizado; `OfficeConsultantsPage` usa `window.confirm()` nativo — padronizar todos pro `Dialog` novo.
+- `DatabasePage.tsx` — bem construída isoladamente, mas sem link de nenhuma linha pro CRUD da entidade. Considerar cross-link como parte da fatia.
+- Falta rota `/admin/consultants` (hoje só existe em `/office/consultants`) — decisão de produto a confirmar antes de implementar.
+
+### Fatia 4 — Escritório
+- `OfficeConsultantsPage.tsx` duplica o convite em lote do Consultor (`BatchInvite` embutido) — considerar reaproveitar o mesmo `Dialog`/fluxo do piloto em vez de manter 2 implementações.
+- Mesma tokenização/ícones/responsividade das demais.
+
+### Fatia 5 — Cliente
+- `CatalogPage.tsx` — botão "Filtro" abre modal com placeholder falso, sem filtro real — decisão de produto (implementar filtro de verdade ou remover o botão) antes de só reskinar.
+- `ProductPage.tsx` — sem breadcrumb (o `Breadcrumb.tsx` órfão foi removido no piloto; decidir se cria um novo ou usa `PageHeader` com contexto).
+- Duas implementações divergentes de "agendar com especialista" (`ProductPage` vs `ConsultoriaPage`) — consolidar em um hook/fluxo só antes de aplicar visual, senão o bug de agendamento órfão (popup fechado sem cleanup) sobrevive escondido atrás de um verniz novo.
+
+### Fatia 6 — Auth
+- Telas de "convite expirado/inválido" sem nenhum botão em 3 de 4 páginas de registro (`RegisterConsultantPage`/`RegisterOfficePage`/`RegisterSpecialistPage` vs. `RegisterPage`, que já tem) — mesmo padrão de beco sem saída já corrigido 3x no piloto; replicar a correção nessas 3 telas é parte natural da fatia.
+
+---
+
+## Fatia 7 — Consolidação transversal (só depois de 1-6 completas)
+
+- Remover `components/ui/Modal.tsx` e `components/shared/Modal.tsx` (os 2 modais antigos concorrentes) — só depois que **todo** consumidor de ambos tiver migrado pro `Dialog` novo (checar com grep antes de apagar).
+- Remover todos os mapas `STATUS_LABELS`/`STATUS_COLORS` locais restantes fora dos já resolvidos acima.
+- Migrar `NegotiationPage.tsx` pro `ProposalStatusBadge` criado na Fatia 1c (fecha a duplicação verbatim apontada na auditoria).
+- Só neste ponto crirar `Tabs`/`Dropdown menu` caso alguma fatia acima tenha revelado um consumidor real pra eles — senão, deixar pra quando surgir.
+
+## Fora de escopo desta spec (decisões separadas, não implementar sem alinhar antes)
+
+- **Comissão/wallet de consultor** — não existe nesta plataforma, não é lacuna (ver `CLAUDE.md` § Known inconsistencies).
+- **Dashboards enriquecidos do Admin/Especialista/Escritório** — só o do Consultor foi desenhado (Fatia 1a). Os outros têm dados/permissões diferentes (ex: Admin precisa de visão cross-role, preview de Base de Dados) e merecem seu próprio brainstorm antes de implementar — não copiar o layout do Consultor sem essa conversa.
+- **Filtro real do catálogo, rota `/admin/consultants`, decisão sobre unificar `ProductPage`/`ConsultoriaPage`** — decisões de produto sinalizadas nas fatias 3/5 acima, não implementar até o cliente confirmar.

--- a/docs/superpowers/specs/2026-07-21-rollout-completo-design-system.md
+++ b/docs/superpowers/specs/2026-07-21-rollout-completo-design-system.md
@@ -66,19 +66,95 @@ Hoje é uma segunda "Meus Clientes" reduzida (mesma tabela, sem convite em lote,
 
 ---
 
+## Tabela canônica de tokenização (reaproveitada por Fatias 2-6)
+
+Achado transversal da pesquisa das Fatias 2/3: existem **2-3 vocabulários de cor "primária" concorrentes** espalhados pela plataforma (`slate-700/800/900` em `ProcessesPage`/`CreateContractPage`; `gray-800/900`/`bg-black` em `ProductsPage`/`SpecialistDashboard`/`CompaniesPage`/`OfficeDashboardPage`'s `ActionCard`; `blue-600` nos modais de conexão). Regra única pra todas as fatias a partir daqui: **qualquer botão de ação vira o `Button` compartilhado** (não importa se hoje é `slate` ou `gray` ou `black`) — a pergunta нunca é "slate ou gray?", é "isso é uma ação primária, secundária ou destrutiva?".
+
+| Padrão bruto encontrado | Vira |
+|---|---|
+| Botão de ação primária: `bg-slate-700/800/900`, `bg-gray-800/900`, `bg-black` (+ hovers) | `<Button>` (variante `solid`, padrão) |
+| Botão secundário: `border-gray-300` + fundo branco/claro | `<Button variant="light">` |
+| Botão destrutivo: `bg-red-600`/`bg-red-500` num botão de ação (não ícone de linha) | `<Button variant="danger">` |
+| Ícone de linha (editar) | `hover:bg-border-soft text-ink-soft` + ícone lucide (`Pencil`) — nunca SVG à mão ou `<img>` |
+| Ícone de linha (excluir) | `hover:bg-status-bad-wash text-status-bad` + ícone lucide (`Trash2`) |
+| Aba/tab ativa vs inativa (ex: `border-slate-700 text-slate-800` vs `border-transparent text-gray-500`) | `border-ink text-ink` (ativa) vs `border-transparent text-muted hover:text-ink-soft` (inativa) — **não** é `Button` nem o `Tabs` ainda-não-construído, continua um botão simples tokenizado até um consumidor justificar o componente compartilhado |
+| `text-gray-400`, `text-slate-400` | `text-subtle` |
+| `text-gray-500`/`600`, `text-slate-500`/`600` | `text-muted` |
+| `text-gray-700`, `text-slate-700`/`800` | `text-ink-soft` |
+| `text-gray-900`, `text-slate-900` | `text-ink` |
+| `border-gray-100`, `border-slate-100` | `border-border-soft` |
+| `border-gray-200`/`300`, `border-slate-200`/`700` (quando não for aba ativa) | `border-border` |
+| `bg-gray-50`/`100`, `bg-slate-50`/`100` | `bg-border-soft` |
+| `bg-white` | `bg-surface` |
+| `focus:ring-slate-500`, `ring-slate-500` | `focus:ring-focus-ring` |
+| Banner de página inteira (erro/sucesso, `bg-red-50 border-red-200 text-red-700` / `bg-green-50 ...`) | `<Alert variant="danger">` / `<Alert variant="success">` |
+| Badge/pílula de status inline menor (não banner) — ex: `bg-blue-100 text-blue-800` pra especialidade, `bg-emerald-50 text-emerald-700` pra taxa | **não forçar pro `StatusBadge`** (que é só pra status de PROCESSO) — tokenizar cor só se for genuinamente um dos 6 status; caso contrário manter como pílula neutra (`bg-border-soft text-ink-soft`) ou, se for uma métrica positiva (taxa/percentual), `bg-status-ok-wash text-status-ok` |
+
+Exceção documentada: cor usada como **destaque não-semântico** (ex: laranja em "valor mínimo" na Fatia 1) fica como está — nem toda cor crua é um status a mapear.
+
+## Fatia 2 — Especialista (detalhada, pronta pra virar plano)
+
+Pesquisa de código confirmou: nenhum arquivo desta fatia usa `Button` ou `Dialog`/`Modal` novos ainda (`ProcessesPage`/`ProductsPage`/`CreateContractPage` são 100% raw); os 2 modais de conexão (Calendly/Google Meet) são overlays construídos à mão, não usam nenhum dos 2 `Modal` antigos.
+
+### 2a. `ProcessesPage.tsx` (548 linhas)
+- Cabeçalho manual → `PageHeader`.
+- 10 `<button>` crus (toggle de filtro, criar processo, limpar busca/filtros, paginação, chips de filtro) → tabela canônica acima (a maioria vira `Button variant="light"` ou `solid`; os "X" de remover chip/busca ficam ícone-only tokenizado, sem virar `Button`).
+- Sem mapa de cor de status (usa só `STATUS_OPTIONS` de rótulo pro filtro) — nada a trocar por `StatusBadge` aqui além de garantir que `ProcessCard` (componente separado, fora desta fatia — só consumido, não redefinido) já renderiza status corretamente; **não tocar em `ProcessCard.tsx`** nesta fatia (é um componente grande e compartilhado, considerar fatia própria depois se a auditoria apontar necessidade).
+
+### 2b. `ProductsPage.tsx` (285 linhas)
+- Ícones de editar/excluir são SVG desenhado à mão (não lucide) → `Pencil`/`Trash2`.
+- 6 botões crus → tabela canônica.
+- Já usa `text-text-primary` (token semântico) misturado com cinza cru no mesmo arquivo — inconsistência a resolver: tudo vira os tokens novos, não o `text-text-primary` antigo nem cinza cru.
+
+### 2c. `CreateContractPage.tsx` (1835 linhas — maior arquivo da plataforma)
+- **Não dividir em componentes menores nesta fatia** — decisão revista: dividir arquivo é uma refatoração estrutural maior que o objetivo desta fatia (aplicar design system); vira candidato de uma limpeza técnica separada, não bloqueia o rollout visual. Aplicar só tokenização + `Button` nos 4 botões crus (CTA de erro/reload, submit, cancelar) e no cabeçalho (ícone `FileText` + título).
+- O padrão de campo de formulário repetido ~35+ vezes (`w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white`) é o ganho mais mecânico: uma substituição de string só, repetida em todo o arquivo (não precisa virar o componente `Input` novo — os campos aqui são controlados por `react-hook-form`/`Controller`, trocar pra `Input` exigiria adaptar a integração; escopo desta fatia é só tokenizar a classe crua, deixar a migração pro componente `Input` pra quando `CreateContractPage` for tocada de novo por outro motivo).
+
+### 2d. `ContractPreviewCallback.tsx` — finalizar tokenização
+- Já usa `Button` em 3 pontos (fundação do piloto). Restam ~11 classes `text-slate-400/500/600/800`/`bg-slate-50` na página em volta (título, corpo, fundo) — tokenizar (`text-ink`/`text-muted`/`bg-bg`), sem mexer na lógica ou nos 3 usos de `Button` já corretos.
+
+### 2e. `RequireCalendlyModal.tsx` / `RequireGoogleMeetModal.tsx` — migrar pro `Dialog`
+- Hoje são overlays 100% construídos à mão (backdrop + painel próprios), cada um com um cabeçalho em gradiente (`from-blue-600 to-indigo-600` / `from-emerald-600 to-teal-600`).
+- **Decisão de design (aplicando o princípio de `PRODUCT.md` — discreto, sem "exibição"): o gradiente sai.** Vira `Dialog`/`DialogContent` padrão (título normal, sem `hideTitle` — não há form duplicando título aqui), ícone (`Calendar`/`Video`) ao lado do título em vez de banner colorido. Os 3 botões (dispensar-X, "Conectar agora", "Lembrar mais tarde") viram `Button` (`solid` / `light`) + o X de fechar do próprio `Dialog`.
+- **Comportamento não muda nesta fatia** — "Lembrar mais tarde" continua suprimindo pelo resto da sessão (o bug em si, se for pra corrigir, é uma mudança de comportamento fora do escopo de "aplicar design system").
+
+## Fatia 3 — Admin (detalhada, pronta pra virar plano)
+
+Reskin simples confirmado com o cliente — **sem** widgets ricos/cross-role nesta fatia (isso vira uma conversa própria depois, como a do Consultor). Pesquisa confirmou: `CompaniesPage`/`SpecialistsPage`/`MyCompanyPage` já usam `Button` parcialmente e o `Modal` antigo (`ui/Modal.tsx`); `DashboardPage`/`CommissionsPage`/`DatabasePage`/`SettingsPage` são 100% raw (zero `Button`, zero modal).
+
+### 3a. `DashboardPage.tsx` — reskin + atalhos rápidos (sem redesenhar os widgets)
+- Cabeçalho manual → `PageHeader`.
+- 6 stat cards (`bg-gray-300`) → `Card` com os mesmos números/labels, só tokenizado.
+- Gráficos (`recharts`, já existentes: `LineChart` de vendas + `PieChart` de processos por consultor) — **mantidos como estão nesta fatia**, só tokenizar a moldura (`Card` em vez de `bg-white rounded-lg p-6 shadow-sm border border-gray-200`); as cores hardcoded do próprio gráfico (`COLORS` array de hex) ficam — não é a mesma paleta de status de processo, é uma paleta de identidade por consultor, fora do escopo desta fatia.
+- **Adicionar atalhos rápidos** (novo, mas pequeno — reaproveita o padrão `ActionCard` que `OfficeDashboardPage.tsx` já usa, só tokenizado): "Gerenciar escritórios" → `/admin/companies`, "Gerenciar especialistas" → `/admin/specialists`, "Configurações" → `/admin/settings`.
+
+### 3b. `CompaniesPage.tsx` (758 linhas) e `SpecialistsPage.tsx` (229 linhas) — finalizar migração
+- Já usam `Button` (parcial) e `Modal` (`ui/Modal.tsx`, `{isOpen, onClose, children}`) — migrar as 3 (`CompaniesPage`) / 2 (`SpecialistsPage`) instâncias de `Modal` pro `Dialog`/`DialogContent` novo (mesmo padrão do piloto — checar se o form interno já tem `<h2>` próprio pra decidir `hideTitle`).
+- `EditIcon`/`TrashIcon` (imagens SVG estáticas) → `Pencil`/`Trash2` lucide.
+- `alert(errorMessage)` nativo no fluxo de erro de exclusão — **manter como está** (não é modal, é fora do escopo de "unificar modal"; troca de `alert()` por um padrão de notificação é uma mudança de UX maior, não desta fatia).
+- Resto: tabela canônica de tokenização.
+
+### 3c. `CommissionsPage.tsx` (537 linhas) — 100% raw, maior risco desta fatia depois do Dashboard
+- `TabButton` local (ativo/inativo) → tokenizar conforme a tabela canônica (não widget novo).
+- `SplitBar({color: "bg-emerald-500"|"bg-sky-500"|"bg-violet-500"})` — recebe cor crua via prop. **Não é status de processo** (é a identidade visual fixa de Especialista/Escritório/Plataforma na barra de divisão de comissão) — manter os 3 tons como estão (são uma paleta categórica própria, de 3 categorias fixas, não 6 status), só confirmar que continuam com bom contraste; não tokenizar como se fossem os tokens de status.
+- `RateRow` (estado local idle/saved/error) → usar `text-status-ok`/`text-status-bad` nos estados salvo/erro.
+- Exportar CSV/PDF (`exportSalesCsv`/`exportSalesPdf`) — lógica intocada, só os botões viram `Button variant="light"` com ícone (`Download`/`FileText`).
+
+### 3d. `DatabasePage.tsx` (207 linhas) — reskin, sem cross-link nesta fatia
+- **Cross-link de cada linha pro CRUD da entidade — fica fora desta fatia** (decisão: é uma mudança de navegação/produto, não só visual; considerar como parte de uma fatia de "consolidação de navegação Admin" futura, não bloquear o reskin nesta).
+- Tab de entidade (mesmo padrão `border-slate-700 text-slate-800` vs cinza) → tokenizar igual `CommissionsPage`.
+- Botões CSV/PDF/paginação → `Button variant="light"`.
+
+### 3e. `SettingsPage.tsx` (414 linhas) e `MyCompanyPage.tsx` (292 linhas)
+- `SettingsPage` tem seu próprio shell de página (`min-h-screen bg-gray-50` + header sticky próprio) diferente do padrão das outras páginas Admin (que renderizam direto no slot do layout) — **normalizar pro mesmo padrão das demais** (sem shell próprio, `PageHeader` como as outras).
+- Toggle switch construído à mão (não existe `Switch` compartilhado, e só tem 1 consumidor) — **não criar componente novo agora** (mesma regra do `Tabs`/`Dropdown`: só com 2º consumidor real). Só tokenizar as cores do toggle em si.
+- Banners de erro/sucesso locais (duplicados entre os 2 arquivos, mesma receita) → `Alert`.
+- `MyCompanyPage` já usa `Button` (só no submit) — manter, só tokenizar o resto do formulário.
+
+### 3f. `Sidebar.tsx` — link "Consultores" pro Admin
+- Adicionar ao `case "ADMIN":` um item `{ to: "/office/consultants", label: "Consultores", icon: <Users size={20} /> }` (rota já permite `ADMIN` no guard, `Users` já importado no arquivo) — **sem rota nova**, decisão confirmada com o cliente.
+
 ## Fatias futuras — nível macro (o que a auditoria já mapeou, sem detalhar componente-a-componente ainda)
-
-### Fatia 2 — Especialista
-- `ProcessesPage.tsx`, `ProductsPage.tsx`: mesmo padrão (StatusBadge, PageHeader, tokens, ícones só lucide — `ProductsPage` hoje tem SVG desenhado à mão pra editar/excluir).
-- `CreateContractPage.tsx` — **maior arquivo da plataforma (1835 linhas)**, maior risco da fatia. Considerar dividir em componentes menores como parte da migração (não só reskin).
-- `ContractPreviewCallback.tsx` já teve o beco sem saída corrigido no piloto — só falta aplicar tokens/Button de forma completa (hoje mistura `Button` novo com classes `bg-slate-700` cruas nos estados não tocados).
-- Modal do Especialista (`RequireCalendlyModal`/`RequireGoogleMeetModal`) — migrar pro `Dialog` novo.
-
-### Fatia 3 — Admin
-- `DashboardPage.tsx` sem atalhos de ação rápida (Office tem `ActionCard`, Admin não) — mesma oportunidade de enriquecimento que o Consultor ganhou nesta sessão; desenhar depois, com brainstorm próprio (dados/permissões diferentes: visão cross-role, Base de Dados).
-- `CompaniesPage`/`SpecialistsPage` já usam modal de confirmação estilizado; `OfficeConsultantsPage` usa `window.confirm()` nativo — padronizar todos pro `Dialog` novo.
-- `DatabasePage.tsx` — bem construída isoladamente, mas sem link de nenhuma linha pro CRUD da entidade. Considerar cross-link como parte da fatia.
-- Falta rota `/admin/consultants` (hoje só existe em `/office/consultants`) — decisão de produto a confirmar antes de implementar.
 
 ### Fatia 4 — Escritório
 - `OfficeConsultantsPage.tsx` duplica o convite em lote do Consultor (`BatchInvite` embutido) — considerar reaproveitar o mesmo `Dialog`/fluxo do piloto em vez de manter 2 implementações.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,8 +8,11 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.20",
         "@tailwindcss/vite": "^4.1.14",
         "axios": "^1.12.2",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "framer-motion": "^12.34.2",
         "lucide-react": "^0.546.0",
         "react": "^19.1.1",
@@ -21,6 +24,7 @@
         "react-image-gallery": "^1.4.0",
         "react-router-dom": "^7.9.4",
         "recharts": "^3.3.0",
+        "tailwind-merge": "^3.6.0",
         "tailwindcss": "^4.1.14",
         "zustand": "^5.0.8"
       },
@@ -1003,6 +1007,320 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.20.tgz",
+      "integrity": "sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.16",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.13",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.14",
+        "@radix-ui/react-presence": "1.1.8",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.16.tgz",
+      "integrity": "sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.13.tgz",
+      "integrity": "sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.14.tgz",
+      "integrity": "sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.2.tgz",
@@ -1742,7 +2060,7 @@
       "version": "19.1.9",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -2136,6 +2454,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2285,10 +2615,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2526,6 +2869,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3051,6 +3400,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -4075,6 +4433,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
@@ -4111,6 +4516,28 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/recharts": {
@@ -4286,6 +4713,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {
@@ -4500,6 +4937,49 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.20",
     "@tailwindcss/vite": "^4.1.14",
     "axios": "^1.12.2",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "framer-motion": "^12.34.2",
     "lucide-react": "^0.546.0",
     "react": "^19.1.1",
@@ -23,6 +26,7 @@
     "react-image-gallery": "^1.4.0",
     "react-router-dom": "^7.9.4",
     "recharts": "^3.3.0",
+    "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4.1.14",
     "zustand": "^5.0.8"
   },

--- a/frontend/src/components/calendly/RequireCalendlyModal.tsx
+++ b/frontend/src/components/calendly/RequireCalendlyModal.tsx
@@ -72,7 +72,7 @@ export default function RequireCalendlyModal() {
             conta do Calendly à plataforma.
           </p>
 
-          <p className="text-sm text-muted">
+          <p className="text-sm text-ink-soft">
             Sem a conexão ativa, clientes não conseguem marcar agendamentos com
             você e seu fluxo de negociação fica bloqueado.
           </p>

--- a/frontend/src/components/calendly/RequireCalendlyModal.tsx
+++ b/frontend/src/components/calendly/RequireCalendlyModal.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
-import { Calendar, X } from "lucide-react";
+import { Calendar } from "lucide-react";
 import { useAuth } from "../../store/authStateManager";
 import {
   getCalendlyOAuthStatus,
   getCalendlyAuthorizeUrl,
 } from "../../services/appointments.service";
+import { Dialog, DialogContent } from "../ui/dialog";
+import { Alert } from "../ui/alert";
+import Button from "../ui/button";
 
 const DISMISS_KEY = "calendly-modal-dismissed-session";
 
@@ -52,58 +55,40 @@ export default function RequireCalendlyModal() {
     setOpen(false);
   };
 
-  if (!open) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="w-full max-w-lg bg-white rounded-2xl shadow-2xl overflow-hidden">
-        <div className="bg-linear-to-br from-blue-600 to-indigo-600 p-6 text-white relative">
-          <button
-            onClick={handleDismiss}
-            className="absolute top-3 right-3 text-white/80 hover:text-white p-1 rounded-full hover:bg-white/10"
-            aria-label="Fechar"
-          >
-            <X size={20} />
-          </button>
-          <div className="flex items-center gap-3 mb-2">
-            <Calendar size={28} />
-            <h2 className="text-xl font-bold">Conecte seu Calendly</h2>
-          </div>
-          <p className="text-sm text-blue-50">
+    <Dialog open={open} onOpenChange={(next) => { if (!next) handleDismiss(); }}>
+      <DialogContent
+        open={open}
+        title={
+          <span className="flex items-center gap-2">
+            <Calendar size={20} aria-hidden />
+            Conecte seu Calendly
+          </span>
+        }
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-ink-soft">
             Para que clientes possam agendar reuniões com você, conecte sua
             conta do Calendly à plataforma.
           </p>
-        </div>
 
-        <div className="p-6 space-y-4">
-          <p className="text-sm text-gray-700">
+          <p className="text-sm text-muted">
             Sem a conexão ativa, clientes não conseguem marcar agendamentos com
             você e seu fluxo de negociação fica bloqueado.
           </p>
 
-          {error && (
-            <div className="bg-red-50 text-red-700 text-sm p-3 rounded-lg border border-red-200">
-              {error}
-            </div>
-          )}
+          {error && <Alert variant="danger">{error}</Alert>}
 
           <div className="flex flex-col sm:flex-row gap-3 pt-2">
-            <button
-              onClick={handleConnect}
-              disabled={loading}
-              className="flex-1 px-4 py-3 bg-gray-900 text-white rounded-lg font-medium hover:bg-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <Button onClick={handleConnect} disabled={loading} className="flex-1">
               {loading ? "Abrindo..." : "Conectar agora"}
-            </button>
-            <button
-              onClick={handleDismiss}
-              className="flex-1 px-4 py-3 bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200 transition-colors"
-            >
+            </Button>
+            <Button variant="light" onClick={handleDismiss} className="flex-1">
               Lembrar mais tarde
-            </button>
+            </Button>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/meetings/RequireGoogleMeetModal.tsx
+++ b/frontend/src/components/meetings/RequireGoogleMeetModal.tsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from "react";
-import { Video, X } from "lucide-react";
+import { Video } from "lucide-react";
 import { useAuth } from "../../store/authStateManager";
 import {
   getGoogleMeetStatus,
   getGoogleMeetAuthorizeUrl,
 } from "../../services/googleMeet.service";
+import { Dialog, DialogContent } from "../ui/dialog";
+import { Alert } from "../ui/alert";
+import Button from "../ui/button";
 
 const DISMISS_KEY = "google-meet-modal-dismissed-session";
 
@@ -57,59 +60,41 @@ export default function RequireGoogleMeetModal() {
     setOpen(false);
   };
 
-  if (!open) return null;
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="w-full max-w-lg bg-white rounded-2xl shadow-2xl overflow-hidden">
-        <div className="bg-linear-to-br from-emerald-600 to-teal-600 p-6 text-white relative">
-          <button
-            onClick={handleDismiss}
-            className="absolute top-3 right-3 text-white/80 hover:text-white p-1 rounded-full hover:bg-white/10"
-            aria-label="Fechar"
-          >
-            <X size={20} />
-          </button>
-          <div className="flex items-center gap-3 mb-2">
-            <Video size={28} />
-            <h2 className="text-xl font-bold">Conecte a conta Google Meet</h2>
-          </div>
-          <p className="text-sm text-emerald-50">
+    <Dialog open={open} onOpenChange={(next) => { if (!next) handleDismiss(); }}>
+      <DialogContent
+        open={open}
+        title={
+          <span className="flex items-center gap-2">
+            <Video size={20} aria-hidden />
+            Conecte a conta Google Meet
+          </span>
+        }
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-ink-soft">
             Para que os especialistas possam criar reuniões no Google Meet,
             conecte uma conta Google Workspace à plataforma.
           </p>
-        </div>
 
-        <div className="p-6 space-y-4">
-          <p className="text-sm text-gray-700">
+          <p className="text-sm text-muted">
             Sem uma conta conectada, as reuniões não geram link do Google Meet.
             A conta precisa ser Google Workspace (contas @gmail.com comuns não
             criam reunião via API).
           </p>
 
-          {error && (
-            <div className="bg-red-50 text-red-700 text-sm p-3 rounded-lg border border-red-200">
-              {error}
-            </div>
-          )}
+          {error && <Alert variant="danger">{error}</Alert>}
 
           <div className="flex flex-col sm:flex-row gap-3 pt-2">
-            <button
-              onClick={handleConnect}
-              disabled={loading}
-              className="flex-1 px-4 py-3 bg-gray-900 text-white rounded-lg font-medium hover:bg-black transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <Button onClick={handleConnect} disabled={loading} className="flex-1">
               {loading ? "Abrindo..." : "Conectar agora"}
-            </button>
-            <button
-              onClick={handleDismiss}
-              className="flex-1 px-4 py-3 bg-gray-100 text-gray-700 rounded-lg font-medium hover:bg-gray-200 transition-colors"
-            >
+            </Button>
+            <Button variant="light" onClick={handleDismiss} className="flex-1">
               Lembrar mais tarde
-            </button>
+            </Button>
           </div>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/frontend/src/components/meetings/RequireGoogleMeetModal.tsx
+++ b/frontend/src/components/meetings/RequireGoogleMeetModal.tsx
@@ -77,7 +77,7 @@ export default function RequireGoogleMeetModal() {
             conecte uma conta Google Workspace à plataforma.
           </p>
 
-          <p className="text-sm text-muted">
+          <p className="text-sm text-ink-soft">
             Sem uma conta conectada, as reuniões não geram link do Google Meet.
             A conta precisa ser Google Workspace (contas @gmail.com comuns não
             criam reunião via API).

--- a/frontend/src/components/patterns/BackButton.tsx
+++ b/frontend/src/components/patterns/BackButton.tsx
@@ -1,0 +1,35 @@
+import { ArrowLeft } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { cn } from "../../lib/utils";
+
+export function BackButton({
+  to,
+  label = "Voltar",
+  className,
+}: {
+  to?: string;
+  label?: string;
+  className?: string;
+}) {
+  const navigate = useNavigate();
+  const classes = cn(
+    "inline-flex items-center gap-1.5 text-sm font-semibold text-ink-soft hover:text-ink w-fit",
+    className
+  );
+
+  if (to) {
+    return (
+      <Link to={to} className={classes}>
+        <ArrowLeft size={16} />
+        {label}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" onClick={() => navigate(-1)} className={classes}>
+      <ArrowLeft size={16} />
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/patterns/EmptyState.tsx
+++ b/frontend/src/components/patterns/EmptyState.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+export interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      className={cn(
+        "text-center py-12 px-4 border border-dashed border-border rounded-lg",
+        className
+      )}
+    >
+      <Icon className="mx-auto mb-3 h-8 w-8 text-subtle" />
+      <p className="font-semibold text-ink">{title}</p>
+      {description && <p className="text-sm text-muted mt-1 mb-4">{description}</p>}
+      {action}
+    </div>
+  );
+}

--- a/frontend/src/components/patterns/PageHeader.tsx
+++ b/frontend/src/components/patterns/PageHeader.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+import { BackButton } from "./BackButton";
+
+export interface PageHeaderProps {
+  title: string;
+  showBack?: boolean;
+  backTo?: string;
+  actions?: ReactNode;
+}
+
+export function PageHeader({ title, showBack = false, backTo, actions }: PageHeaderProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+      <div className="flex flex-col gap-1">
+        {showBack && <BackButton to={backTo} />}
+        <h1 className="text-h1 font-bold text-ink">{title}</h1>
+      </div>
+      {actions && <div className="flex gap-2">{actions}</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/patterns/ProposalStatusBadge.tsx
+++ b/frontend/src/components/patterns/ProposalStatusBadge.tsx
@@ -1,0 +1,36 @@
+import { cn } from "../../lib/utils";
+
+// Status de PROPOSTA (não confundir com status de PROCESSO — StatusBadge).
+// Mesma receita visual (pílula neutra + ponto de cor) por consistência,
+// reaproveitando os mesmos tokens de status já usados no processo:
+// PENDING → âmbar (aguardando, como NEGOTIATION), ACCEPTED → verde (como
+// COMPLETED), REJECTED → vermelho (como REJECTED), COUNTERED → azul (como
+// SCHEDULING) — sem inventar cor nova pra um conceito adjacente.
+const PROPOSAL_STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
+  PENDING: { label: "Aguardando resposta", dot: "bg-status-neg" },
+  ACCEPTED: { label: "Aceita", dot: "bg-status-ok" },
+  REJECTED: { label: "Rejeitada", dot: "bg-status-bad" },
+  COUNTERED: { label: "Contraproposta enviada", dot: "bg-status-sched" },
+};
+
+export function ProposalStatusBadge({
+  status,
+  className,
+}: {
+  status: string;
+  className?: string;
+}) {
+  const config = PROPOSAL_STATUS_CONFIG[status];
+  if (!config) return null;
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-border-soft px-2.5 py-1 text-xs font-semibold text-ink-soft",
+        className
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config.dot)} />
+      {config.label}
+    </span>
+  );
+}

--- a/frontend/src/components/patterns/StatusBadge.tsx
+++ b/frontend/src/components/patterns/StatusBadge.tsx
@@ -1,0 +1,31 @@
+import { cn } from "../../lib/utils";
+
+const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
+  SCHEDULING: { label: "Agendamento", dot: "bg-status-sched" },
+  NEGOTIATION: { label: "Negociação", dot: "bg-status-neg" },
+  PROCESSING_CONTRACT: { label: "Contrato", dot: "bg-status-proc" },
+  DOCUMENTATION: { label: "Documentação", dot: "bg-status-doc" },
+  COMPLETED: { label: "Concluído", dot: "bg-status-ok" },
+  REJECTED: { label: "Rejeitado", dot: "bg-status-bad" },
+};
+
+export function StatusBadge({
+  status,
+  className,
+}: {
+  status: string;
+  className?: string;
+}) {
+  const config = STATUS_CONFIG[status];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-border-soft px-2.5 py-1 text-xs font-semibold text-ink-soft",
+        className
+      )}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", config?.dot ?? "bg-subtle")} />
+      {config?.label ?? status}
+    </span>
+  );
+}

--- a/frontend/src/components/patterns/StatusBadge.tsx
+++ b/frontend/src/components/patterns/StatusBadge.tsx
@@ -1,13 +1,22 @@
 import { cn } from "../../lib/utils";
 
-const STATUS_CONFIG: Record<string, { label: string; dot: string }> = {
-  SCHEDULING: { label: "Agendamento", dot: "bg-status-sched" },
-  NEGOTIATION: { label: "Negociação", dot: "bg-status-neg" },
-  PROCESSING_CONTRACT: { label: "Contrato", dot: "bg-status-proc" },
-  DOCUMENTATION: { label: "Documentação", dot: "bg-status-doc" },
-  COMPLETED: { label: "Concluído", dot: "bg-status-ok" },
-  REJECTED: { label: "Rejeitado", dot: "bg-status-bad" },
-};
+// Um único lugar pra label + cor de cada status de processo — StatusBadge,
+// o gráfico do dashboard (Task 3) e os filtros de ConsultantProcessesPage/
+// ConsultantProcessDetailPage (Tasks 4/5) consomem isto em vez de duplicar
+// o mapa. `hex` deve ficar em sincronia com os tokens --color-status-* em
+// frontend/src/index.css — existe só porque bibliotecas de gráfico (SVG)
+// não conseguem ler classes Tailwind, precisam do valor de cor literal.
+export const PROCESS_STATUS_META = [
+  { value: "SCHEDULING", label: "Agendamento", dot: "bg-status-sched", hex: "#1d4ed8" },
+  { value: "NEGOTIATION", label: "Negociação", dot: "bg-status-neg", hex: "#b45309" },
+  { value: "PROCESSING_CONTRACT", label: "Contrato", dot: "bg-status-proc", hex: "#c2410c" },
+  { value: "DOCUMENTATION", label: "Documentação", dot: "bg-status-doc", hex: "#7e22ce" },
+  { value: "COMPLETED", label: "Concluído", dot: "bg-status-ok", hex: "#15803d" },
+  { value: "REJECTED", label: "Rejeitado", dot: "bg-status-bad", hex: "#b91c1c" },
+] as const;
+
+const STATUS_CONFIG: Record<string, (typeof PROCESS_STATUS_META)[number]> =
+  Object.fromEntries(PROCESS_STATUS_META.map((meta) => [meta.value, meta]));
 
 export function StatusBadge({
   status,

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,0 +1,25 @@
+import type { HTMLAttributes } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const alertVariants = cva("flex gap-3 items-start rounded-md border px-4 py-3 text-sm", {
+  variants: {
+    variant: {
+      success: "bg-status-ok-wash border-status-ok-line text-status-ok",
+      warning: "bg-status-neg-wash border-status-neg-line text-status-neg",
+      danger: "bg-status-bad-wash border-status-bad-line text-status-bad",
+      info: "bg-status-sched-wash border-status-sched-line text-status-sched",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+  },
+});
+
+export interface AlertProps
+  extends HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+export function Alert({ className, variant, ...props }: AlertProps) {
+  return <div role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+}

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes } from "react";
 import { cva, type VariantProps } from "class-variance-authority";
+import { motion, useReducedMotion } from "framer-motion";
 import { cn } from "../../lib/utils";
 
 const alertVariants = cva("flex gap-3 items-start rounded-md border px-4 py-3 text-sm", {
@@ -17,9 +18,19 @@ const alertVariants = cva("flex gap-3 items-start rounded-md border px-4 py-3 te
 });
 
 export interface AlertProps
-  extends HTMLAttributes<HTMLDivElement>,
+  extends Omit<HTMLAttributes<HTMLDivElement>, "onDrag" | "onDragStart" | "onDragEnd" | "onAnimationStart" | "onAnimationEnd">,
     VariantProps<typeof alertVariants> {}
 
 export function Alert({ className, variant, ...props }: AlertProps) {
-  return <div role="alert" className={cn(alertVariants({ variant }), className)} {...props} />;
+  const shouldReduceMotion = useReducedMotion();
+  return (
+    <motion.div
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      initial={{ opacity: 0, y: -4 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: shouldReduceMotion ? 0 : 0.15 }}
+      {...props}
+    />
+  );
 }

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,50 +1,33 @@
-import React from 'react';
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
 
-interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: 'solid' | 'light' | 'muted' | 'brand';
-}
+const buttonVariants = cva(
+  'font-semibold py-2 px-4 rounded-lg cursor-pointer transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95',
+  {
+    variants: {
+      variant: {
+        solid: 'bg-button-solid text-white hover:bg-[--color-button-solid-hover] focus:ring-[--color-button-solid]',
+        light: 'bg-white text-gray-900 border border-gray-300 hover:bg-gray-100 focus:ring-gray-400',
+        muted: 'bg-gray-300 text-gray-900 hover:bg-gray-400 focus:ring-gray-300',
+        brand: 'bg-brand-primary text-brand-primary-fg hover:opacity-90 focus:ring-brand-primary',
+        ghost: 'bg-transparent text-ink-soft hover:bg-border-soft focus:ring-focus-ring',
+        danger: 'bg-status-bad text-white hover:bg-status-bad-hover focus:ring-status-bad',
+      },
+    },
+    defaultVariants: {
+      variant: 'solid',
+    },
+  }
+);
 
-export default function Button({
-  children,
-  className,
-  variant = 'solid',
-  ...props
-}: ButtonProps) {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
 
-  const buttonStyles = `
-    font-semibold py-2 px-4 rounded-lg
-    cursor-pointer transition-all duration-200
-    focus:outline-none focus:ring-2 focus:ring-brand-dark focus:ring-offset-2
-    disabled:opacity-50 disabled:cursor-not-allowed
-    active:scale-95
-  `;
-
-  const variantStyles = {
-    solid: `
-      bg-button-solid text-white
-      hover:bg-[--color-button-solid-hover]
-      focus:ring-[--color-button-solid]`,
-    light: `
-      bg-white text-gray-900 border border-gray-300
-      hover:bg-gray-100
-      focus:ring-gray-400`,
-    muted: `
-      bg-gray-300 text-gray-900
-      hover:bg-gray-400
-      focus:ring-gray-300`,
-    // 'brand' consome os tokens whitelabel — fundo = cor primária do escritório
-    // e texto auto-derivado por contraste WCAG via ThemeProvider.
-    brand: `
-      bg-brand-primary text-brand-primary-fg
-      hover:opacity-90
-      focus:ring-brand-primary`,
-  };
-
+export default function Button({ children, className, variant, ...props }: ButtonProps) {
   return (
-    <button
-      className={`${buttonStyles} ${variantStyles[variant]} ${className}`}
-      {...props}
-    >
+    <button className={cn(buttonVariants({ variant }), className)} {...props}>
       {children}
     </button>
   );

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../lib/utils';
 
 const buttonVariants = cva(
-  'font-semibold py-2 px-4 rounded-lg cursor-pointer transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95',
+  'inline-flex items-center justify-center gap-2 font-semibold py-2 px-4 rounded-lg cursor-pointer transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed active:scale-95',
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,14 @@
+import type { HTMLAttributes } from "react";
+import { cn } from "../../lib/utils";
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        "bg-surface border border-border rounded-lg shadow-ds-card p-6",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -9,22 +9,25 @@ export function DialogContent({
   title,
   children,
   className,
+  hideTitle,
 }: {
   title: string;
   children: ReactNode;
   className?: string;
+  hideTitle?: boolean;
 }) {
   return (
     <DialogPrimitive.Portal>
       <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/45" />
       <DialogPrimitive.Content
+        aria-describedby={undefined}
         className={cn(
           "fixed left-1/2 top-1/2 z-50 w-[min(560px,90vw)] max-h-[85vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-lg bg-surface p-6 shadow-ds-modal",
           className
         )}
       >
-        <div className="flex items-center justify-between mb-4">
-          <DialogPrimitive.Title className="text-base font-semibold text-ink">
+        <div className={cn("flex items-center mb-4", hideTitle ? "justify-end" : "justify-between")}>
+          <DialogPrimitive.Title className={cn("text-base font-semibold text-ink", hideTitle && "sr-only")}>
             {title}
           </DialogPrimitive.Title>
           <DialogPrimitive.Close

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,44 +1,67 @@
 import type { ReactNode } from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { X } from "lucide-react";
 import { cn } from "../../lib/utils";
 
 export const Dialog = DialogPrimitive.Root;
 
 export function DialogContent({
+  open,
   title,
   children,
   className,
   hideTitle,
 }: {
+  open: boolean;
   title: string;
   children: ReactNode;
   className?: string;
   hideTitle?: boolean;
 }) {
+  const shouldReduceMotion = useReducedMotion();
+  const duration = shouldReduceMotion ? 0 : 0.15;
+
   return (
-    <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/45" />
-      <DialogPrimitive.Content
-        aria-describedby={undefined}
-        className={cn(
-          "fixed left-1/2 top-1/2 z-50 w-[min(560px,90vw)] max-h-[85vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-lg bg-surface p-6 shadow-ds-modal",
-          className
-        )}
-      >
-        <div className={cn("flex items-center mb-4", hideTitle ? "justify-end" : "justify-between")}>
-          <DialogPrimitive.Title className={cn("text-base font-semibold text-ink", hideTitle && "sr-only")}>
-            {title}
-          </DialogPrimitive.Title>
-          <DialogPrimitive.Close
-            className="text-muted hover:text-ink"
-            aria-label="Fechar"
-          >
-            <X size={18} />
-          </DialogPrimitive.Close>
-        </div>
-        {children}
-      </DialogPrimitive.Content>
-    </DialogPrimitive.Portal>
+    <AnimatePresence>
+      {open && (
+        <DialogPrimitive.Portal forceMount>
+          <DialogPrimitive.Overlay asChild forceMount>
+            <motion.div
+              className="fixed inset-0 z-50 bg-black/45"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration }}
+            />
+          </DialogPrimitive.Overlay>
+          <DialogPrimitive.Content asChild forceMount aria-describedby={undefined}>
+            <motion.div
+              className={cn(
+                "fixed left-1/2 top-1/2 z-50 w-[min(560px,90vw)] max-h-[85vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-lg bg-surface p-6 shadow-ds-modal",
+                className
+              )}
+              initial={{ opacity: 0, scale: 0.96 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.96 }}
+              transition={{ duration }}
+            >
+              <div className={cn("flex items-center mb-4", hideTitle ? "justify-end" : "justify-between")}>
+                <DialogPrimitive.Title className={cn("text-base font-semibold text-ink", hideTitle && "sr-only")}>
+                  {title}
+                </DialogPrimitive.Title>
+                <DialogPrimitive.Close
+                  className="text-muted hover:text-ink"
+                  aria-label="Fechar"
+                >
+                  <X size={18} />
+                </DialogPrimitive.Close>
+              </div>
+              {children}
+            </motion.div>
+          </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+      )}
+    </AnimatePresence>
   );
 }

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -14,7 +14,7 @@ export function DialogContent({
   hideTitle,
 }: {
   open: boolean;
-  title: string;
+  title: ReactNode;
   children: ReactNode;
   className?: string;
   hideTitle?: boolean;

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+export const Dialog = DialogPrimitive.Root;
+
+export function DialogContent({
+  title,
+  children,
+  className,
+}: {
+  title: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/45" />
+      <DialogPrimitive.Content
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 w-[min(560px,90vw)] max-h-[85vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-lg bg-surface p-6 shadow-ds-modal",
+          className
+        )}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <DialogPrimitive.Title className="text-base font-semibold text-ink">
+            {title}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Close
+            className="text-muted hover:text-ink"
+            aria-label="Fechar"
+          >
+            <X size={18} />
+          </DialogPrimitive.Close>
+        </div>
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    className={cn(
+      "w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink placeholder:text-subtle focus:outline-none focus:ring-2 focus:ring-focus-ring",
+      className
+    )}
+    {...props}
+  />
+));
+Input.displayName = "Input";

--- a/frontend/src/hooks/useCalendlyScheduling.ts
+++ b/frontend/src/hooks/useCalendlyScheduling.ts
@@ -100,6 +100,14 @@ export function useCalendlyScheduling({
         return;
       }
 
+      // Calendly já disparou `event_scheduled` com um payload válido — isso É
+      // a fonte da verdade de que o usuário concluiu o agendamento. Marcar
+      // como confirmado AQUI (síncrono, antes do await de rede abaixo) evita
+      // a janela de corrida em que o usuário fecha o popup entre o evento do
+      // Calendly e a resposta do nosso backend — nesse intervalo o registro
+      // NÃO pode ser tratado como abandono e cancelado.
+      confirmedRef.current = true;
+
       try {
         setSyncState("syncing");
         setSyncMessage("Sincronizando seu agendamento...");
@@ -111,15 +119,28 @@ export function useCalendlyScheduling({
           client_observed_at: new Date().toISOString(),
         });
 
-        confirmedRef.current = true;
         setIsModalOpen(false);
         await pollCalendlySyncStatus(pendingAppointmentId);
       } catch (err) {
+        // O agendamento já aconteceu de verdade no Calendly (confirmedRef já
+        // é true) — só a nossa sincronização falhou. Não deixar o usuário
+        // preso num popup fechado/stale: fecha e manda pra Meus Processos,
+        // igual ao fluxo de sucesso, só que com aviso de que pode faltar
+        // atualizar a página.
         console.error("Erro ao sincronizar evento do Calendly:", err);
         setSyncState("error");
         setSyncMessage(
-          "Agendamento criado, mas houve falha na sincronização automática. Você pode seguir em Meus Processos.",
+          "Agendamento confirmado no Calendly, mas houve falha ao sincronizar com a plataforma. Redirecionando para Meus Processos...",
         );
+        setIsModalOpen(false);
+        setTimeout(() => {
+          navigate("/customer/processes", {
+            state: {
+              message:
+                "Agendamento confirmado no Calendly! Se o horário não aparecer imediatamente em Meus Processos, atualize a página em instantes.",
+            },
+          });
+        }, 1000);
       }
     },
   });

--- a/frontend/src/hooks/useCalendlyScheduling.ts
+++ b/frontend/src/hooks/useCalendlyScheduling.ts
@@ -1,0 +1,168 @@
+import { useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCalendlyEventListener } from "react-calendly";
+import {
+  cancelPendingAppointment,
+  getCalendlySyncStatus,
+  registerCalendlyScheduledEvent,
+  type CalendlySyncStatus,
+} from "../services/appointments.service";
+
+export type CalendlySyncState =
+  | "idle"
+  | "waiting_event"
+  | "syncing"
+  | "done"
+  | "error";
+
+interface UseCalendlySchedulingOptions {
+  /** Mensagem exibida na página de destino (Meus Processos) após o redirect de sucesso. */
+  successRedirectMessage: string;
+  /** Efeito colateral extra quando a sincronização confirma o agendamento (ex: atualizar estado local da página). */
+  onSynced?: (status: CalendlySyncStatus) => void;
+}
+
+/**
+ * useCalendlyScheduling
+ *
+ * Ciclo de vida compartilhado do popup do Calendly: abrir, escutar o evento de
+ * agendamento (`calendly.event_scheduled`), registrar no backend, sincronizar
+ * status (com polling) e navegar para "Meus Processos" ao concluir.
+ *
+ * Também cobre o cleanup de abandono: se o usuário fechar o popup sem o evento
+ * ter sido confirmado, cancela o agendamento PENDING criado para evitar
+ * registros órfãos no banco.
+ *
+ * Não cobre: criação do agendamento (payloads diferentes por página) nem
+ * verificações prévias específicas de cada página — isso continua em cada
+ * página, que chama `openPopup` já com o `pendingAppointment.id` em mãos.
+ */
+export function useCalendlyScheduling({
+  successRedirectMessage,
+  onSynced,
+}: UseCalendlySchedulingOptions) {
+  const navigate = useNavigate();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalUrl, setModalUrl] = useState<string | null>(null);
+  const [pendingAppointmentId, setPendingAppointmentId] = useState<
+    string | null
+  >(null);
+  const [syncState, setSyncState] = useState<CalendlySyncState>("idle");
+  const [syncMessage, setSyncMessage] = useState("");
+  const confirmedRef = useRef(false);
+
+  const pollCalendlySyncStatus = async (appointmentId: string) => {
+    const maxAttempts = 8;
+    const intervalMs = 3500;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const status = await getCalendlySyncStatus(appointmentId);
+
+      if (status.calendly_sync_status === "SYNCED" || status.appointment_datetime) {
+        onSynced?.(status);
+        setSyncState("done");
+        setSyncMessage(
+          "Agendamento recebido! Você pode acompanhar os detalhes em Meus Processos.",
+        );
+
+        setTimeout(() => {
+          navigate("/customer/processes", {
+            state: { message: successRedirectMessage },
+          });
+        }, 900);
+        return;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    setSyncState("done");
+    setSyncMessage(
+      "Solicitação registrada. Estamos finalizando a sincronização do horário com o calendário.",
+    );
+  };
+
+  useCalendlyEventListener({
+    onEventScheduled: async (event) => {
+      if (!pendingAppointmentId) {
+        return;
+      }
+
+      const payload = (event as any)?.data?.payload;
+      const eventUri = payload?.event?.uri;
+      const inviteeUri = payload?.invitee?.uri;
+
+      if (!eventUri || !inviteeUri) {
+        setSyncState("error");
+        setSyncMessage(
+          "Não foi possível capturar os dados do agendamento. Verifique seus processos para confirmar.",
+        );
+        return;
+      }
+
+      try {
+        setSyncState("syncing");
+        setSyncMessage("Sincronizando seu agendamento...");
+
+        await registerCalendlyScheduledEvent(pendingAppointmentId, {
+          event_uri: eventUri,
+          invitee_uri: inviteeUri,
+          client_event: "calendly.event_scheduled",
+          client_observed_at: new Date().toISOString(),
+        });
+
+        confirmedRef.current = true;
+        setIsModalOpen(false);
+        await pollCalendlySyncStatus(pendingAppointmentId);
+      } catch (err) {
+        console.error("Erro ao sincronizar evento do Calendly:", err);
+        setSyncState("error");
+        setSyncMessage(
+          "Agendamento criado, mas houve falha na sincronização automática. Você pode seguir em Meus Processos.",
+        );
+      }
+    },
+  });
+
+  /** Seta o agendamento pendente em foco, abre o popup do Calendly. */
+  const openPopup = (appointmentId: string, calendlyUrl: string) => {
+    confirmedRef.current = false;
+    setPendingAppointmentId(appointmentId);
+    setModalUrl(calendlyUrl);
+    setSyncState("waiting_event");
+    setSyncMessage(
+      "Conclua seu agendamento no Calendly para sincronizar automaticamente com a plataforma.",
+    );
+    setIsModalOpen(true);
+  };
+
+  /**
+   * Fecha o popup. Se o usuário abandonou o Calendly sem confirmar o
+   * agendamento (`onEventScheduled` nunca disparou), cancela o agendamento
+   * PENDING para não deixar registro órfão no banco.
+   */
+  const closePopup = async () => {
+    setIsModalOpen(false);
+
+    if (!confirmedRef.current && pendingAppointmentId) {
+      try {
+        await cancelPendingAppointment(pendingAppointmentId);
+      } catch (err) {
+        console.error("Erro ao cancelar agendamento ao fechar modal", err);
+      } finally {
+        setPendingAppointmentId(null);
+        setSyncState("idle");
+        setSyncMessage("");
+      }
+    }
+  };
+
+  return {
+    isModalOpen,
+    modalUrl,
+    syncState,
+    syncMessage,
+    openPopup,
+    closePopup,
+  };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,57 @@
   --color-brand-primary-fg: var(--brand-primary-fg, #FFFFFF);
   --color-brand-secondary: var(--brand-secondary, #1C1C1C);
   --color-brand-secondary-fg: var(--brand-secondary-fg, #FFFFFF);
+
+  /* Design system v2 (ver DESIGN.md) — tokens novos, aditivos.
+     Os tokens acima continuam intactos até a migração das telas
+     existentes (rollout fatiado por área, fora desta spec). */
+  --color-ink: #1c1c1c;
+  --color-ink-soft: #3c3c3c;
+  --color-action: #2c2c2c;
+  --color-action-hover: #1c1c1c;
+  --color-muted: #6b6b6b;
+  --color-subtle: #9a9a9a;
+  --color-border: #d9d9d9;
+  --color-border-soft: #e9e9e9;
+  --color-surface: #ffffff;
+  --color-focus-ring: #1c1c1c;
+
+  --color-status-sched: #1d4ed8;
+  --color-status-sched-wash: #eff6ff;
+  --color-status-sched-line: #bfdbfe;
+
+  --color-status-neg: #b45309;
+  --color-status-neg-wash: #fffbeb;
+  --color-status-neg-line: #fde68a;
+
+  --color-status-proc: #c2410c;
+  --color-status-proc-wash: #fff7ed;
+  --color-status-proc-line: #fed7aa;
+
+  --color-status-doc: #7e22ce;
+  --color-status-doc-wash: #faf5ff;
+  --color-status-doc-line: #e9d5ff;
+
+  --color-status-ok: #15803d;
+  --color-status-ok-wash: #f0fdf4;
+  --color-status-ok-line: #bbf7d0;
+
+  --color-status-bad: #b91c1c;
+  --color-status-bad-wash: #fef2f2;
+  --color-status-bad-line: #fecaca;
+  --color-status-bad-hover: #941414;
+
+  --shadow-ds-card: 0 1px 2px rgba(28,28,28,.06), 0 1px 3px rgba(28,28,28,.08);
+  --shadow-ds-floating: 0 4px 12px rgba(28,28,28,.12);
+  --shadow-ds-modal: 0 10px 30px rgba(0,0,0,.25);
+
+  /* Tipografia (DESIGN.md § Tipografia) — só os 2 papéis usados no piloto
+     (h1/h2); os demais papéis da tabela (display/h3/body/small/label) ficam
+     para quando uma tela real os consumir, na fase de rollout do restante. */
+  --text-h1: 1.625rem;
+  --text-h1--line-height: 1.25;
+  --text-h2: 1.25rem;
+  --text-h2--line-height: 1.3;
 }
 
 @layer components {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,7 @@
   --color-border: #d9d9d9;
   --color-border-soft: #e9e9e9;
   --color-surface: #ffffff;
+  --color-bg: #f5f5f5;
   --color-focus-ring: #1c1c1c;
 
   --color-status-sched: #1d4ed8;

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -141,6 +141,11 @@ export default function Sidebar() {
             icon: <UserCog size={20} />,
           },
           {
+            to: "/office/consultants",
+            label: "Consultores",
+            icon: <Users size={20} />,
+          },
+          {
             to: "/admin/commissions",
             label: "Comissões",
             icon: <Percent size={20} />,

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Settings,
   Percent,
   Database,
+  UserCheck,
 } from "lucide-react";
 import { useContext } from "react";
 import { AppContext } from "../contexts/AppContext";
@@ -185,6 +186,14 @@ export default function Sidebar() {
           },
         );
         break;
+    }
+
+    if (user.role !== "OFFICE") {
+      links.push({
+        to: "/advisor/dashboard",
+        label: "Meus Assessorados",
+        icon: <UserCheck size={20} />,
+      });
     }
   }
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/pages/admin/CommissionsPage.tsx
+++ b/frontend/src/pages/admin/CommissionsPage.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState, type ReactNode } from "react";
 import {
   Percent,
   Save,
-  AlertCircle,
   Check,
   Loader,
   Sliders,
@@ -29,6 +28,9 @@ import {
   type SaleCommission,
 } from "../../services/commissions.service";
 import { openPrintablePdf } from "../../utils/export";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { Card } from "../../components/ui/card";
 
 const brl = (n: number) =>
   n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
@@ -145,17 +147,17 @@ export default function CommissionsPage() {
   return (
     <div className="text-text-main w-full">
       <div className="flex items-center gap-3 mb-6">
-        <Percent className="w-7 h-7 text-slate-700" />
+        <Percent className="w-7 h-7 text-ink-soft" />
         <div>
-          <h1 className="h1-style">Comissões</h1>
-          <p className="text-sm text-gray-500">
+          <h1 className="text-h1 font-bold text-ink">Comissões</h1>
+          <p className="text-sm text-muted">
             Comissão de cada especialista, escritório e da plataforma — e o fluxo
             de cada venda.
           </p>
         </div>
       </div>
 
-      <div className="flex gap-1 border-b border-gray-200 mb-6">
+      <div className="flex gap-1 border-b border-border mb-6">
         <TabButton
           active={tab === "config"}
           onClick={() => setTab("config")}
@@ -176,31 +178,30 @@ export default function CommissionsPage() {
         ) : (
           <>
             {error && (
-              <div className="mb-6 flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
-                <AlertCircle className="w-5 h-5 flex-shrink-0" />
-                <p className="text-sm">{error}</p>
-              </div>
+              <Alert variant="danger" className="mb-6">
+                {error}
+              </Alert>
             )}
 
-            <div className="mb-6 p-4 bg-slate-50 border border-slate-200 rounded-lg text-sm text-slate-600">
+            <Alert variant="info" className="mb-6">
               No modelo aninhado: o <b>especialista</b> leva uma fatia do total
               da comissão; o <b>escritório</b> leva uma fatia do <b>restante</b>;
               e a <b>plataforma</b> fica automaticamente com o que sobra do
               restante (não é configurada aqui).
-            </div>
+            </Alert>
 
-            <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            <Card className="mb-6">
+              <h2 className="text-lg font-semibold text-ink mb-1">
                 Escritórios
               </h2>
-              <p className="text-sm text-gray-500 mb-4">
+              <p className="text-sm text-muted mb-4">
                 Fatia de cada escritório sobre o <b>restante</b> da comissão
                 (depois da fatia do especialista). A plataforma fica com o que
                 sobrar.
               </p>
               <div className="flex flex-col gap-4">
                 {companies.length === 0 ? (
-                  <p className="text-sm text-gray-400">
+                  <p className="text-sm text-subtle">
                     Nenhum escritório cadastrado.
                   </p>
                 ) : (
@@ -209,9 +210,9 @@ export default function CommissionsPage() {
                     return (
                       <div
                         key={company.id}
-                        className="border border-gray-200 rounded-lg p-3"
+                        className="border border-border rounded-lg p-3"
                       >
-                        <p className="font-medium text-gray-800 mb-2">
+                        <p className="font-medium text-ink-soft mb-2">
                           {company.name}
                         </p>
                         <RateRow
@@ -219,7 +220,7 @@ export default function CommissionsPage() {
                           initialRate={officeRate}
                           onSave={(rate) => saveCompanyRate(company.id, rate)}
                         />
-                        <p className="text-xs text-gray-400 mt-2">
+                        <p className="text-xs text-subtle mt-2">
                           → Plataforma fica com {Math.max(0, 100 - officeRate)}% do
                           restante
                         </p>
@@ -228,18 +229,18 @@ export default function CommissionsPage() {
                   })
                 )}
               </div>
-            </section>
+            </Card>
 
-            <section className="bg-white rounded-lg border border-gray-200 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            <Card>
+              <h2 className="text-lg font-semibold text-ink mb-1">
                 Especialistas
               </h2>
-              <p className="text-sm text-gray-500 mb-4">
+              <p className="text-sm text-muted mb-4">
                 Fatia de cada especialista sobre o total da comissão.
               </p>
               <div className="flex flex-col gap-3">
                 {specialists.length === 0 ? (
-                  <p className="text-sm text-gray-400">
+                  <p className="text-sm text-subtle">
                     Nenhum especialista cadastrado.
                   </p>
                 ) : (
@@ -253,7 +254,7 @@ export default function CommissionsPage() {
                   ))
                 )}
               </div>
-            </section>
+            </Card>
           </>
         ))}
 
@@ -279,8 +280,8 @@ function TabButton({
       onClick={onClick}
       className={`flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
         active
-          ? "border-slate-700 text-slate-800"
-          : "border-transparent text-gray-500 hover:text-gray-700"
+          ? "border-ink text-ink"
+          : "border-transparent text-muted hover:text-ink-soft"
       }`}
     >
       {icon}
@@ -292,7 +293,7 @@ function TabButton({
 function CenterLoader() {
   return (
     <div className="flex items-center justify-center min-h-[300px]">
-      <Loader className="w-8 h-8 animate-spin text-gray-400" />
+      <Loader className="w-8 h-8 animate-spin text-subtle" />
     </div>
   );
 }
@@ -313,16 +314,10 @@ function SalesCommissionsTab() {
   }, []);
 
   if (loading) return <CenterLoader />;
-  if (error)
-    return (
-      <div className="flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
-        <AlertCircle className="w-5 h-5 flex-shrink-0" />
-        <p className="text-sm">{error}</p>
-      </div>
-    );
+  if (error) return <Alert variant="danger">{error}</Alert>;
   if (sales.length === 0)
     return (
-      <p className="text-sm text-gray-400 p-4">
+      <p className="text-sm text-subtle p-4">
         Nenhuma venda fechada ainda.
       </p>
     );
@@ -330,22 +325,14 @@ function SalesCommissionsTab() {
   return (
     <div className="flex flex-col gap-5">
       <div className="flex justify-end gap-2">
-        <button
-          type="button"
-          onClick={() => exportSalesCsv(sales)}
-          className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
-        >
+        <Button type="button" variant="light" onClick={() => exportSalesCsv(sales)}>
           <Download className="w-4 h-4" />
           Exportar CSV
-        </button>
-        <button
-          type="button"
-          onClick={() => exportSalesPdf(sales)}
-          className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
-        >
+        </Button>
+        <Button type="button" variant="light" onClick={() => exportSalesPdf(sales)}>
           <FileText className="w-4 h-4" />
           Exportar PDF
-        </button>
+        </Button>
       </div>
       {sales.map((s) => (
         <SaleCard key={s.processId} sale={s} />
@@ -367,27 +354,27 @@ function SaleCard({ sale }: { sale: SaleCommission }) {
     sale.restante > 0 ? (sale.platformValue / sale.restante) * 100 : 0;
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-5">
+    <Card className="p-5">
       <div className="flex flex-wrap items-baseline justify-between gap-2 mb-4">
-        <h3 className="font-semibold text-gray-900">{sale.productLabel}</h3>
-        <span className="text-xs text-gray-400">
+        <h3 className="font-semibold text-ink">{sale.productLabel}</h3>
+        <span className="text-xs text-subtle">
           Cliente {sale.clientName} · Especialista {sale.specialistName}
         </span>
       </div>
 
       <div className="flex flex-wrap gap-x-8 gap-y-1 mb-4 text-sm">
         <div>
-          <span className="text-gray-500">Venda: </span>
-          <span className="font-semibold text-gray-900">
+          <span className="text-muted">Venda: </span>
+          <span className="font-semibold text-ink">
             {brl(sale.saleValue)}
           </span>
         </div>
         <div>
-          <span className="text-gray-500">Comissão total: </span>
-          <span className="font-semibold text-gray-900">
+          <span className="text-muted">Comissão total: </span>
+          <span className="font-semibold text-ink">
             {brl(sale.totalCommission)}
           </span>
-          <span className="text-gray-400">
+          <span className="text-subtle">
             {" "}
             ({sale.totalCommissionRate}% da venda)
           </span>
@@ -403,8 +390,8 @@ function SaleCard({ sale }: { sale: SaleCommission }) {
           color="bg-emerald-500"
         />
 
-        <div className="pl-3 border-l-2 border-gray-200 ml-1 flex flex-col gap-3">
-          <p className="text-xs text-gray-400">
+        <div className="pl-3 border-l-2 border-border ml-1 flex flex-col gap-3">
+          <p className="text-xs text-subtle">
             restante {brl(sale.restante)}
             {!hasOffice && " (sem escritório → 100% plataforma)"}
           </p>
@@ -426,7 +413,7 @@ function SaleCard({ sale }: { sale: SaleCommission }) {
           />
         </div>
       </div>
-    </div>
+    </Card>
   );
 }
 
@@ -445,17 +432,17 @@ function SplitBar({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-      <span className="w-56 min-w-[140px] text-sm text-gray-700">{label}</span>
-      <div className="flex-1 min-w-[120px] h-2.5 bg-gray-100 rounded-full overflow-hidden">
+      <span className="w-56 min-w-[140px] text-sm text-ink-soft">{label}</span>
+      <div className="flex-1 min-w-[120px] h-2.5 bg-border-soft rounded-full overflow-hidden">
         <div
           className={`h-full rounded-full ${color}`}
           style={{ width: `${Math.min(100, Math.max(0, share))}%` }}
         />
       </div>
-      <span className="w-28 text-right text-sm font-medium text-gray-900">
+      <span className="w-28 text-right text-sm font-medium text-ink">
         {brl(value)}
       </span>
-      <span className="w-32 text-right text-xs text-gray-400">
+      <span className="w-32 text-right text-xs text-subtle">
         {Math.round(share)}% {shareLabel}
       </span>
     </div>
@@ -497,8 +484,8 @@ function RateRow({
   };
 
   return (
-    <div className="flex flex-wrap items-center gap-3 bg-gray-50 border border-gray-200 rounded-lg px-4 py-3">
-      <span className="flex-1 min-w-[160px] font-medium text-gray-800">
+    <div className="flex flex-wrap items-center gap-3 bg-border-soft border border-border rounded-lg px-4 py-3">
+      <span className="flex-1 min-w-[160px] font-medium text-ink-soft">
         {label}
       </span>
       <div className="flex items-center gap-2">
@@ -509,28 +496,23 @@ function RateRow({
           max={100}
           value={value}
           onChange={(e) => setValue(e.target.value)}
-          className="w-24 px-2 py-1 border border-gray-300 rounded-md text-right"
+          className="w-24 px-2 py-1 border border-border rounded-md text-right"
         />
-        <span className="text-gray-500 text-sm">%</span>
+        <span className="text-muted text-sm">%</span>
       </div>
-      <button
-        type="button"
-        onClick={handleSave}
-        disabled={!dirty || saving}
-        className="flex items-center gap-1 px-3 py-1.5 text-sm rounded-md bg-slate-700 text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-slate-800"
-      >
+      <Button type="button" onClick={handleSave} disabled={!dirty || saving}>
         {saving ? (
           <Loader className="w-4 h-4 animate-spin" />
         ) : (
           <Save className="w-4 h-4" />
         )}
         Salvar
-      </button>
+      </Button>
       {status === "saved" && (
-        <Check className="w-4 h-4 text-green-600" aria-label="Salvo" />
+        <Check className="w-4 h-4 text-status-ok" aria-label="Salvo" />
       )}
       {status === "error" && (
-        <span className="text-xs text-red-600">Erro ao salvar</span>
+        <span className="text-xs text-status-bad">Erro ao salvar</span>
       )}
     </div>
   );

--- a/frontend/src/pages/admin/CompaniesPage.tsx
+++ b/frontend/src/pages/admin/CompaniesPage.tsx
@@ -12,9 +12,9 @@ import {
 import { adminInviteOffice, officeService, type OfficeClient } from "../../services/office";
 import type { PaginationMeta } from "../../types/types";
 import Button from "../../components/ui/button";
-import EditIcon from "../../assets/icons/edit.svg";
-import TrashIcon from "../../assets/icons/trash.svg";
-import Modal from "../../components/ui/Modal";
+import { Alert } from "../../components/ui/alert";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
 import NewCompanyForm from "./NewCompanyForm";
 import { AppContext } from "../../contexts/AppContext";
 import { resolveCompanyLogo } from "../../utils/branding";
@@ -28,6 +28,8 @@ import {
   Link,
   Copy,
   Check,
+  Pencil,
+  Trash2,
 } from "lucide-react";
 
 // Estado de um painel de consultores expandido por empresa
@@ -288,8 +290,8 @@ export default function CompaniesPage() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex flex-col items-center gap-4">
-          <div className="w-12 h-12 border-3 border-gray-200 border-t-primary rounded-full animate-spin" />
-          <p className="text-gray-600">Carregando empresas...</p>
+          <div className="w-12 h-12 border-3 border-border-soft border-t-primary rounded-full animate-spin" />
+          <p className="text-muted">Carregando empresas...</p>
         </div>
       </div>
     );
@@ -297,23 +299,25 @@ export default function CompaniesPage() {
 
   // Exibe uma mensagem de erro se a busca de dados falhar.
   if (error) {
-    return <p className="text-red-500">{error}</p>;
+    return <Alert variant="danger">{error}</Alert>;
   }
 
 
   return (
     <div className="text-text-main w-full">
       {/* --- CABEÇALHO DA PÁGINA --- */}
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <h1 className="h1-style">Gestão de Escritórios</h1>
-        <Button type="button" onClick={() => setIsNewCompanyModalOpen(true)}>
-          + Novo Escritório
-        </Button>
-      </div>
+      <PageHeader
+        title="Gestão de Escritórios"
+        actions={
+          <Button type="button" onClick={() => setIsNewCompanyModalOpen(true)}>
+            + Novo Escritório
+          </Button>
+        }
+      />
 
       {/* --- TABELA DE ESCRITÓRIOS --- */}
       <div className="p-6 rounded-lg shadow bg-brand-container bg-bg-container overflow-x-auto">
-        <h2 className="h2-style">Escritórios</h2>
+        <h2 className="text-h2 font-semibold text-ink">Escritórios</h2>
         <p className="text-base mb-8 mt-2">
           Lista completa de empresas parceiras
         </p>
@@ -329,7 +333,7 @@ export default function CompaniesPage() {
         {/* Corpo da Lista */}
         <div className="mt-4 flex flex-col gap-4 max-h-[70vh] overflow-y-auto p-2">
           {filteredCompanies.length === 0 ? (
-            <p className="text-center text-gray-500 py-8">
+            <p className="text-center text-muted py-8">
               {searchTerm
                 ? "Nenhuma empresa encontrada com esse termo de busca."
                 : "Nenhuma empresa cadastrada."}
@@ -344,7 +348,7 @@ export default function CompaniesPage() {
               return (
                 <div
                   key={company.id}
-                  className="rounded-lg shadow-sm bg-white overflow-hidden"
+                  className="rounded-lg shadow-sm bg-surface overflow-hidden"
                 >
                   {/* Linha principal da empresa */}
                   <div className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr_auto] gap-3 md:gap-5 items-start md:items-center bg-brand-card p-4 md:p-6">
@@ -352,7 +356,7 @@ export default function CompaniesPage() {
                       {/* Botão expand/collapse */}
                       <button
                         onClick={() => toggleExpand(company.id)}
-                        className="p-1 rounded hover:bg-gray-100 transition-colors"
+                        className="p-1 rounded hover:bg-border-soft transition-colors"
                         title={
                           isExpanded
                             ? "Recolher consultores"
@@ -360,9 +364,9 @@ export default function CompaniesPage() {
                         }
                       >
                         {isExpanded ? (
-                          <ChevronUp className="w-5 h-5 text-gray-500" />
+                          <ChevronUp className="w-5 h-5 text-muted" />
                         ) : (
-                          <ChevronDown className="w-5 h-5 text-gray-500" />
+                          <ChevronDown className="w-5 h-5 text-muted" />
                         )}
                       </button>
                       {(() => {
@@ -374,14 +378,14 @@ export default function CompaniesPage() {
                             className="h-8 w-24 object-contain"
                           />
                         ) : (
-                          <div className="h-8 w-24 flex items-center justify-center bg-gray-200 rounded text-xs text-gray-500">
+                          <div className="h-8 w-24 flex items-center justify-center bg-border-soft rounded text-xs text-muted">
                             Sem Logo
                           </div>
                         );
                       })()}
                       <div>
                         <span className="font-medium">{company.name}</span>
-                        <span className="block text-xs text-gray-400">
+                        <span className="block text-xs text-subtle">
                           {company.cnpj}
                         </span>
                       </div>
@@ -390,11 +394,11 @@ export default function CompaniesPage() {
                     {/* % Escritório (fatia do restante) */}
                     <div>
                       {company.commission_rate != null ? (
-                        <span className="inline-flex items-center gap-1 text-sm font-medium text-emerald-700 bg-emerald-50 px-2.5 py-1 rounded-full">
+                        <span className="inline-flex items-center gap-1 text-sm font-medium text-status-ok bg-status-ok-wash px-2.5 py-1 rounded-full">
                           {company.commission_rate}%
                         </span>
                       ) : (
-                        <span className="text-gray-400 text-sm">
+                        <span className="text-subtle text-sm">
                           Não definida
                         </span>
                       )}
@@ -404,7 +408,7 @@ export default function CompaniesPage() {
                     <div>
                       <button
                         onClick={() => toggleExpand(company.id)}
-                        className="inline-flex items-center gap-1.5 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+                        className="inline-flex items-center gap-1.5 text-sm text-muted hover:text-ink transition-colors"
                       >
                         <Users className="w-4 h-4" />
                         <span className="font-medium">
@@ -414,34 +418,34 @@ export default function CompaniesPage() {
                     </div>
 
                     {/* Ações */}
-                    <div className="flex justify-end items-center gap-4 text-gray-400">
+                    <div className="flex justify-end items-center gap-4 text-subtle">
                       <button
                         title="Convidar gerente do escritório (OFFICE)"
                         onClick={() => openInviteModal(company, "OFFICE")}
-                        className="text-xs font-medium bg-gray-800 text-white px-2 py-1 rounded hover:bg-black"
+                        className="text-xs font-medium bg-action text-white px-2 py-1 rounded hover:bg-ink"
                       >
                         + Gerente
                       </button>
-                      <button onClick={() => setCompanyToEdit(company)}>
-                        <img
-                          src={EditIcon}
-                          alt="Editar"
-                          className="h-6 w-6 cursor-pointer hover:text-gray-600"
-                        />
+                      <button
+                        onClick={() => setCompanyToEdit(company)}
+                        className="p-1.5 rounded hover:bg-border-soft text-ink-soft"
+                        title="Editar"
+                      >
+                        <Pencil size={18} />
                       </button>
-                      <button onClick={() => setCompanyToDelete(company)}>
-                        <img
-                          src={TrashIcon}
-                          alt="Deletar"
-                          className="h-5 w-5 cursor-pointer hover:text-gray-600"
-                        />
+                      <button
+                        onClick={() => setCompanyToDelete(company)}
+                        className="p-1.5 rounded hover:bg-status-bad-wash text-status-bad"
+                        title="Deletar"
+                      >
+                        <Trash2 size={18} />
                       </button>
                     </div>
                   </div>
 
                   {/* Painel expandido: consultores / clientes */}
                   {isExpanded && (
-                    <div className="border-t border-gray-100 bg-gray-50 px-6 py-4">
+                    <div className="border-t border-border-soft bg-border-soft px-6 py-4">
                       {/* Header do painel: abas + botão convidar */}
                       <div className="flex items-center justify-between mb-3">
                         <div className="flex items-center gap-4">
@@ -449,8 +453,8 @@ export default function CompaniesPage() {
                             onClick={() => switchPanelTab(company.id, "consultants")}
                             className={`text-xs font-semibold uppercase tracking-wider pb-1 border-b-2 -mb-px ${
                               activeTab === "consultants"
-                                ? "border-slate-700 text-gray-900"
-                                : "border-transparent text-gray-400 hover:text-gray-600"
+                                ? "border-ink text-ink"
+                                : "border-transparent text-muted hover:text-ink-soft"
                             }`}
                           >
                             Consultores
@@ -459,8 +463,8 @@ export default function CompaniesPage() {
                             onClick={() => switchPanelTab(company.id, "clients")}
                             className={`text-xs font-semibold uppercase tracking-wider pb-1 border-b-2 -mb-px ${
                               activeTab === "clients"
-                                ? "border-slate-700 text-gray-900"
-                                : "border-transparent text-gray-400 hover:text-gray-600"
+                                ? "border-ink text-ink"
+                                : "border-transparent text-muted hover:text-ink-soft"
                             }`}
                           >
                             Clientes
@@ -469,7 +473,7 @@ export default function CompaniesPage() {
                         {activeTab === "consultants" && (
                           <button
                             onClick={() => openInviteModal(company)}
-                            className="inline-flex items-center gap-1.5 text-xs font-medium bg-black text-white px-3 py-1.5 rounded hover:bg-gray-800 transition-colors"
+                            className="inline-flex items-center gap-1.5 text-xs font-medium bg-action text-white px-3 py-1.5 rounded hover:bg-ink transition-colors"
                           >
                             <Link className="w-3.5 h-3.5" />
                             Convidar Consultor
@@ -479,21 +483,21 @@ export default function CompaniesPage() {
 
                       {activeTab === "clients" ? (
                         clientsState?.loading ? (
-                          <div className="flex items-center justify-center py-6 gap-2 text-gray-500">
+                          <div className="flex items-center justify-center py-6 gap-2 text-muted">
                             <Loader2 className="w-5 h-5 animate-spin" />
                             <span className="text-sm">Carregando clientes...</span>
                           </div>
                         ) : clientsState?.error ? (
-                          <p className="text-sm text-red-500 py-4 text-center">
+                          <p className="text-sm text-status-bad py-4 text-center">
                             {clientsState.error}
                           </p>
                         ) : !clientsState || clientsState.clients.length === 0 ? (
-                          <p className="text-sm text-gray-500 py-4 text-center">
+                          <p className="text-sm text-muted py-4 text-center">
                             Nenhum cliente ligado a consultores deste escritório.
                           </p>
                         ) : (
                           <>
-                            <div className="grid grid-cols-[2fr_2fr_2fr_1fr] gap-4 px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                            <div className="grid grid-cols-[2fr_2fr_2fr_1fr] gap-4 px-3 py-2 text-xs font-semibold text-muted uppercase tracking-wider">
                               <div>Cliente</div>
                               <div>E-mail</div>
                               <div>Consultor</div>
@@ -503,20 +507,20 @@ export default function CompaniesPage() {
                               {clientsState.clients.map((client) => (
                                 <div
                                   key={client.id}
-                                  className="grid grid-cols-[2fr_2fr_2fr_1fr] gap-4 items-center px-3 py-3 bg-white rounded-lg border border-gray-100"
+                                  className="grid grid-cols-[2fr_2fr_2fr_1fr] gap-4 items-center px-3 py-3 bg-surface rounded-lg border border-border-soft"
                                 >
-                                  <div className="text-sm font-medium text-gray-900">
+                                  <div className="text-sm font-medium text-ink">
                                     {client.name} {client.surname}
                                   </div>
-                                  <div className="text-sm text-gray-600 truncate">
+                                  <div className="text-sm text-muted truncate">
                                     {client.email}
                                   </div>
-                                  <div className="text-sm text-gray-700">
+                                  <div className="text-sm text-ink-soft">
                                     {client.consultant
                                       ? `${client.consultant.name} ${client.consultant.surname}`
                                       : "—"}
                                   </div>
-                                  <div className="text-xs text-gray-400">
+                                  <div className="text-xs text-subtle">
                                     {client.created_at
                                       ? new Date(client.created_at).toLocaleDateString("pt-BR")
                                       : "—"}
@@ -530,22 +534,22 @@ export default function CompaniesPage() {
                         <>
                       {expandedState.loading &&
                       expandedState.consultants.length === 0 ? (
-                        <div className="flex items-center justify-center py-6 gap-2 text-gray-500">
+                        <div className="flex items-center justify-center py-6 gap-2 text-muted">
                           <Loader2 className="w-5 h-5 animate-spin" />
                           <span className="text-sm">Carregando consultores...</span>
                         </div>
                       ) : expandedState.error ? (
-                        <p className="text-sm text-red-500 py-4 text-center">
+                        <p className="text-sm text-status-bad py-4 text-center">
                           {expandedState.error}
                         </p>
                       ) : expandedState.consultants.length === 0 ? (
-                        <p className="text-sm text-gray-500 py-4 text-center">
+                        <p className="text-sm text-muted py-4 text-center">
                           Nenhum consultor associado a este escritório.
                         </p>
                       ) : (
                         <>
                           {/* Cabeçalho da sub-tabela */}
-                          <div className="grid grid-cols-[2fr_2fr_1fr_1fr] gap-4 px-3 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
+                          <div className="grid grid-cols-[2fr_2fr_1fr_1fr] gap-4 px-3 py-2 text-xs font-semibold text-muted uppercase tracking-wider">
                             <div>Nome</div>
                             <div>E-mail</div>
                             <div>Clientes</div>
@@ -557,25 +561,25 @@ export default function CompaniesPage() {
                             {expandedState.consultants.map((consultant) => (
                               <div
                                 key={consultant.id}
-                                className="grid grid-cols-[2fr_2fr_1fr_1fr] gap-4 items-center px-3 py-3 bg-white rounded-lg border border-gray-100"
+                                className="grid grid-cols-[2fr_2fr_1fr_1fr] gap-4 items-center px-3 py-3 bg-surface rounded-lg border border-border-soft"
                               >
                                 <div>
-                                  <span className="text-sm font-medium text-gray-900">
+                                  <span className="text-sm font-medium text-ink">
                                     {consultant.name} {consultant.surname}
                                   </span>
-                                  <span className="block text-xs text-gray-400">
+                                  <span className="block text-xs text-subtle">
                                     Consultor
                                   </span>
                                 </div>
-                                <div className="text-sm text-gray-600 truncate">
+                                <div className="text-sm text-muted truncate">
                                   {consultant.email}
                                 </div>
                                 <div>
-                                  <span className="text-sm text-gray-700 font-medium">
+                                  <span className="text-sm text-ink-soft font-medium">
                                     {consultant.clients_count ?? 0}
                                   </span>
                                 </div>
-                                <div className="text-xs text-gray-400">
+                                <div className="text-xs text-subtle">
                                   {consultant.created_at
                                     ? new Date(consultant.created_at).toLocaleDateString("pt-BR")
                                     : "—"}
@@ -586,8 +590,8 @@ export default function CompaniesPage() {
 
                           {/* Paginação dos consultores */}
                           {expandedState.pagination.total_pages > 1 && (
-                            <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-200">
-                              <span className="text-xs text-gray-500">
+                            <div className="flex items-center justify-between mt-4 pt-3 border-t border-border">
+                              <span className="text-xs text-muted">
                                 Página {expandedState.pagination.current_page} de{" "}
                                 {expandedState.pagination.total_pages} (
                                 {expandedState.pagination.total}{" "}
@@ -605,7 +609,7 @@ export default function CompaniesPage() {
                                     !expandedState.pagination.has_prev ||
                                     expandedState.loading
                                   }
-                                  className="p-1.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                  className="p-1.5 rounded hover:bg-border-soft disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                                 >
                                   <ChevronLeft className="w-4 h-4" />
                                 </button>
@@ -620,7 +624,7 @@ export default function CompaniesPage() {
                                     !expandedState.pagination.has_next ||
                                     expandedState.loading
                                   }
-                                  className="p-1.5 rounded hover:bg-gray-200 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                  className="p-1.5 rounded hover:bg-border-soft disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                                 >
                                   <ChevronRight className="w-4 h-4" />
                                 </button>
@@ -643,116 +647,125 @@ export default function CompaniesPage() {
       {/* --- MODAIS --- */}
 
       {/* Modal para criar novo escritório ou editar existente */}
-      <Modal
-        isOpen={isNewCompanyModalOpen || !!companyToEdit}
-        onClose={() => {
-          setIsNewCompanyModalOpen(false);
-          setCompanyToEdit(null);
+      <Dialog
+        open={isNewCompanyModalOpen || !!companyToEdit}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsNewCompanyModalOpen(false);
+            setCompanyToEdit(null);
+          }
         }}
       >
-        <NewCompanyForm
-          onSuccess={handleFormSuccess}
-          companyToEdit={companyToEdit}
-        />
-      </Modal>
+        <DialogContent
+          open={isNewCompanyModalOpen || !!companyToEdit}
+          title={companyToEdit ? "Editar Escritório" : "Novo Escritório"}
+          hideTitle
+        >
+          <NewCompanyForm
+            onSuccess={handleFormSuccess}
+            companyToEdit={companyToEdit}
+          />
+        </DialogContent>
+      </Dialog>
 
       {/* --- NOVO MODAL PARA CONFIRMAÇÃO DE EXCLUSÃO --- */}
-      <Modal
-        isOpen={!!companyToDelete}
-        onClose={() => setCompanyToDelete(null)}
-      >
-        <div className="text-center">
-          <h2 className="h2-style mb-4">Confirmar Exclusão</h2>
-          <p className="text-text-secondary mb-8">
-            Tem a certeza que deseja apagar o escritório{" "}
-            <span className="font-bold">{companyToDelete?.name}</span>? Esta
-            ação não pode ser desfeita.
-          </p>
-          <div className="flex justify-center gap-4">
-            <Button onClick={() => setCompanyToDelete(null)}>Cancelar</Button>
-            <Button onClick={handleConfirmDelete}>Confirmar Exclusão</Button>
+      <Dialog open={!!companyToDelete} onOpenChange={(open) => !open && setCompanyToDelete(null)}>
+        <DialogContent open={!!companyToDelete} title="Confirmar Exclusão" hideTitle>
+          <div className="text-center">
+            <h2 className="text-h2 font-semibold text-ink mb-4">Confirmar Exclusão</h2>
+            <p className="text-text-secondary mb-8">
+              Tem a certeza que deseja apagar o escritório{" "}
+              <span className="font-bold">{companyToDelete?.name}</span>? Esta
+              ação não pode ser desfeita.
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button variant="light" onClick={() => setCompanyToDelete(null)}>Cancelar</Button>
+              <Button variant="danger" onClick={handleConfirmDelete}>Confirmar Exclusão</Button>
+            </div>
           </div>
-        </div>
-      </Modal>
+        </DialogContent>
+      </Dialog>
 
       {/* Modal de convite de consultor / gerente */}
-      <Modal isOpen={!!inviteState} onClose={() => setInviteState(null)}>
-        {inviteState && (
-          <div className="space-y-4">
-            <h2 className="h2-style">
-              {inviteState.role === "OFFICE" ? "Convidar Gerente" : "Convidar Consultor"}
-            </h2>
-            <p className="text-sm text-gray-500">
-              Escritório: <strong>{inviteState.companyName}</strong>
-            </p>
+      <Dialog open={!!inviteState} onOpenChange={(open) => !open && setInviteState(null)}>
+        <DialogContent open={!!inviteState} title="Convidar" hideTitle>
+          {inviteState && (
+            <div className="space-y-4">
+              <h2 className="text-h2 font-semibold text-ink">
+                {inviteState.role === "OFFICE" ? "Convidar Gerente" : "Convidar Consultor"}
+              </h2>
+              <p className="text-sm text-muted">
+                Escritório: <strong>{inviteState.companyName}</strong>
+              </p>
 
-            {inviteState.inviteLink ? (
-              <div className="space-y-3">
-                <p className="text-sm text-green-700 font-medium">
-                  Link de convite gerado! Envie para o {inviteState.role === "OFFICE" ? "gerente" : "consultor"}:
-                </p>
-                <div className="flex items-center gap-2 bg-gray-50 border border-gray-200 rounded-md px-3 py-2">
-                  <span className="text-xs text-gray-700 truncate flex-1 font-mono">
-                    {inviteState.inviteLink}
-                  </span>
-                  <button
-                    onClick={handleCopyLink}
-                    className="shrink-0 p-1 rounded hover:bg-gray-200 transition-colors"
-                    title="Copiar link"
-                  >
-                    {inviteState.copied
-                      ? <Check className="w-4 h-4 text-green-600" />
-                      : <Copy className="w-4 h-4 text-gray-500" />}
-                  </button>
+              {inviteState.inviteLink ? (
+                <div className="space-y-3">
+                  <p className="text-sm text-status-ok font-medium">
+                    Link de convite gerado! Envie para o {inviteState.role === "OFFICE" ? "gerente" : "consultor"}:
+                  </p>
+                  <div className="flex items-center gap-2 bg-border-soft border border-border rounded-md px-3 py-2">
+                    <span className="text-xs text-ink-soft truncate flex-1 font-mono">
+                      {inviteState.inviteLink}
+                    </span>
+                    <button
+                      onClick={handleCopyLink}
+                      className="shrink-0 p-1 rounded hover:bg-border-soft transition-colors"
+                      title="Copiar link"
+                    >
+                      {inviteState.copied
+                        ? <Check className="w-4 h-4 text-status-ok" />
+                        : <Copy className="w-4 h-4 text-muted" />}
+                    </button>
+                  </div>
+                  <p className="text-xs text-subtle">
+                    O link expira em 7 dias. Um e-mail também foi enviado automaticamente.
+                  </p>
+                  <div className="flex justify-end pt-2">
+                    <Button type="button" variant="light" onClick={() => setInviteState(null)}>
+                      Fechar
+                    </Button>
+                  </div>
                 </div>
-                <p className="text-xs text-gray-400">
-                  O link expira em 7 dias. Um e-mail também foi enviado automaticamente.
-                </p>
-                <div className="flex justify-end pt-2">
-                  <Button type="button" onClick={() => setInviteState(null)}>
-                    Fechar
-                  </Button>
-                </div>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">
-                    E-mail do {inviteState.role === "OFFICE" ? "gerente" : "consultor"}
-                  </label>
-                  <input
-                    type="email"
-                    value={inviteState.email}
-                    onChange={(e) =>
-                      setInviteState((prev) => prev ? { ...prev, email: e.target.value } : null)
-                    }
-                    placeholder={inviteState.role === "OFFICE" ? "gerente@exemplo.com" : "consultor@exemplo.com"}
-                    className="block w-full px-3 py-2 border border-gray-300 rounded-md"
-                    autoFocus
-                  />
-                </div>
+              ) : (
+                <div className="space-y-4">
+                  <div>
+                    <label className="block text-sm font-medium text-ink-soft mb-1">
+                      E-mail do {inviteState.role === "OFFICE" ? "gerente" : "consultor"}
+                    </label>
+                    <input
+                      type="email"
+                      value={inviteState.email}
+                      onChange={(e) =>
+                        setInviteState((prev) => prev ? { ...prev, email: e.target.value } : null)
+                      }
+                      placeholder={inviteState.role === "OFFICE" ? "gerente@exemplo.com" : "consultor@exemplo.com"}
+                      className="block w-full px-3 py-2 border border-border rounded-md"
+                      autoFocus
+                    />
+                  </div>
 
-                {inviteState.error && (
-                  <p className="text-sm text-red-500">{inviteState.error}</p>
-                )}
+                  {inviteState.error && (
+                    <p className="text-sm text-status-bad">{inviteState.error}</p>
+                  )}
 
-                <div className="flex justify-end gap-3 pt-2">
-                  <Button type="button" onClick={() => setInviteState(null)}>
-                    Cancelar
-                  </Button>
-                  <Button
-                    type="button"
-                    onClick={handleSendInvite}
-                    disabled={inviteState.isLoading}
-                  >
-                    {inviteState.isLoading ? "Gerando..." : "Gerar Convite"}
-                  </Button>
+                  <div className="flex justify-end gap-3 pt-2">
+                    <Button type="button" variant="light" onClick={() => setInviteState(null)}>
+                      Cancelar
+                    </Button>
+                    <Button
+                      type="button"
+                      onClick={handleSendInvite}
+                      disabled={inviteState.isLoading}
+                    >
+                      {inviteState.isLoading ? "Gerando..." : "Gerar Convite"}
+                    </Button>
+                  </div>
                 </div>
-              </div>
-            )}
-          </div>
-        )}
-      </Modal>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -12,11 +12,14 @@ import {
   Cell,
 } from "recharts";
 import { useEffect, useState, useContext } from "react";
+import { Link } from "react-router-dom";
 import {
   getDashboardStats,
   type DashboardStats,
 } from "../../services/dashboard.service";
 import { AppContext } from "../../contexts/AppContext";
+import { Card } from "../../components/ui/card";
+import { PageHeader } from "../../components/patterns/PageHeader";
 
 export default function DashboardPage() {
   const { setSearchTerm } = useContext(AppContext);
@@ -49,151 +52,133 @@ export default function DashboardPage() {
   const salesByMonth = stats?.salesByMonth ?? [];
   const consultantsPerformance = stats?.consultantsPerformance ?? [];
 
+  // Paleta própria do gráfico (identidade visual por consultor) — não é paleta de status, fica como está
   const COLORS = ["#3B82F6", "#1E40AF", "#1E3A8A", "#0C2340", "#051E3E"];
 
   return (
     <div className="w-full">
-      {/* Header */}
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">
-          Seja bem vindo de volta, Administrador!
-        </h1>
-        <p className="text-gray-600">
-          Acompanhe os indicadores de desempenho, processos ativos e a
-          performance dos consultores em tempo real.
-        </p>
-      </div>
+      <PageHeader title="Seja bem vindo de volta, Administrador!" />
 
       {/* Cards de Estatísticas */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 md:gap-6 mb-8">
         {/* Card 1: Processos Ativos - DADOS REAIS */}
-        <div className="bg-gray-300 rounded-lg p-6">
-          <p className="text-gray-700 font-semibold mb-2">Processos Ativos</p>
+        <Card>
+          <p className="text-ink-soft font-semibold mb-2">Processos Ativos</p>
           {isLoading ? (
-            <p className="text-2xl font-bold text-gray-900 mb-2">
-              Carregando...
-            </p>
+            <p className="text-2xl font-bold text-ink mb-2">Carregando...</p>
           ) : (
             <>
-              <p className="text-4xl font-bold text-gray-900 mb-2">
+              <p className="text-4xl font-bold text-ink mb-2">
                 {stats?.activeProcesses || 0}
               </p>
-              <p className="text-sm text-gray-600">Processos em andamento</p>
+              <p className="text-sm text-muted">Processos em andamento</p>
             </>
           )}
-        </div>
+        </Card>
 
         {/* Card 2: Taxa de Conversão - DADOS REAIS */}
-        <div className="bg-gray-300 rounded-lg p-6">
-          <p className="text-gray-700 font-semibold mb-2">Taxa de Conversão</p>
+        <Card>
+          <p className="text-ink-soft font-semibold mb-2">Taxa de Conversão</p>
           {isLoading ? (
-            <p className="text-2xl font-bold text-gray-900 mb-2">
-              Carregando...
-            </p>
+            <p className="text-2xl font-bold text-ink mb-2">Carregando...</p>
           ) : (
             <>
-              <p className="text-4xl font-bold text-gray-900 mb-2">
+              <p className="text-4xl font-bold text-ink mb-2">
                 {stats?.conversionRate || 0}%
               </p>
-              <p className="text-sm text-gray-600">Meta 80%</p>
+              <p className="text-sm text-muted">Meta 80%</p>
             </>
           )}
-        </div>
+        </Card>
 
         {/* Card 3: Escritórios Ativos - DADOS REAIS */}
-        <div className="bg-gray-300 rounded-lg p-6">
-          <p className="text-gray-700 font-semibold mb-2">Escritórios Ativos</p>
+        <Card>
+          <p className="text-ink-soft font-semibold mb-2">
+            Escritórios Ativos
+          </p>
           {isLoading ? (
-            <p className="text-2xl font-bold text-gray-900 mb-2">
-              Carregando...
-            </p>
+            <p className="text-2xl font-bold text-ink mb-2">Carregando...</p>
           ) : (
             <>
-              <p className="text-4xl font-bold text-gray-900 mb-2">
+              <p className="text-4xl font-bold text-ink mb-2">
                 {stats?.activeCompanies || 0}
               </p>
-              <p className="text-sm text-gray-600">Empresas parceiras</p>
+              <p className="text-sm text-muted">Empresas parceiras</p>
             </>
           )}
-        </div>
+        </Card>
 
         {/* Card 4: Especialistas Ativos - DADOS REAIS */}
-        <div className="bg-gray-300 rounded-lg p-6">
-          <p className="text-gray-700 font-semibold mb-2">
+        <Card>
+          <p className="text-ink-soft font-semibold mb-2">
             Especialistas Ativos
           </p>
           {isLoading ? (
-            <p className="text-2xl font-bold text-gray-900 mb-2">
-              Carregando...
-            </p>
+            <p className="text-2xl font-bold text-ink mb-2">Carregando...</p>
           ) : (
             <>
-              <p className="text-4xl font-bold text-gray-900 mb-2">
+              <p className="text-4xl font-bold text-ink mb-2">
                 {specialistsCount}
               </p>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-muted">
                 Carros, Lanchas, Helicópteros
               </p>
             </>
           )}
-        </div>
+        </Card>
 
         {/* Card 5: Clientes Cadastrados - DADOS REAIS */}
-        <div className="bg-gray-300 rounded-lg p-6">
-          <p className="text-gray-700 font-semibold mb-2">
+        <Card>
+          <p className="text-ink-soft font-semibold mb-2">
             Clientes Cadastrados
           </p>
           {isLoading ? (
-            <p className="text-2xl font-bold text-gray-900 mb-2">
-              Carregando...
-            </p>
+            <p className="text-2xl font-bold text-ink mb-2">Carregando...</p>
           ) : (
             <>
-              <p className="text-4xl font-bold text-gray-900 mb-2">
+              <p className="text-4xl font-bold text-ink mb-2">
                 {stats?.totalClients || 0}
               </p>
-              <p className="text-sm text-gray-600">Total na plataforma</p>
+              <p className="text-sm text-muted">Total na plataforma</p>
             </>
           )}
-        </div>
+        </Card>
 
         {/* Card 6: Produtos Cadastrados - DADOS REAIS */}
-        <div className="bg-gray-300 rounded-lg p-6">
-          <p className="text-gray-700 font-semibold mb-2">
+        <Card>
+          <p className="text-ink-soft font-semibold mb-2">
             Produtos Cadastrados
           </p>
           {isLoading ? (
-            <p className="text-2xl font-bold text-gray-900 mb-2">
-              Carregando...
-            </p>
+            <p className="text-2xl font-bold text-ink mb-2">Carregando...</p>
           ) : (
             <>
-              <p className="text-4xl font-bold text-gray-900 mb-2">
+              <p className="text-4xl font-bold text-ink mb-2">
                 {stats?.totalProducts || 0}
               </p>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-muted">
                 {stats?.productsByType.cars ?? 0} carros ·{" "}
                 {stats?.productsByType.boats ?? 0} embarcações ·{" "}
                 {stats?.productsByType.aircrafts ?? 0} aeronaves
               </p>
             </>
           )}
-        </div>
+        </Card>
       </div>
 
       {/* Gráficos */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         {/* Gráfico de Vendas */}
-        <div className="md:col-span-2 bg-white rounded-lg p-6 shadow-sm border border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Vendas</h2>
+        <Card className="md:col-span-2">
+          <h2 className="text-lg font-semibold text-ink mb-4">Vendas</h2>
           <div className="flex gap-4 mb-4">
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 bg-red-500 rounded-full"></div>
-              <span className="text-sm text-gray-600">Não vendidos</span>
+              <span className="text-sm text-muted">Não vendidos</span>
             </div>
             <div className="flex items-center gap-2">
               <div className="w-3 h-3 bg-green-500 rounded-full"></div>
-              <span className="text-sm text-gray-600">Vendidos</span>
+              <span className="text-sm text-muted">Vendidos</span>
             </div>
           </div>
           <ResponsiveContainer width="100%" height={300}>
@@ -207,15 +192,15 @@ export default function DashboardPage() {
               <Line type="monotone" dataKey="vendidos" stroke="#22C55E" />
             </LineChart>
           </ResponsiveContainer>
-        </div>
+        </Card>
 
         {/* Gráfico de Desempenho por Consultor */}
-        <div className="bg-white rounded-lg p-6 shadow-sm border border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">
+        <Card>
+          <h2 className="text-lg font-semibold text-ink mb-4">
             Desempenho de Vendas por Consultor
           </h2>
           {consultantsPerformance.length === 0 ? (
-            <p className="text-sm text-gray-500">
+            <p className="text-sm text-muted">
               Sem dados suficientes para exibir o desempenho por consultor.
             </p>
           ) : (
@@ -255,13 +240,13 @@ export default function DashboardPage() {
                           backgroundColor: COLORS[index % COLORS.length],
                         }}
                       ></div>
-                      <span className="text-gray-700">{item.name}</span>
+                      <span className="text-ink-soft">{item.name}</span>
                     </div>
                     <div className="flex gap-4">
-                      <span className="text-gray-900 font-semibold">
+                      <span className="text-ink font-semibold">
                         {item.value} vendas
                       </span>
-                      <span className="text-green-600 font-semibold">
+                      <span className="text-status-ok font-semibold">
                         {item.percentage}%
                       </span>
                     </div>
@@ -270,8 +255,26 @@ export default function DashboardPage() {
               </div>
             </>
           )}
-        </div>
+        </Card>
+      </div>
+
+      {/* Atalhos rápidos */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6">
+        <ActionCard to="/admin/companies" label="Gerenciar escritórios" />
+        <ActionCard to="/admin/specialists" label="Gerenciar especialistas" />
+        <ActionCard to="/admin/settings" label="Configurações" />
       </div>
     </div>
+  );
+}
+
+function ActionCard({ to, label }: { to: string; label: string }) {
+  return (
+    <Link
+      to={to}
+      className="block bg-action hover:bg-ink text-white font-medium py-4 px-6 rounded-lg shadow-ds-card text-center"
+    >
+      {label}
+    </Link>
   );
 }

--- a/frontend/src/pages/admin/DatabasePage.tsx
+++ b/frontend/src/pages/admin/DatabasePage.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import {
   Database,
   Loader,
-  AlertCircle,
   ChevronLeft,
   ChevronRight,
   Download,
@@ -16,6 +15,9 @@ import {
   type RecordsPage,
 } from "../../services/admin-database.service";
 import { downloadCsv, openPrintablePdf } from "../../utils/export";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { EmptyState } from "../../components/patterns/EmptyState";
 
 const PAGE_SIZE = 20;
 
@@ -74,16 +76,16 @@ export default function DatabasePage() {
   return (
     <div className="text-text-main w-full">
       <div className="flex items-center gap-3 mb-6">
-        <Database className="w-7 h-7 text-slate-700" />
+        <Database className="w-7 h-7 text-ink-soft" />
         <div>
-          <h1 className="h1-style">Base de dados</h1>
-          <p className="text-sm text-gray-500">
+          <h1 className="text-h1 font-bold text-ink">Base de dados</h1>
+          <p className="text-sm text-muted">
             Visão consolidada — navegue por todas as tabelas da plataforma.
           </p>
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-1 border-b border-gray-200 mb-4">
+      <div className="flex flex-wrap gap-1 border-b border-border mb-4">
         {entities.map((e) => (
           <button
             key={e.key}
@@ -94,8 +96,8 @@ export default function DatabasePage() {
             }}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
               active === e.key
-                ? "border-slate-700 text-slate-800"
-                : "border-transparent text-gray-500 hover:text-gray-700"
+                ? "border-ink text-ink"
+                : "border-transparent text-muted hover:text-ink-soft"
             }`}
           >
             {e.label}
@@ -104,30 +106,30 @@ export default function DatabasePage() {
       </div>
 
       {error && (
-        <div className="mb-4 flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
-          <AlertCircle className="w-5 h-5 flex-shrink-0" />
-          <p className="text-sm">{error}</p>
-        </div>
+        <Alert variant="danger" className="mb-4">
+          {error}
+        </Alert>
       )}
 
       {loading ? (
         <div className="flex items-center justify-center min-h-[300px]">
-          <Loader className="w-8 h-8 animate-spin text-gray-400" />
+          <Loader className="w-8 h-8 animate-spin text-subtle" />
         </div>
       ) : rows.length === 0 ? (
-        <p className="text-sm text-gray-400 p-4">Nenhum registro.</p>
+        <EmptyState icon={Database} title="Nenhum registro." />
       ) : (
         <>
           <div className="flex justify-end gap-2 mb-3">
-            <button
+            <Button
               type="button"
+              variant="light"
               onClick={() => downloadCsv(`${active}.csv`, columns, exportRows())}
-              className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
             >
               <Download className="w-4 h-4" /> CSV
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="light"
               onClick={() =>
                 openPrintablePdf(
                   `Base de dados — ${activeLabel}`,
@@ -135,20 +137,19 @@ export default function DatabasePage() {
                   exportRows(),
                 )
               }
-              className="flex items-center gap-2 px-3 py-1.5 text-sm rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50"
             >
               <FileText className="w-4 h-4" /> PDF
-            </button>
+            </Button>
           </div>
 
-          <div className="overflow-auto border border-gray-200 rounded-lg max-h-[65vh]">
+          <div className="overflow-auto border border-border rounded-lg max-h-[65vh]">
             <table className="min-w-full text-sm">
-              <thead className="bg-gray-50 sticky top-0 z-10">
+              <thead className="bg-border-soft sticky top-0 z-10">
                 <tr>
                   {columns.map((c) => (
                     <th
                       key={c}
-                      className="px-3 py-2 text-left font-medium text-gray-600 whitespace-nowrap"
+                      className="px-3 py-2 text-left font-medium text-muted whitespace-nowrap"
                     >
                       {c}
                     </th>
@@ -157,13 +158,13 @@ export default function DatabasePage() {
               </thead>
               <tbody>
                 {rows.map((row, i) => (
-                  <tr key={i} className="border-t border-gray-100">
+                  <tr key={i} className="border-t border-border-soft">
                     {columns.map((c) => {
                       const text = formatCell(row[c]);
                       return (
                         <td
                           key={c}
-                          className="px-3 py-2 whitespace-nowrap text-gray-700 max-w-[280px] truncate"
+                          className="px-3 py-2 whitespace-nowrap text-ink-soft max-w-[280px] truncate"
                           title={text}
                         >
                           {text}
@@ -176,28 +177,28 @@ export default function DatabasePage() {
             </table>
           </div>
 
-          <div className="flex items-center justify-between mt-3 text-sm text-gray-500">
+          <div className="flex items-center justify-between mt-3 text-sm text-muted">
             <span>{result?.total ?? 0} registros</span>
             <div className="flex items-center gap-2">
-              <button
+              <Button
                 type="button"
+                variant="light"
                 disabled={page <= 1}
                 onClick={() => setPage((p) => p - 1)}
-                className="flex items-center gap-1 px-2 py-1 border border-gray-300 rounded disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 <ChevronLeft className="w-4 h-4" /> Anterior
-              </button>
+              </Button>
               <span>
                 Página {page} de {totalPages}
               </span>
-              <button
+              <Button
                 type="button"
+                variant="light"
                 disabled={page >= totalPages}
                 onClick={() => setPage((p) => p + 1)}
-                className="flex items-center gap-1 px-2 py-1 border border-gray-300 rounded disabled:opacity-40 disabled:cursor-not-allowed"
               >
                 Próxima <ChevronRight className="w-4 h-4" />
-              </button>
+              </Button>
             </div>
           </div>
         </>

--- a/frontend/src/pages/admin/MyCompanyPage.tsx
+++ b/frontend/src/pages/admin/MyCompanyPage.tsx
@@ -6,6 +6,8 @@ import {
   updatePlatformCompany,
 } from "../../services/platform-company.service";
 import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { Card } from "../../components/ui/card";
 
 /**
  * Página "Minha Empresa" - Admin
@@ -101,7 +103,7 @@ export default function MyCompanyPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <Loader className="w-8 h-8 animate-spin text-gray-400" />
+        <Loader className="w-8 h-8 animate-spin text-subtle" />
       </div>
     );
   }
@@ -110,10 +112,10 @@ export default function MyCompanyPage() {
     <div className="max-w-3xl mx-auto px-4 py-8">
       {/* Header */}
       <div className="flex items-center gap-3 mb-8">
-        <Building2 className="w-8 h-8 text-slate-700" />
+        <Building2 className="w-8 h-8 text-ink-soft" />
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Minha Empresa</h1>
-          <p className="text-sm text-gray-500">
+          <h1 className="text-2xl font-bold text-ink">Minha Empresa</h1>
+          <p className="text-sm text-muted">
             Dados da empresa dona da plataforma. Usados automaticamente nos
             contratos.
           </p>
@@ -122,41 +124,41 @@ export default function MyCompanyPage() {
 
       {/* Messages */}
       {error && (
-        <div className="mb-6 flex items-center gap-2 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700">
+        <Alert variant="danger" className="mb-6">
           <AlertCircle className="w-5 h-5 flex-shrink-0" />
-          <p className="text-sm">{error}</p>
-        </div>
+          <p>{error}</p>
+        </Alert>
       )}
 
       {successMessage && (
-        <div className="mb-6 flex items-center gap-2 p-4 bg-green-50 border border-green-200 rounded-lg text-green-700">
+        <Alert variant="success" className="mb-6">
           <Check className="w-5 h-5 flex-shrink-0" />
-          <p className="text-sm">{successMessage}</p>
-        </div>
+          <p>{successMessage}</p>
+        </Alert>
       )}
 
       {/* Form */}
       <form onSubmit={handleSubmit}>
-        <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4 border-b pb-2">
+        <Card className="mb-6">
+          <h2 className="text-h2 font-semibold text-ink border-b border-border-soft pb-2 mb-4">
             Dados Gerais
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-ink-soft mb-1">
                 Razão Social *
               </label>
               <input
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-ink-soft mb-1">
                 CNPJ *
               </label>
               <input
@@ -165,13 +167,13 @@ export default function MyCompanyPage() {
                 onChange={(e) => setCnpj(e.target.value)}
                 maxLength={18}
                 placeholder="00.000.000/0000-00"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-ink-soft mb-1">
                 Endereço
               </label>
               <input
@@ -179,12 +181,12 @@ export default function MyCompanyPage() {
                 value={address}
                 onChange={(e) => setAddress(e.target.value)}
                 placeholder="Av. Paulista, 1000 - São Paulo/SP"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-ink-soft mb-1">
                 CEP
               </label>
               <input
@@ -193,19 +195,19 @@ export default function MyCompanyPage() {
                 onChange={(e) => setCep(e.target.value)}
                 maxLength={9}
                 placeholder="00000-000"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
               />
             </div>
           </div>
-        </section>
+        </Card>
 
-        <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4 border-b pb-2">
+        <Card className="mb-6">
+          <h2 className="text-h2 font-semibold text-ink border-b border-border-soft pb-2 mb-4">
             Dados Bancários
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-ink-soft mb-1">
                 Banco *
               </label>
               <input
@@ -213,13 +215,13 @@ export default function MyCompanyPage() {
                 value={bank}
                 onChange={(e) => setBank(e.target.value)}
                 placeholder="Ex: Banco do Brasil"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-ink-soft mb-1">
                 Agência *
               </label>
               <input
@@ -228,13 +230,13 @@ export default function MyCompanyPage() {
                 onChange={(e) => setAgency(e.target.value)}
                 maxLength={10}
                 placeholder="Ex: 0001"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 required
               />
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-ink-soft mb-1">
                 Conta Corrente *
               </label>
               <input
@@ -243,33 +245,33 @@ export default function MyCompanyPage() {
                 onChange={(e) => setCheckingAccount(e.target.value)}
                 maxLength={20}
                 placeholder="Ex: 12345-6"
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 required
               />
             </div>
           </div>
-        </section>
+        </Card>
 
-        <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4 border-b pb-2">
+        <Card className="mb-6">
+          <h2 className="text-h2 font-semibold text-ink border-b border-border-soft pb-2 mb-4">
             Comissão Padrão
           </h2>
           <div className="max-w-xs">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label className="block text-sm font-medium text-ink-soft mb-1">
               Taxa Padrão de Comissão (%)
             </label>
-            <div className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg text-gray-700">
+            <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-lg text-ink-soft">
               {defaultCommissionRate ? `${defaultCommissionRate}%` : "—"}
             </div>
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted mt-1">
               Edite na aba{" "}
-              <Link to="/admin/commissions" className="text-slate-700 underline">
+              <Link to="/admin/commissions" className="text-ink-soft underline">
                 Comissões
               </Link>
               .
             </p>
           </div>
-        </section>
+        </Card>
 
         <div className="flex justify-end">
           <Button type="submit" disabled={isSaving}>

--- a/frontend/src/pages/admin/NewCompanyForm.tsx
+++ b/frontend/src/pages/admin/NewCompanyForm.tsx
@@ -201,7 +201,7 @@ export default function NewCompanyForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <h2 className="h2-style">
+      <h2 className="text-h2 font-semibold text-ink">
         {companyToEdit ? "Editar Escritório" : "Novo Escritório"}
       </h2>
 

--- a/frontend/src/pages/admin/NewSpecialistForm.tsx
+++ b/frontend/src/pages/admin/NewSpecialistForm.tsx
@@ -29,7 +29,7 @@ export default function NewSpecialistForm({
   if (specialistToEdit) {
     return (
       <div className="space-y-6 text-center">
-        <h2 className="h2-style">Editar Especialista</h2>
+        <h2 className="text-h2 font-semibold text-ink">Editar Especialista</h2>
         <p className="text-text-secondary">
           A edição de especialistas será feita pelo próprio especialista nas
           configurações de perfil.
@@ -77,7 +77,7 @@ export default function NewSpecialistForm({
   if (inviteLink) {
     return (
       <div className="space-y-4">
-        <h2 className="h2-style">Convidar Especialista</h2>
+        <h2 className="text-h2 font-semibold text-ink">Convidar Especialista</h2>
         <p className="text-sm text-green-700 font-medium">
           Link de convite gerado! Envie para o especialista:
         </p>
@@ -112,7 +112,7 @@ export default function NewSpecialistForm({
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
-      <h2 className="h2-style">Convidar Especialista</h2>
+      <h2 className="text-h2 font-semibold text-ink">Convidar Especialista</h2>
       <p className="text-sm text-gray-500">
         O especialista receberá um link para concluir o cadastro (nome, CPF,
         RG, senha e dados bancários).

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Settings, Check, AlertCircle, Save, Video } from "lucide-react";
+import { Settings, Check, AlertCircle, Save, Video, X } from "lucide-react";
 import { getSettings, updateSetting } from "../../services/settings.service";
 import {
   getGoogleMeetStatus,
@@ -7,6 +7,8 @@ import {
   disconnectGoogleMeet,
   type GoogleMeetStatus,
 } from "../../services/googleMeet.service";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
 
 /**
  * Admin Settings Page
@@ -172,67 +174,60 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200 sticky top-0 z-40">
-        <div className="max-w-7xl mx-auto px-4 py-4 sm:px-6 sm:py-6 lg:px-8">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-slate-100 rounded-lg">
-              <Settings size={24} className="text-slate-700" />
-            </div>
-            <div>
-              <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900">
-                Configurações do Sistema
-              </h1>
-              <p className="text-sm text-gray-600 mt-1">
-                Gerencie as configurações gerais da plataforma
-              </p>
-            </div>
+    <div className="text-text-main w-full">
+      <div className="max-w-4xl mx-auto px-4 py-6 sm:px-6 lg:px-8">
+        {/* Header */}
+        <div className="flex items-center gap-3 mb-6">
+          <Settings size={24} className="text-ink-soft" />
+          <div>
+            <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-ink">
+              Configurações do Sistema
+            </h1>
+            <p className="text-sm text-muted mt-1">
+              Gerencie as configurações gerais da plataforma
+            </p>
           </div>
         </div>
-      </div>
 
-      {/* Main Content */}
-      <div className="max-w-4xl mx-auto px-4 py-6 sm:px-6 lg:px-8">
         {/* Success Message */}
         {successMessage && (
-          <div className="mb-6 p-4 bg-green-50 border border-green-200 rounded-lg flex items-center gap-3">
-            <Check size={20} className="text-green-600" />
-            <p className="text-sm text-green-700">{successMessage}</p>
-          </div>
+          <Alert variant="success" className="mb-6">
+            <Check size={20} />
+            <p>{successMessage}</p>
+          </Alert>
         )}
 
         {/* Error Alert */}
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center gap-3">
-            <AlertCircle size={20} className="text-red-600" />
-            <p className="text-sm text-red-700">{error}</p>
+          <Alert variant="danger" className="mb-6">
+            <AlertCircle size={20} />
+            <p className="flex-1">{error}</p>
             <button
               onClick={() => setError(null)}
-              className="ml-auto text-red-600 hover:text-red-800"
+              className="text-status-bad hover:opacity-70"
             >
-              ✕
+              <X size={16} />
             </button>
-          </div>
+          </Alert>
         )}
 
         {/* Loading State */}
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
             <div className="text-center">
-              <div className="inline-block animate-spin rounded-full h-10 w-10 border-b-2 border-slate-700"></div>
-              <p className="mt-4 text-gray-600">Carregando configurações...</p>
+              <div className="inline-block animate-spin rounded-full h-10 w-10 border-b-2 border-ink"></div>
+              <p className="mt-4 text-muted">Carregando configurações...</p>
             </div>
           </div>
         ) : (
           <div className="space-y-6">
             {/* Proposals Settings Section */}
-            <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
-              <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
-                <h2 className="text-lg font-semibold text-gray-900">
+            <div className="bg-surface rounded-lg border border-border shadow-sm overflow-hidden">
+              <div className="px-6 py-4 border-b border-border-soft bg-border-soft">
+                <h2 className="text-lg font-semibold text-ink">
                   Configurações de Propostas
                 </h2>
-                <p className="text-sm text-gray-600 mt-1">
+                <p className="text-sm text-muted mt-1">
                   Configure regras para propostas de negociação
                 </p>
               </div>
@@ -243,11 +238,11 @@ export default function SettingsPage() {
                   <div className="flex-1">
                     <label
                       htmlFor="minimumProposalEnabled"
-                      className="text-sm font-medium text-gray-900"
+                      className="text-sm font-medium text-ink"
                     >
                       Habilitar valor mínimo de proposta
                     </label>
-                    <p className="text-sm text-gray-500 mt-1">
+                    <p className="text-sm text-muted mt-1">
                       Quando ativado, propostas devem ter no mínimo a
                       porcentagem definida abaixo do valor original do produto.
                     </p>
@@ -255,8 +250,8 @@ export default function SettingsPage() {
                   <button
                     onClick={handleToggleMinimumProposal}
                     disabled={isSaving === "minimum_proposal_enabled"}
-                    className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-slate-500 focus:ring-offset-2 ${
-                      minimumProposalEnabled ? "bg-slate-700" : "bg-gray-200"
+                    className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-focus-ring focus:ring-offset-2 ${
+                      minimumProposalEnabled ? "bg-action" : "bg-border"
                     } ${
                       isSaving === "minimum_proposal_enabled"
                         ? "opacity-50"
@@ -275,14 +270,14 @@ export default function SettingsPage() {
 
                 {/* Minimum Proposal Percentage */}
                 {minimumProposalEnabled && (
-                  <div className="pt-4 border-t border-gray-100">
+                  <div className="pt-4 border-t border-border-soft">
                     <label
                       htmlFor="minimumProposalPercentage"
-                      className="block text-sm font-medium text-gray-900 mb-1"
+                      className="block text-sm font-medium text-ink mb-1"
                     >
                       Porcentagem mínima do valor original
                     </label>
-                    <p className="text-sm text-gray-500 mb-3">
+                    <p className="text-sm text-muted mb-3">
                       Propostas devem ser no mínimo este percentual do valor do
                       produto. Por exemplo: 80% significa que uma proposta para
                       um produto de R$ 100.000 deve ser no mínimo R$ 80.000.
@@ -298,16 +293,15 @@ export default function SettingsPage() {
                           }
                           min="0"
                           max="100"
-                          className="w-full px-4 py-2 pr-8 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                          className="w-full px-4 py-2 pr-8 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                         />
-                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500">
+                        <span className="absolute right-3 top-1/2 -translate-y-1/2 text-muted">
                           %
                         </span>
                       </div>
-                      <button
+                      <Button
                         onClick={handleSavePercentage}
                         disabled={isSaving === "minimum_proposal_percentage"}
-                        className="inline-flex items-center gap-2 px-4 py-2 bg-slate-700 text-white rounded-lg font-medium hover:bg-slate-800 transition disabled:opacity-50"
                       >
                         {isSaving === "minimum_proposal_percentage" ? (
                           <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
@@ -315,7 +309,7 @@ export default function SettingsPage() {
                           <Save size={16} />
                         )}
                         Salvar
-                      </button>
+                      </Button>
                     </div>
                   </div>
                 )}
@@ -323,13 +317,13 @@ export default function SettingsPage() {
             </div>
 
             {/* Google Meet Connection Section */}
-            <div className="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden">
-              <div className="px-6 py-4 border-b border-gray-100 bg-gray-50">
-                <h2 className="text-lg font-semibold text-gray-900 flex items-center gap-2">
-                  <Video size={18} className="text-slate-700" />
+            <div className="bg-surface rounded-lg border border-border shadow-sm overflow-hidden">
+              <div className="px-6 py-4 border-b border-border-soft bg-border-soft">
+                <h2 className="text-lg font-semibold text-ink flex items-center gap-2">
+                  <Video size={18} className="text-ink-soft" />
                   Reuniões — Conta Google Meet
                 </h2>
-                <p className="text-sm text-gray-600 mt-1">
+                <p className="text-sm text-muted mt-1">
                   Conecte uma conta Google Workspace para gerar as salas de
                   reunião. A conta precisa ser Workspace (contas @gmail.com
                   comuns não geram link do Meet via API).
@@ -341,20 +335,20 @@ export default function SettingsPage() {
                   <div className="flex-1">
                     {meetStatus?.connected ? (
                       <div className="flex items-center gap-2">
-                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-green-100 text-green-700">
+                        <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-status-ok-wash text-status-ok">
                           <Check size={12} /> Conectado
                         </span>
-                        <span className="text-sm text-gray-700">
+                        <span className="text-sm text-ink-soft">
                           {meetStatus.google_email}
                         </span>
                       </div>
                     ) : (
-                      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+                      <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-border-soft text-ink-soft">
                         Nenhuma conta conectada
                       </span>
                     )}
                     {meetStatus?.last_error && (
-                      <p className="text-sm text-red-600 mt-2">
+                      <p className="text-sm text-status-bad mt-2">
                         Erro na conexão ({meetStatus.last_error}). Reconecte a
                         conta.
                       </p>
@@ -362,50 +356,41 @@ export default function SettingsPage() {
                   </div>
 
                   {meetStatus?.connected ? (
-                    <button
+                    <Button
+                      variant="light"
                       onClick={handleDisconnectMeet}
                       disabled={meetBusy}
-                      className="inline-flex items-center gap-2 px-4 py-2 border border-gray-300 text-gray-700 rounded-lg font-medium hover:bg-gray-50 transition disabled:opacity-50"
                     >
                       Desconectar
-                    </button>
+                    </Button>
                   ) : (
-                    <button
-                      onClick={handleConnectMeet}
-                      disabled={meetBusy}
-                      className="inline-flex items-center gap-2 px-4 py-2 bg-slate-700 text-white rounded-lg font-medium hover:bg-slate-800 transition disabled:opacity-50"
-                    >
+                    <Button onClick={handleConnectMeet} disabled={meetBusy}>
                       {meetBusy ? (
                         <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
                       ) : (
                         <Video size={16} />
                       )}
                       Conectar conta Google
-                    </button>
+                    </Button>
                   )}
                 </div>
               </div>
             </div>
 
             {/* Info Box */}
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <div className="flex items-start gap-3">
-                <AlertCircle
-                  size={20}
-                  className="text-blue-600 flex-shrink-0 mt-0.5"
-                />
-                <div>
-                  <h4 className="text-sm font-medium text-blue-900">
-                    Sobre as configurações
-                  </h4>
-                  <p className="text-sm text-blue-700 mt-1">
-                    As alterações nas configurações são aplicadas imediatamente
-                    para todas as novas negociações. Processos em andamento não
-                    são afetados retroativamente.
-                  </p>
-                </div>
+            <Alert variant="info">
+              <AlertCircle size={20} className="flex-shrink-0 mt-0.5" />
+              <div>
+                <h4 className="text-sm font-medium">
+                  Sobre as configurações
+                </h4>
+                <p className="text-sm mt-1">
+                  As alterações nas configurações são aplicadas imediatamente
+                  para todas as novas negociações. Processos em andamento não
+                  são afetados retroativamente.
+                </p>
               </div>
-            </div>
+            </Alert>
           </div>
         )}
       </div>

--- a/frontend/src/pages/admin/SpecialistsPage.tsx
+++ b/frontend/src/pages/admin/SpecialistsPage.tsx
@@ -6,11 +6,12 @@ import {
 } from "../../services/specialists.service";
 import { getSpecialistDashboardStats } from "../../services/dashboard.service";
 import Button from "../../components/ui/button";
-import EditIcon from "../../assets/icons/edit.svg";
-import TrashIcon from "../../assets/icons/trash.svg";
-import Modal from "../../components/ui/Modal";
+import { Alert } from "../../components/ui/alert";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
 import NewSpecialistForm from "./NewSpecialistForm";
 import { AppContext } from "../../contexts/AppContext";
+import { Pencil, Trash2 } from "lucide-react";
 
 // Interface para armazenar os dados de cada especialista
 interface SpecialistWithStats extends Specialist {
@@ -107,27 +108,29 @@ export default function SpecialistsPage() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex flex-col items-center gap-4">
-          <div className="w-12 h-12 border-3 border-gray-200 border-t-primary rounded-full animate-spin" />
-          <p className="text-gray-600">Carregando especialistas...</p>
+          <div className="w-12 h-12 border-3 border-border-soft border-t-primary rounded-full animate-spin" />
+          <p className="text-muted">Carregando especialistas...</p>
         </div>
       </div>
     );
   }
-  if (error) return <p className="text-red-500">{error}</p>;
+  if (error) return <Alert variant="danger">{error}</Alert>;
 
   return (
     <div className="text-text-main w-full">
       {/* Cabeçalho */}
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <h1 className="h1-style">Gestão de Especialistas</h1>
-        <Button type="button" onClick={() => setIsNewSpecialistModalOpen(true)}>
-          + Novo Especialista
-        </Button>
-      </div>
+      <PageHeader
+        title="Gestão de Especialistas"
+        actions={
+          <Button type="button" onClick={() => setIsNewSpecialistModalOpen(true)}>
+            + Novo Especialista
+          </Button>
+        }
+      />
 
       {/* Tabela */}
       <div className="p-6 rounded-lg shadow bg-brand-container bg-bg-container overflow-x-auto">
-        <h2 className="h2-style">Especialistas</h2>
+        <h2 className="text-h2 font-semibold text-ink">Especialistas</h2>
         <p className="text-base mb-8 mt-2">Lista completa de especialistas</p>
 
         {/* Cabeçalho da lista */}
@@ -142,7 +145,7 @@ export default function SpecialistsPage() {
         {/* Corpo da lista */}
         <div className="mt-4 flex flex-col gap-4 max-h-[70vh] overflow-y-auto p-2">
           {filteredSpecialists.length === 0 ? (
-            <p className="text-center text-gray-500 py-8">
+            <p className="text-center text-muted py-8">
               {searchTerm
                 ? "Nenhum especialista encontrado com esse termo de busca."
                 : "Nenhum especialista cadastrado."}
@@ -152,7 +155,7 @@ export default function SpecialistsPage() {
               return (
                 <div
                   key={specialist.id}
-                  className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr_1fr_auto] gap-3 md:gap-5 items-start md:items-center bg-brand-card p-4 md:p-6 rounded-lg shadow-sm bg-white"
+                  className="grid grid-cols-1 md:grid-cols-[2fr_1fr_1fr_1fr_auto] gap-3 md:gap-5 items-start md:items-center bg-brand-card p-4 md:p-6 rounded-lg shadow-sm bg-surface"
                 >
                   <div className="flex items-center gap-3">
                     <span className="font-normal">
@@ -160,27 +163,27 @@ export default function SpecialistsPage() {
                     </span>
                   </div>
                   <div>
-                    <span className="bg-blue-100 text-blue-800 text-base px-2.5 py-0.5 rounded-full">
+                    <span className="bg-border-soft text-ink-soft text-base px-2.5 py-0.5 rounded-full">
                       {specialist.speciality ?? "-"}
                     </span>
                   </div>
                   <div>{specialist.activeProcesses ?? 0}</div>
                   <div>{specialist.conversionRate ?? 0}%</div>
-                  <div className="flex justify-end items-center gap-4 text-gray-400">
-                    <button onClick={() => setSpecialistToEdit(specialist)}>
-                      <img
-                        src={EditIcon}
-                        alt="Editar"
-                        className="h-6 w-6 cursor-pointer hover:text-gray-600"
-                      />
+                  <div className="flex justify-end items-center gap-4 text-subtle">
+                    <button
+                      onClick={() => setSpecialistToEdit(specialist)}
+                      className="p-1.5 rounded hover:bg-border-soft text-ink-soft"
+                      title="Editar"
+                    >
+                      <Pencil size={18} />
                     </button>
 
-                    <button onClick={() => setSpecialistToDelete(specialist)}>
-                      <img
-                        src={TrashIcon}
-                        alt="Deletar"
-                        className="h-5 w-5 cursor-pointer hover:text-gray-600"
-                      />
+                    <button
+                      onClick={() => setSpecialistToDelete(specialist)}
+                      className="p-1.5 rounded hover:bg-status-bad-wash text-status-bad"
+                      title="Deletar"
+                    >
+                      <Trash2 size={18} />
                     </button>
                   </div>
                 </div>
@@ -191,39 +194,46 @@ export default function SpecialistsPage() {
       </div>
 
       {/* Modal criação/edição */}
-      <Modal
-        isOpen={isNewSpecialistModalOpen || !!specialistToEdit}
-        onClose={() => {
-          setIsNewSpecialistModalOpen(false);
-          setSpecialistToEdit(null);
+      <Dialog
+        open={isNewSpecialistModalOpen || !!specialistToEdit}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsNewSpecialistModalOpen(false);
+            setSpecialistToEdit(null);
+          }
         }}
       >
-        <NewSpecialistForm
-          onSuccess={handleFormSuccess}
-          specialistToEdit={specialistToEdit}
-        />
-      </Modal>
+        <DialogContent
+          open={isNewSpecialistModalOpen || !!specialistToEdit}
+          title={specialistToEdit ? "Editar Especialista" : "Novo Especialista"}
+          hideTitle
+        >
+          <NewSpecialistForm
+            onSuccess={handleFormSuccess}
+            specialistToEdit={specialistToEdit}
+          />
+        </DialogContent>
+      </Dialog>
 
       {/* Modal exclusão */}
-      <Modal
-        isOpen={!!specialistToDelete}
-        onClose={() => setSpecialistToDelete(null)}
-      >
-        <div className="text-center">
-          <h2 className="h2-style mb-4">Confirmar Exclusão</h2>
-          <p className="text-text-secondary mb-8">
-            Tem a certeza que deseja apagar o especialista{" "}
-            <span className="font-bold">{specialistToDelete?.name}</span>? Esta
-            ação não pode ser desfeita.
-          </p>
-          <div className="flex justify-center gap-4">
-            <Button onClick={() => setSpecialistToDelete(null)}>
-              Cancelar
-            </Button>
-            <Button onClick={handleConfirmDelete}>Confirmar Exclusão</Button>
+      <Dialog open={!!specialistToDelete} onOpenChange={(open) => !open && setSpecialistToDelete(null)}>
+        <DialogContent open={!!specialistToDelete} title="Confirmar Exclusão" hideTitle>
+          <div className="text-center">
+            <h2 className="text-h2 font-semibold text-ink mb-4">Confirmar Exclusão</h2>
+            <p className="text-text-secondary mb-8">
+              Tem a certeza que deseja apagar o especialista{" "}
+              <span className="font-bold">{specialistToDelete?.name}</span>? Esta
+              ação não pode ser desfeita.
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button variant="light" onClick={() => setSpecialistToDelete(null)}>
+                Cancelar
+              </Button>
+              <Button variant="danger" onClick={handleConfirmDelete}>Confirmar Exclusão</Button>
+            </div>
           </div>
-        </div>
-      </Modal>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/pages/auth/RegisterConsultantPage.tsx
+++ b/frontend/src/pages/auth/RegisterConsultantPage.tsx
@@ -105,6 +105,9 @@ export default function RegisterConsultantPage() {
         <div className="max-w-md w-full bg-white rounded-lg shadow p-8 text-center">
           <h1 className="text-xl font-bold text-red-600 mb-2">Convite inválido</h1>
           <p className="text-gray-600">{tokenError}</p>
+          <Button onClick={() => navigate("/login")} className="mt-4">
+            Ir para Login
+          </Button>
         </div>
       </div>
     );

--- a/frontend/src/pages/auth/RegisterOfficePage.tsx
+++ b/frontend/src/pages/auth/RegisterOfficePage.tsx
@@ -110,6 +110,9 @@ export default function RegisterOfficePage() {
         <div className="max-w-md w-full bg-white rounded-lg shadow p-8 text-center">
           <h1 className="text-xl font-bold text-red-600 mb-2">Convite inválido</h1>
           <p className="text-gray-600">{tokenError}</p>
+          <Button onClick={() => navigate("/login")} className="mt-4">
+            Ir para Login
+          </Button>
         </div>
       </div>
     );

--- a/frontend/src/pages/auth/RegisterSpecialistPage.tsx
+++ b/frontend/src/pages/auth/RegisterSpecialistPage.tsx
@@ -118,6 +118,9 @@ export default function RegisterSpecialistPage() {
         <div className="max-w-md w-full bg-white rounded-lg shadow p-8 text-center">
           <h1 className="text-xl font-bold text-red-600 mb-2">Convite inválido</h1>
           <p className="text-gray-600">{tokenError}</p>
+          <Button onClick={() => navigate("/login")} className="mt-4">
+            Ir para Login
+          </Button>
         </div>
       </div>
     );

--- a/frontend/src/pages/catalog/CatalogPage.tsx
+++ b/frontend/src/pages/catalog/CatalogPage.tsx
@@ -3,23 +3,19 @@ import { useParams, useNavigate } from "react-router-dom";
 import { getCars } from "../../services/cars.service.ts";
 import { getBoats } from "../../services/boats.service.ts";
 import { getAircrafts } from "../../services/aircrafts.service.ts";
-import type {
-  FiltersAircraftsMeta,
-  FiltersBoatsMeta,
-  FiltersCarMeta,
-  FiltersMeta,
-  PaginationMeta,
-  Product,
-} from "../../types/types.ts";
+import type { PaginationMeta, Product } from "../../types/types.ts";
 import {
   ChevronLeft,
   ChevronRight,
   ChevronsLeft,
   ChevronsRight,
-  FunnelIcon,
+  Filter,
 } from "lucide-react";
 import Button from "../../components/ui/button.tsx";
-import Modal from "../../components/ui/Modal.tsx";
+import { Dialog, DialogContent } from "../../components/ui/dialog.tsx";
+import { Input } from "../../components/ui/input.tsx";
+import { PageHeader } from "../../components/patterns/PageHeader.tsx";
+import { EmptyState } from "../../components/patterns/EmptyState.tsx";
 import ProductCard from "../../components/product/ProductCard";
 import Loading from "../../components/ui/Loading.tsx";
 
@@ -29,6 +25,21 @@ const titles: { [key: string]: string } = {
   boats: "Embarcações",
   aircrafts: "Aeronaves",
 };
+
+// Filtro aplicado pelo cliente no catálogo — só os 6 campos comuns às 3
+// categorias (marca/modelo/ano/preço). Estruturalmente compatível com
+// Partial<FiltersCarMeta>/Partial<FiltersBoatsMeta>/Partial<FiltersAircraftsMeta>,
+// então passa direto pros services sem cast.
+interface ProductFilters {
+  marca?: string;
+  modelo?: string;
+  ano_min?: number;
+  ano_max?: number;
+  preco_min?: number;
+  preco_max?: number;
+}
+
+const EMPTY_FILTERS: ProductFilters = {};
 
 export default function Catalog() {
   // Coleta a categoria passada na rota
@@ -40,13 +51,10 @@ export default function Catalog() {
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
   const [pagination, setPagination] = useState<PaginationMeta | null>(null);
-  const [filter, setFilters] = useState<
-    | FiltersMeta<FiltersCarMeta>
-    | FiltersMeta<FiltersBoatsMeta>
-    | FiltersMeta<FiltersAircraftsMeta>
-    | null
-  >(null);
+  const [filter, setFilter] = useState<ProductFilters | null>(null);
   const [filterModal, setFilterModal] = useState(false);
+  // Rascunho do formulário do modal — só vira o filtro aplicado ao clicar "Aplicar"
+  const [filterDraft, setFilterDraft] = useState<ProductFilters>(EMPTY_FILTERS);
 
   //Consumir a api
   useEffect(() => {
@@ -56,17 +64,30 @@ export default function Catalog() {
       try {
         let data: Product[] = [];
         let pagination: PaginationMeta | null = null;
+        const appliedFilters = filter ?? EMPTY_FILTERS;
         switch (category) {
           case "cars":
-            ({ cars: data, pagination } = await getCars(page));
+            ({ cars: data, pagination } = await getCars(
+              page,
+              20,
+              appliedFilters,
+            ));
             break;
 
           case "boats":
-            ({ boats: data, pagination } = await getBoats(page));
+            ({ boats: data, pagination } = await getBoats(
+              page,
+              20,
+              appliedFilters,
+            ));
             break;
 
           case "aircrafts":
-            ({ aircrafts: data, pagination } = await getAircrafts(page));
+            ({ aircrafts: data, pagination } = await getAircrafts(
+              page,
+              20,
+              appliedFilters,
+            ));
             break;
 
           default:
@@ -103,6 +124,43 @@ export default function Catalog() {
     setPage(1);
   }
 
+  // Abre o modal de filtro, iniciando o rascunho a partir do filtro já aplicado
+  function openFilterModal() {
+    setFilterDraft(filter ?? EMPTY_FILTERS);
+    setFilterModal(true);
+  }
+
+  function updateDraftText(field: "marca" | "modelo", value: string) {
+    setFilterDraft((prev) => ({ ...prev, [field]: value || undefined }));
+  }
+
+  function updateDraftNumber(
+    field: "ano_min" | "ano_max" | "preco_min" | "preco_max",
+    value: string,
+  ) {
+    setFilterDraft((prev) => ({
+      ...prev,
+      [field]: value === "" ? undefined : Number(value),
+    }));
+  }
+
+  // Aplica o rascunho como filtro ativo: fecha o modal, reseta a página e
+  // dispara o refetch (o useEffect já reage à mudança de `filter`)
+  function applyFilters(event: React.FormEvent) {
+    event.preventDefault();
+    setFilter(filterDraft);
+    setPage(1);
+    setFilterModal(false);
+  }
+
+  // Limpa o filtro ativo (não só o rascunho do modal) e volta pra página 1
+  function clearFilters() {
+    setFilterDraft(EMPTY_FILTERS);
+    setFilter(EMPTY_FILTERS);
+    setPage(1);
+    setFilterModal(false);
+  }
+
   // Tela de carregamento
   if (loading) {
     return <Loading size="lg" text="Carregando produtos..." fullScreen />;
@@ -111,16 +169,15 @@ export default function Catalog() {
   const title = titles[category || ""] || "Catálogo";
   return (
     <div className="flex flex-col gap-8 mx-auto w-full">
-      <div className="flex justify-between">
-        <h1 className="text-4xl">{title}</h1>
-        <Button
-          className="bg-secondary text-white rounded-sm px-4 py-1 flex justify-center items-center text-base gap-2"
-          onClick={() => setFilterModal(true)}
-        >
-          <FunnelIcon fill="#FFFFFF" />
-          Filtro
-        </Button>
-      </div>
+      <PageHeader
+        title={title}
+        actions={
+          <Button variant="light" onClick={openFilterModal}>
+            <Filter className="w-4 h-4" />
+            Filtro
+          </Button>
+        }
+      />
 
       {/* Apresentação dos produtos */}
       {products.length > 0 ? (
@@ -148,7 +205,11 @@ export default function Catalog() {
           })}
         </div>
       ) : (
-        <p className="min-h-screen">Nenhum produto encontrado.</p>
+        <EmptyState
+          icon={Filter}
+          title="Nenhum produto encontrado."
+          description="Tente ajustar os filtros de busca."
+        />
       )}
 
       {/* Numeração das páginas*/}
@@ -156,22 +217,34 @@ export default function Catalog() {
         <div className="w-full h-full flex flex-row justify-center items-center gap-2">
           {pagination?.has_prev && (
             <>
-              <button onClick={goFirstPage}>
-                <ChevronsLeft />
+              <button
+                onClick={goFirstPage}
+                className="p-1.5 rounded hover:bg-border-soft text-ink-soft transition-colors"
+              >
+                <ChevronsLeft className="w-5 h-5" />
               </button>
-              <button onClick={goPrevPage}>
-                <ChevronLeft />
+              <button
+                onClick={goPrevPage}
+                className="p-1.5 rounded hover:bg-border-soft text-ink-soft transition-colors"
+              >
+                <ChevronLeft className="w-5 h-5" />
               </button>
             </>
           )}
           <span>{page}</span>
           {pagination?.has_next && (
             <>
-              <button onClick={goNextPage}>
-                <ChevronRight />
+              <button
+                onClick={goNextPage}
+                className="p-1.5 rounded hover:bg-border-soft text-ink-soft transition-colors"
+              >
+                <ChevronRight className="w-5 h-5" />
               </button>
-              <button onClick={goLastPage}>
-                <ChevronsRight />
+              <button
+                onClick={goLastPage}
+                className="p-1.5 rounded hover:bg-border-soft text-ink-soft transition-colors"
+              >
+                <ChevronsRight className="w-5 h-5" />
               </button>
             </>
           )}
@@ -179,15 +252,117 @@ export default function Catalog() {
       )}
 
       {/* Modal de filtros */}
-      <Modal
-        isOpen={filterModal}
-        onClose={() => {
-          setFilters(filter);
-          setFilterModal(false);
-        }}
-      >
-        Inserir informações
-      </Modal>
+      <Dialog open={filterModal} onOpenChange={setFilterModal}>
+        <DialogContent open={filterModal} title="Filtrar catálogo">
+          <form onSubmit={applyFilters} className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label
+                  htmlFor="filter-marca"
+                  className="block text-sm font-medium text-ink-soft mb-1"
+                >
+                  Marca
+                </label>
+                <Input
+                  id="filter-marca"
+                  value={filterDraft.marca ?? ""}
+                  onChange={(e) => updateDraftText("marca", e.target.value)}
+                  placeholder="Ex: Ferrari"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="filter-modelo"
+                  className="block text-sm font-medium text-ink-soft mb-1"
+                >
+                  Modelo
+                </label>
+                <Input
+                  id="filter-modelo"
+                  value={filterDraft.modelo ?? ""}
+                  onChange={(e) => updateDraftText("modelo", e.target.value)}
+                  placeholder="Ex: 488 GTB"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="filter-ano-min"
+                  className="block text-sm font-medium text-ink-soft mb-1"
+                >
+                  Ano mínimo
+                </label>
+                <Input
+                  id="filter-ano-min"
+                  type="number"
+                  value={filterDraft.ano_min ?? ""}
+                  onChange={(e) =>
+                    updateDraftNumber("ano_min", e.target.value)
+                  }
+                  placeholder="Ex: 2018"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="filter-ano-max"
+                  className="block text-sm font-medium text-ink-soft mb-1"
+                >
+                  Ano máximo
+                </label>
+                <Input
+                  id="filter-ano-max"
+                  type="number"
+                  value={filterDraft.ano_max ?? ""}
+                  onChange={(e) =>
+                    updateDraftNumber("ano_max", e.target.value)
+                  }
+                  placeholder="Ex: 2024"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="filter-preco-min"
+                  className="block text-sm font-medium text-ink-soft mb-1"
+                >
+                  Preço mínimo
+                </label>
+                <Input
+                  id="filter-preco-min"
+                  type="number"
+                  value={filterDraft.preco_min ?? ""}
+                  onChange={(e) =>
+                    updateDraftNumber("preco_min", e.target.value)
+                  }
+                  placeholder="R$"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="filter-preco-max"
+                  className="block text-sm font-medium text-ink-soft mb-1"
+                >
+                  Preço máximo
+                </label>
+                <Input
+                  id="filter-preco-max"
+                  type="number"
+                  value={filterDraft.preco_max ?? ""}
+                  onChange={(e) =>
+                    updateDraftNumber("preco_max", e.target.value)
+                  }
+                  placeholder="R$"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 pt-2">
+              <Button type="button" variant="light" onClick={clearFilters}>
+                Limpar filtros
+              </Button>
+              <Button type="submit">Aplicar</Button>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/pages/catalog/CatalogPage.tsx
+++ b/frontend/src/pages/catalog/CatalogPage.tsx
@@ -56,6 +56,17 @@ export default function Catalog() {
   // Rascunho do formulário do modal — só vira o filtro aplicado ao clicar "Aplicar"
   const [filterDraft, setFilterDraft] = useState<ProductFilters>(EMPTY_FILTERS);
 
+  // Reseta filtro e página ao trocar de categoria. A rota é um único
+  // `/catalog/:category` sem `key`, então o React Router não remonta este
+  // componente quando só o param `category` muda (troca via <Link> na
+  // sidebar) — sem isso, um filtro aplicado em "Carros" (ex: marca Ferrari)
+  // continuava ativo ao trocar pra "Embarcações", derrubando a busca por
+  // engano ("Nenhum produto encontrado" sem o cliente saber por quê).
+  useEffect(() => {
+    setFilter(null);
+    setPage(1);
+  }, [category]);
+
   //Consumir a api
   useEffect(() => {
     const fetchData = async () => {

--- a/frontend/src/pages/catalog/ProductPage.tsx
+++ b/frontend/src/pages/catalog/ProductPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { ArrowLeft, Mail, CheckCircle, ExternalLink } from "lucide-react";
-import { PopupModal, useCalendlyEventListener } from "react-calendly";
+import { PopupModal } from "react-calendly";
 import { getCarById, type RawCar } from "../../services/cars.service";
 import { getBoatById, type RawBoat } from "../../services/boats.service";
 import {
@@ -12,17 +12,20 @@ import { getUserById } from "../../services/users.service";
 import {
   checkExistingAppointment,
   createPendingAppointment,
-  getCalendlySyncStatus,
-  registerCalendlyScheduledEvent,
   type Appointment,
 } from "../../services/appointments.service";
 import { getProcessesByClient } from "../../services/processes.service";
 import ProductDetails from "../../components/product/ProductDetails";
 import Loading from "../../components/ui/Loading";
-import Modal from "../../components/ui/Modal";
+import Button from "../../components/ui/button";
+import { Card } from "../../components/ui/card";
+import { Alert } from "../../components/ui/alert";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
 import StartProcessForClientModal from "../consultant/StartProcessForClientModal";
 import { useAuth } from "../../store/authStateManager";
 import { useCheckAppointment } from "../../hooks/useCheckAppointment";
+import { useCalendlyScheduling } from "../../hooks/useCalendlyScheduling";
 import type { Product } from "../../types/types";
 
 interface Specialist {
@@ -62,18 +65,43 @@ export default function ProductPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isCreatingPending, setIsCreatingPending] = useState(false);
-  const [isCalendlyModalOpen, setIsCalendlyModalOpen] = useState(false);
-  const [calendlyModalUrl, setCalendlyModalUrl] = useState<string | null>(null);
-  const [pendingAppointmentId, setPendingAppointmentId] = useState<
-    string | null
-  >(null);
   const [lockedAppointment, setLockedAppointment] =
     useState<Appointment | null>(null);
-  const [calendlySyncState, setCalendlySyncState] = useState<
-    "idle" | "waiting_event" | "syncing" | "done" | "error"
-  >("idle");
-  const [calendlySyncMessage, setCalendlySyncMessage] = useState<string>("");
   const [isStartProcessModalOpen, setIsStartProcessModalOpen] = useState(false);
+  // Aviso de resultado da tentativa de criação do agendamento PENDING, antes
+  // de o popup do Calendly sequer abrir (conflito 409 / falha de rede). A
+  // partir do momento que o popup abre, quem governa o aviso é o hook
+  // (calendlySyncState / calendlySyncMessage).
+  const [creationNotice, setCreationNotice] = useState<{
+    variant: "success" | "danger";
+    message: string;
+  } | null>(null);
+
+  const {
+    isModalOpen: isCalendlyModalOpen,
+    modalUrl: calendlyModalUrl,
+    syncState: calendlySyncState,
+    syncMessage: calendlySyncMessage,
+    openPopup,
+    closePopup,
+  } = useCalendlyScheduling({
+    successRedirectMessage:
+      "Solicitação de agendamento registrada com sucesso! Verifique seus processos.",
+    onSynced: (syncStatus) => {
+      setLockedAppointment((prev) =>
+        prev
+          ? {
+              ...prev,
+              status:
+                syncStatus.status === "PENDING" ? prev.status : syncStatus.status,
+              appointment_datetime:
+                syncStatus.appointment_datetime ?? prev.appointment_datetime,
+              calendly_sync_status: syncStatus.calendly_sync_status,
+            }
+          : prev,
+      );
+    },
+  });
 
   // Hook para verificar agendamentos existentes
   // APENAS dispara verificação após specialist ser carregado com sucesso
@@ -212,84 +240,6 @@ export default function ProductPage() {
     loadProduct();
   }, [productType, id]);
 
-  useCalendlyEventListener({
-    onEventScheduled: async (event) => {
-      if (!pendingAppointmentId) {
-        return;
-      }
-
-      const payload = (event as any)?.data?.payload;
-      const eventUri = payload?.event?.uri;
-      const inviteeUri = payload?.invitee?.uri;
-
-      if (!eventUri || !inviteeUri) {
-        setCalendlySyncState("error");
-        setCalendlySyncMessage(
-          "Não foi possível capturar os dados do agendamento. Verifique seus processos para confirmar.",
-        );
-        return;
-      }
-
-      try {
-        setCalendlySyncState("syncing");
-        setCalendlySyncMessage("Sincronizando seu agendamento...");
-
-        await registerCalendlyScheduledEvent(pendingAppointmentId, {
-          event_uri: eventUri,
-          invitee_uri: inviteeUri,
-          client_event: "calendly.event_scheduled",
-          client_observed_at: new Date().toISOString(),
-        });
-
-        setIsCalendlyModalOpen(false);
-
-        try {
-          const syncStatus = await getCalendlySyncStatus(pendingAppointmentId);
-          setLockedAppointment((prev) =>
-            prev
-              ? {
-                  ...prev,
-                  status:
-                    syncStatus.status === "PENDING"
-                      ? prev.status
-                      : syncStatus.status,
-                  appointment_datetime:
-                    syncStatus.appointment_datetime ??
-                    prev.appointment_datetime,
-                  calendly_sync_status: syncStatus.calendly_sync_status,
-                }
-              : prev,
-          );
-        } catch (statusErr) {
-          console.warn(
-            "Não foi possível consultar status pós-sync:",
-            statusErr,
-          );
-        }
-
-        setCalendlySyncState("done");
-        setCalendlySyncMessage(
-          "Solicitação registrada com sucesso! Redirecionando para Meus Processos...",
-        );
-        redirectToProcesses(
-          "Solicitação de agendamento registrada com sucesso! Verifique seus processos.",
-          700,
-        );
-      } catch (err) {
-        console.error("Erro ao sincronizar evento do Calendly:", err);
-        setCalendlySyncState("error");
-        setCalendlySyncMessage(
-          "Agendamento criado, mas houve falha na sincronização automática. Redirecionando para Meus Processos...",
-        );
-        setIsCalendlyModalOpen(false);
-        redirectToProcesses(
-          "Solicitação criada! Se o horário não aparecer imediatamente, atualize a página de processos em instantes.",
-          1000,
-        );
-      }
-    },
-  });
-
   /**
    * Cria agendamento PENDING e abre Calendly em modal
    */
@@ -306,8 +256,7 @@ export default function ProductPage() {
     }
 
     setIsCreatingPending(true);
-    setCalendlySyncState("idle");
-    setCalendlySyncMessage("");
+    setCreationNotice(null);
     try {
       const clientProcesses = await getProcessesByClient(user.id, 1, 100);
       const activeProcess = clientProcesses.find(
@@ -336,15 +285,8 @@ export default function ProductPage() {
         notes: "Cliente abriu agendamento via popup da plataforma",
       });
 
-      setPendingAppointmentId(pendingAppointment.id);
       setLockedAppointment(pendingAppointment);
-      setCalendlySyncState("waiting_event");
-      setCalendlySyncMessage(
-        "Conclua seu agendamento no Calendly para sincronizar automaticamente com a plataforma.",
-      );
-
-      setCalendlyModalUrl(formattedUrl);
-      setIsCalendlyModalOpen(true);
+      openPopup(pendingAppointment.id, formattedUrl);
     } catch (err: any) {
       if (err.response?.status === 409) {
         try {
@@ -362,17 +304,19 @@ export default function ProductPage() {
         } catch (checkError) {
           console.error("Erro ao recuperar agendamento existente:", checkError);
         }
-        setCalendlySyncState("done");
-        setCalendlySyncMessage(
-          "Você já possui uma solicitação de agendamento para este produto.",
-        );
+        setCreationNotice({
+          variant: "success",
+          message: "Você já possui uma solicitação de agendamento para este produto.",
+        });
         redirectToProcesses(
           "Você já possui uma solicitação de agendamento para este produto.",
         );
       } else {
         console.error("Erro ao criar agendamento pendente:", err);
-        setCalendlySyncState("error");
-        setCalendlySyncMessage("Erro ao criar solicitação de agendamento.");
+        setCreationNotice({
+          variant: "danger",
+          message: "Erro ao criar solicitação de agendamento.",
+        });
       }
     } finally {
       setIsCreatingPending(false);
@@ -463,58 +407,43 @@ export default function ProductPage() {
   if (error || !product) {
     return (
       <div className="flex flex-col items-center justify-center min-h-[60vh] p-6">
-        <p className="text-xl text-gray-600 mb-4">
+        <p className="text-xl text-muted mb-4">
           {error || "Produto não encontrado"}
         </p>
-        <button
-          onClick={handleBackToCatalog}
-          className="flex items-center gap-2 px-4 py-2 bg-black text-white rounded-lg"
-        >
+        <Button onClick={handleBackToCatalog}>
           <ArrowLeft size={18} />
           Voltar ao catálogo
-        </button>
+        </Button>
       </div>
     );
   }
 
   return (
     <div className="p-4 md:p-6 max-w-5xl mx-auto">
-      {/* Header com botão voltar */}
-      <div className="flex items-center gap-4 mb-6">
-        <button
-          onClick={handleBackToCatalog}
-          className="p-2 rounded-full hover:bg-gray-100 transition-colors"
-          aria-label="Voltar ao catálogo"
-        >
-          <ArrowLeft size={24} />
-        </button>
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-900">
-          {product.marca} {product.modelo}
-        </h1>
-      </div>
+      <PageHeader showBack title={`${product.marca} ${product.modelo}`} />
 
       {/* Detalhes do produto */}
-      <div className="bg-white rounded-lg shadow-lg p-4 md:p-6 mb-6">
+      <Card className="p-4 md:p-6 mb-6">
         <ProductDetails product={product} />
-      </div>
+      </Card>
 
       {/* Seção de agendamento - só aparece se houver especialista */}
       {specialist && (
-        <div className="bg-white rounded-lg shadow-lg p-4 md:p-6">
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">
+        <Card className="p-4 md:p-6">
+          <h2 className="text-xl font-semibold text-ink mb-4">
             Agendar Reunião
           </h2>
 
           {/* Informações do especialista */}
-          <div className="bg-gray-50 rounded-lg p-4 mb-6">
-            <p className="text-sm text-gray-600 mb-1">
+          <div className="bg-border-soft rounded-lg p-4 mb-6">
+            <p className="text-sm text-muted mb-1">
               Especialista responsável
             </p>
-            <p className="font-semibold text-gray-900">
+            <p className="font-semibold text-ink">
               {specialist.name} {specialist.surname}
             </p>
             {specialist.speciality && (
-              <p className="text-sm text-gray-500 capitalize">
+              <p className="text-sm text-muted capitalize">
                 Especialista em {specialist.speciality.toLowerCase()}s
               </p>
             )}
@@ -524,14 +453,14 @@ export default function ProductPage() {
           {!user ? (
             /* Usuário não logado - mostrar botão para cadastro */
             <div className="space-y-4">
-              <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
-                <p className="text-sm text-amber-800">
+              <Alert variant="warning">
+                <p className="text-sm">
                   <strong>Atenção:</strong> Para agendar uma reunião com o
                   especialista, você precisa criar uma conta ou fazer login.
                 </p>
-              </div>
+              </Alert>
 
-              <button
+              <Button
                 onClick={() =>
                   navigate("/register", {
                     state: {
@@ -540,12 +469,12 @@ export default function ProductPage() {
                     },
                   })
                 }
-                className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium"
+                className="w-full"
               >
                 Criar Conta para Agendar
-              </button>
+              </Button>
 
-              <p className="text-sm text-center text-gray-500">
+              <p className="text-sm text-center text-muted">
                 Já tem uma conta?{" "}
                 <button
                   onClick={() =>
@@ -562,52 +491,47 @@ export default function ProductPage() {
           ) : user.role === "CONSULTANT" ? (
             /* Consultor - não agenda em nome próprio; inicia processo para um cliente */
             <div className="space-y-4">
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <p className="text-sm text-blue-800">
+              <Alert variant="info">
+                <p className="text-sm">
                   <strong>Modo Consultor:</strong> Você não pode agendar uma reunião em seu próprio nome. Selecione qual cliente terá o processo criado para este produto.
                 </p>
-              </div>
+              </Alert>
 
-              <button
+              <Button
                 onClick={() => setIsStartProcessModalOpen(true)}
-                className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors font-medium"
+                className="w-full"
               >
                 Iniciar processo para cliente
-              </button>
+              </Button>
             </div>
           ) : user.role !== "CUSTOMER" ? (
             /* SPECIALIST / ADMIN — apenas clientes podem agendar */
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-              <p className="text-sm text-gray-700">
+            <div className="bg-border-soft border border-border rounded-lg p-4">
+              <p className="text-sm text-ink-soft">
                 Apenas clientes podem agendar reuniões a partir do catálogo.
               </p>
             </div>
           ) : isCheckingAppointment ? (
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <p className="text-sm text-blue-800">
-                Verificando agendamentos...
-              </p>
-            </div>
+            <Alert variant="info">
+              <p className="text-sm">Verificando agendamentos...</p>
+            </Alert>
           ) : checkAppointmentError ? (
-            <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
-              <p className="text-sm text-amber-800">
+            <Alert variant="warning">
+              <p className="text-sm">
                 Não foi possível validar seus agendamentos agora. Para evitar
                 duplicidade, atualize a página e tente novamente em instantes.
               </p>
-            </div>
+            </Alert>
           ) : currentAppointment ? (
-            <div className="bg-green-50 border border-green-200 rounded-lg p-4 flex items-start gap-3">
-              <CheckCircle
-                size={20}
-                className="text-green-600 flex-shrink-0 mt-0.5"
-              />
+            <Alert variant="success">
+              <CheckCircle size={20} className="flex-shrink-0 mt-0.5" />
               <div>
-                <p className="font-semibold text-green-900">
+                <p className="font-semibold">
                   {currentAppointment.status === "PENDING"
                     ? "Aguardando confirmação do especialista"
                     : "Agendamento já realizado"}
                 </p>
-                <p className="text-sm text-green-800 mt-1">
+                <p className="text-sm mt-1">
                   {currentAppointment.status === "PENDING"
                     ? "Você já demonstrou interesse neste produto. O especialista irá confirmar seu agendamento em breve."
                     : "Você já possui um agendamento marcado com este especialista para este produto."}
@@ -629,36 +553,43 @@ export default function ProductPage() {
                   )}
                 </p>
               </div>
-            </div>
+            </Alert>
           ) : specialist.calendly_url?.trim() ? (
             /* Com Calendly URL - Botão para acessar e criar PENDING */
             <div className="space-y-4">
-              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-                <p className="text-sm text-blue-800">
+              <Alert variant="info">
+                <p className="text-sm">
                   <strong>Dica:</strong> Clique no botão abaixo para agendar
                   uma reunião no popup. Assim que concluir, a plataforma tenta
                   sincronizar automaticamente seu agendamento.
                 </p>
-              </div>
+              </Alert>
 
-              {calendlySyncState !== "idle" && calendlySyncMessage && (
-                <div
-                  className={`rounded-lg border p-4 text-sm ${
-                    calendlySyncState === "error"
-                      ? "bg-red-50 border-red-200 text-red-800"
-                      : calendlySyncState === "done"
-                        ? "bg-green-50 border-green-200 text-green-800"
-                        : "bg-amber-50 border-amber-200 text-amber-800"
-                  }`}
-                >
-                  {calendlySyncMessage}
-                </div>
+              {creationNotice ? (
+                <Alert variant={creationNotice.variant}>
+                  {creationNotice.message}
+                </Alert>
+              ) : (
+                calendlySyncState !== "idle" &&
+                calendlySyncMessage && (
+                  <Alert
+                    variant={
+                      calendlySyncState === "error"
+                        ? "danger"
+                        : calendlySyncState === "done"
+                          ? "success"
+                          : "warning"
+                    }
+                  >
+                    {calendlySyncMessage}
+                  </Alert>
+                )
               )}
 
-              <button
+              <Button
                 onClick={handleCalendlyClick}
                 disabled={isCreatingPending}
-                className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-green-600 text-white rounded-lg hover:bg-green-700 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full flex items-center justify-center gap-3"
               >
                 {isCreatingPending ? (
                   <>
@@ -671,19 +602,19 @@ export default function ProductPage() {
                     Agendar reunião com o especialista
                   </>
                 )}
-              </button>
+              </Button>
             </div>
           ) : (
             /* Sem Calendly URL - fallback email */
             <div className="space-y-4">
-              <p className="text-gray-600">
+              <p className="text-muted">
                 Este especialista não possui agenda online. Entre em contato por
                 e-mail para agendar uma reunião.
               </p>
-              <button
+              <Button
                 onClick={handleEmailClick}
                 disabled={isCreatingPending}
-                className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-gray-800 text-white rounded-lg hover:bg-gray-900 transition-colors font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full flex items-center justify-center gap-3"
               >
                 {isCreatingPending ? (
                   <>
@@ -696,17 +627,17 @@ export default function ProductPage() {
                     Enviar E-mail para o Especialista
                   </>
                 )}
-              </button>
+              </Button>
             </div>
           )}
-        </div>
+        </Card>
       )}
 
       {calendlyModalUrl && isCalendlyModalOpen && (
         <PopupModal
           url={calendlyModalUrl}
           open={isCalendlyModalOpen}
-          onModalClose={() => setIsCalendlyModalOpen(false)}
+          onModalClose={closePopup}
           rootElement={document.getElementById("root") ?? document.body}
           prefill={{
             name: user ? `${user.name} ${user.surname}`.trim() : undefined,
@@ -717,26 +648,32 @@ export default function ProductPage() {
 
       {/* Modal do Consultor: iniciar processo para cliente */}
       {specialist && product && productType && id && (
-        <Modal
-          isOpen={isStartProcessModalOpen}
-          onClose={() => setIsStartProcessModalOpen(false)}
+        <Dialog
+          open={isStartProcessModalOpen}
+          onOpenChange={setIsStartProcessModalOpen}
         >
-          <StartProcessForClientModal
-            productType={
-              (productType.toUpperCase() === "CARS"
-                ? "CAR"
-                : productType.toUpperCase() === "BOATS"
-                  ? "BOAT"
-                  : productType.toUpperCase() === "AIRCRAFTS"
-                    ? "AIRCRAFT"
-                    : (productType.toUpperCase() as "CAR" | "BOAT" | "AIRCRAFT"))
-            }
-            productId={Number(id)}
-            specialistId={specialist.id}
-            productLabel={`${product.marca} ${product.modelo}`.trim()}
-            onClose={() => setIsStartProcessModalOpen(false)}
-          />
-        </Modal>
+          <DialogContent
+            open={isStartProcessModalOpen}
+            title="Iniciar processo para cliente"
+            hideTitle
+          >
+            <StartProcessForClientModal
+              productType={
+                (productType.toUpperCase() === "CARS"
+                  ? "CAR"
+                  : productType.toUpperCase() === "BOATS"
+                    ? "BOAT"
+                    : productType.toUpperCase() === "AIRCRAFTS"
+                      ? "AIRCRAFT"
+                      : (productType.toUpperCase() as "CAR" | "BOAT" | "AIRCRAFT"))
+              }
+              productId={Number(id)}
+              specialistId={specialist.id}
+              productLabel={`${product.marca} ${product.modelo}`.trim()}
+              onClose={() => setIsStartProcessModalOpen(false)}
+            />
+          </DialogContent>
+        </Dialog>
       )}
     </div>
   );

--- a/frontend/src/pages/consultant/BatchInviteClients.tsx
+++ b/frontend/src/pages/consultant/BatchInviteClients.tsx
@@ -56,7 +56,7 @@ export default function BatchInviteClients({
   };
 
   return (
-    <div className="w-[min(560px,90vw)]">
+    <div className="w-full">
       <h2 className="h2-style mb-1">Convite de clientes em lote</h2>
       <p className="text-sm text-gray-500 mb-4">
         Envie um CSV com as colunas <b>name</b> e <b>email</b>. Cada cliente

--- a/frontend/src/pages/consultant/BatchInviteClients.tsx
+++ b/frontend/src/pages/consultant/BatchInviteClients.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Loader2, Upload } from "lucide-react";
+import { Loader2, Upload, CheckCircle2, XCircle, RefreshCw } from "lucide-react";
 import Button from "../../components/ui/button";
 import {
   createClientInviteJob,
@@ -71,20 +71,18 @@ export default function BatchInviteClients({
           setJob(null);
           setError(null);
         }}
-        className="block w-full text-sm mb-4 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border file:border-gray-300 file:bg-gray-50 file:text-sm"
+        className="block w-full text-sm mb-4 file:mr-3 file:py-1.5 file:px-3 file:rounded-md file:border file:border-border file:bg-border-soft file:text-sm"
       />
 
-      {error && <p className="text-sm text-red-600 mb-3">{error}</p>}
+      {error && (
+        <p className="text-sm text-status-bad mb-3">{error}</p>
+      )}
 
       {!job && (
         <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50"
-          >
+          <Button type="button" variant="light" onClick={onClose}>
             Cancelar
-          </button>
+          </Button>
           <Button type="button" onClick={upload} disabled={!file || uploading}>
             {uploading ? (
               <Loader2 className="w-4 h-4 animate-spin" />
@@ -98,16 +96,25 @@ export default function BatchInviteClients({
 
       {job && (
         <div>
-          <div className="flex flex-wrap gap-4 text-sm mb-3">
-            <span className="text-green-700">✓ {job.successItems} enviados</span>
-            <span className="text-red-600">✗ {job.failedItems} falhas</span>
-            <span className="text-gray-500">
-              ↻ {job.duplicateItems} duplicados
+          <div className="flex flex-wrap items-center gap-4 text-sm mb-3">
+            <span className="flex items-center gap-1 text-status-ok">
+              <CheckCircle2 className="w-4 h-4" /> {job.successItems} enviados
+            </span>
+            <span className="flex items-center gap-1 text-status-bad">
+              <XCircle className="w-4 h-4" /> {job.failedItems} falhas
+            </span>
+            <span className="flex items-center gap-1 text-muted">
+              <RefreshCw className="w-4 h-4" /> {job.duplicateItems} duplicados
             </span>
             {!job.done && (
-              <span className="flex items-center gap-1 text-gray-500">
+              <span className="flex items-center gap-1 text-muted">
                 <Loader2 className="w-4 h-4 animate-spin" /> processando…
               </span>
+            )}
+            {!job.done && (
+              <Button type="button" variant="light" onClick={onClose} className="ml-auto">
+                Fechar (continua em segundo plano)
+              </Button>
             )}
           </div>
 
@@ -123,7 +130,7 @@ export default function BatchInviteClients({
                     <td className="px-2 py-1 whitespace-nowrap">
                       {STATUS_LABEL[it.status] ?? it.status}
                     </td>
-                    <td className="px-2 py-1 text-xs text-red-500">
+                    <td className="px-2 py-1 text-xs text-status-bad">
                       {it.error_message ?? ""}
                     </td>
                   </tr>

--- a/frontend/src/pages/consultant/BatchInviteClients.tsx
+++ b/frontend/src/pages/consultant/BatchInviteClients.tsx
@@ -118,8 +118,8 @@ export default function BatchInviteClients({
             )}
           </div>
 
-          <div className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg">
-            <table className="min-w-full text-sm">
+          <div className="max-h-64 overflow-y-auto overflow-x-auto border border-gray-200 rounded-lg">
+            <table className="min-w-[420px] text-sm">
               <tbody>
                 {job.items.map((it) => (
                   <tr key={it.row_number} className="border-t border-gray-100">

--- a/frontend/src/pages/consultant/ConsultantClientsPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantClientsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   getClients,
@@ -7,13 +7,16 @@ import {
   type Client,
 } from "../../services/consultant.service";
 import Button from "../../components/ui/button";
-import Modal from "../../components/ui/Modal";
+import { Alert } from "../../components/ui/alert";
+import { Card } from "../../components/ui/card";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge } from "../../components/patterns/StatusBadge";
+import { EmptyState } from "../../components/patterns/EmptyState";
 import InviteClientForm from "./InviteClientForm";
 import BatchInviteClients from "./BatchInviteClients";
 import EditClientForm from "./EditClientForm";
-import { ChevronDown, ChevronUp, Loader2 } from "lucide-react";
-import TrashIcon from "../../assets/icons/trash.svg";
-import EditIcon from "../../assets/icons/edit.svg";
+import { ChevronDown, ChevronUp, Loader2, Pencil, Trash2, Plus, Users } from "lucide-react";
 
 type Process = {
   id: string;
@@ -21,24 +24,6 @@ type Process = {
   product_type: string | null;
   created_at: string;
   specialist?: { name: string; surname: string; speciality: string };
-};
-
-const STATUS_LABELS: Record<string, string> = {
-  SCHEDULING: "Agendamento",
-  NEGOTIATION: "Negociação",
-  PROCESSING_CONTRACT: "Contrato",
-  DOCUMENTATION: "Documentação",
-  COMPLETED: "Concluído",
-  REJECTED: "Rejeitado",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  SCHEDULING: "bg-blue-100 text-blue-700",
-  NEGOTIATION: "bg-yellow-100 text-yellow-700",
-  PROCESSING_CONTRACT: "bg-orange-100 text-orange-700",
-  DOCUMENTATION: "bg-purple-100 text-purple-700",
-  COMPLETED: "bg-green-100 text-green-700",
-  REJECTED: "bg-red-100 text-red-700",
 };
 
 function formatCPF(cpf: string | null): string {
@@ -118,147 +103,185 @@ export default function ConsultantClientsPage() {
     );
   }
 
-  if (error) return <p className="text-red-500">{error}</p>;
-
   return (
     <div className="text-text-main w-full">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <h1 className="h1-style">Meus Clientes</h1>
-        <div className="flex gap-2">
-          <Button type="button" onClick={() => setIsBatchModalOpen(true)}>
-            Convite em lote
-          </Button>
-          <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
-            + Convidar Cliente
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title="Meus Clientes"
+        actions={
+          <>
+            <Button type="button" variant="light" onClick={() => setIsBatchModalOpen(true)}>
+              Convite em lote
+            </Button>
+            <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
+              <Plus size={16} />
+              Convidar cliente
+            </Button>
+          </>
+        }
+      />
 
-      <div className="p-6 rounded-lg shadow bg-white">
-        <h2 className="h2-style">Clientes</h2>
-        <p className="text-sm text-gray-500 mt-1 mb-6">
+      {error && (
+        <Alert variant="danger" className="mb-4">
+          {error}
+        </Alert>
+      )}
+
+      <Card>
+        <h2 className="text-h2 font-semibold text-ink mb-1">Clientes</h2>
+        <p className="text-sm text-muted mb-6">
           Expanda um cliente para ver seus processos. Para criar processo, abra o catálogo e clique em "Iniciar processo para cliente" no produto.
         </p>
 
         {clients.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
-            Nenhum cliente ainda. Clique em "+ Convidar Cliente" para começar.
-          </div>
+          <EmptyState
+            icon={Users}
+            title="Nenhum cliente ainda"
+            description='Clique em "Convidar cliente" para começar.'
+            action={
+              <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
+                <Plus size={16} />
+                Convidar cliente
+              </Button>
+            }
+          />
         ) : (
-          <div className="flex flex-col gap-3">
-            {clients.map((client) => {
-              const isExpanded = expandedClient === client.id;
-              const processes = clientProcesses[client.id] ?? [];
-              const isLoadingProc = loadingProcesses === client.id;
+          <div className="overflow-x-auto rounded-lg border border-border">
+            <table className="w-full min-w-[640px] text-sm">
+              <thead>
+                <tr className="border-b border-border">
+                  <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">
+                    Cliente
+                  </th>
+                  <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">
+                    E-mail
+                  </th>
+                  <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">
+                    Cadastro
+                  </th>
+                  <th className="w-24 px-4 py-3" />
+                </tr>
+              </thead>
+              <tbody>
+                {clients.map((client) => {
+                  const isExpanded = expandedClient === client.id;
+                  const processes = clientProcesses[client.id] ?? [];
+                  const isLoadingProc = loadingProcesses === client.id;
 
-              return (
-                <div key={client.id} className="rounded-lg border border-gray-200 overflow-hidden">
-                  {/* Client row */}
-                  <div className="grid grid-cols-[auto_2fr_1.5fr_1fr_auto] gap-4 items-center px-4 py-4 bg-white">
-                    <button
-                      onClick={() => toggleExpand(client.id)}
-                      className="p-1 hover:bg-gray-100 rounded"
-                    >
-                      {isExpanded
-                        ? <ChevronUp className="w-5 h-5 text-gray-500" />
-                        : <ChevronDown className="w-5 h-5 text-gray-500" />
-                      }
-                    </button>
-
-                    <div>
-                      <p className="font-medium text-gray-900">{client.name} {client.surname}</p>
-                      <p className="text-xs text-gray-400">{formatCPF(client.cpf)}</p>
-                    </div>
-
-                    <p className="text-sm text-gray-600 truncate">{client.email}</p>
-
-                    <p className="text-xs text-gray-400">
-                      {client.created_at ? new Date(client.created_at).toLocaleDateString("pt-BR") : "-"}
-                    </p>
-
-                    <div className="flex items-center gap-2">
-                      <button onClick={() => setClientToEdit(client)} className="p-1.5 hover:bg-gray-100 rounded">
-                        <img src={EditIcon} alt="Editar" className="h-4 w-4" />
-                      </button>
-                      <button onClick={() => setClientToDelete(client)} className="p-1.5 hover:bg-red-50 rounded">
-                        <img src={TrashIcon} alt="Remover" className="h-4 w-4" />
-                      </button>
-                    </div>
-                  </div>
-
-                  {/* Expanded: processes */}
-                  {isExpanded && (
-                    <div className="border-t border-gray-100 bg-gray-50 px-6 py-4">
-                      {isLoadingProc ? (
-                        <div className="flex items-center gap-2 text-gray-400 text-sm">
-                          <Loader2 className="w-4 h-4 animate-spin" />
-                          Carregando processos...
-                        </div>
-                      ) : processes.length === 0 ? (
-                        <p className="text-sm text-gray-500">Nenhum processo ainda.</p>
-                      ) : (
-                        <div className="space-y-2">
-                          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-3">
-                            Processos ({processes.length})
-                          </p>
-                          {processes.map((proc) => (
-                            <div
-                              key={proc.id}
-                              onClick={() => navigate(`/consultant/processes/${proc.id}`)}
-                              className="flex items-center justify-between bg-white rounded-lg px-4 py-3 border border-gray-100 hover:border-gray-300 cursor-pointer transition-colors"
+                  return (
+                    <Fragment key={client.id}>
+                      <tr className="border-b border-border-soft hover:bg-border-soft/50">
+                        <td className="px-4 py-3">
+                          <button
+                            onClick={() => toggleExpand(client.id)}
+                            className="inline-flex items-center gap-2 font-medium text-ink"
+                          >
+                            {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                            {client.name} {client.surname}
+                          </button>
+                          <p className="text-xs text-subtle mt-0.5 pl-6">{formatCPF(client.cpf)}</p>
+                        </td>
+                        <td className="px-4 py-3 text-muted truncate">{client.email}</td>
+                        <td className="px-4 py-3 text-muted">
+                          {client.created_at ? new Date(client.created_at).toLocaleDateString("pt-BR") : "-"}
+                        </td>
+                        <td className="px-4 py-3">
+                          <div className="flex items-center gap-1 justify-end">
+                            <button
+                              onClick={() => setClientToEdit(client)}
+                              className="p-1.5 rounded hover:bg-border-soft text-ink-soft"
                             >
-                              <div className="flex items-center gap-3">
-                                <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_COLORS[proc.status] ?? "bg-gray-100 text-gray-600"}`}>
-                                  {STATUS_LABELS[proc.status] ?? proc.status}
-                                </span>
-                                <span className="text-sm text-gray-600">
-                                  {proc.product_type ?? "Consultoria"} •{" "}
-                                  {proc.specialist ? `${proc.specialist.name} ${proc.specialist.surname}` : "—"}
-                                </span>
+                              <Pencil size={16} />
+                            </button>
+                            <button
+                              onClick={() => setClientToDelete(client)}
+                              className="p-1.5 rounded hover:bg-status-bad-wash text-status-bad"
+                            >
+                              <Trash2 size={16} />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                      {isExpanded && (
+                        <tr>
+                          <td colSpan={4} className="bg-border-soft/40 px-6 py-4">
+                            {isLoadingProc ? (
+                              <div className="flex items-center gap-2 text-subtle text-sm">
+                                <Loader2 className="w-4 h-4 animate-spin" />
+                                Carregando processos...
                               </div>
-                              <span className="text-xs text-gray-400">
-                                {new Date(proc.created_at).toLocaleDateString("pt-BR")}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
+                            ) : processes.length === 0 ? (
+                              <p className="text-sm text-muted">Nenhum processo ainda.</p>
+                            ) : (
+                              <div className="space-y-2">
+                                <p className="text-xs font-semibold text-muted uppercase tracking-wider mb-3">
+                                  Processos ({processes.length})
+                                </p>
+                                {processes.map((proc) => (
+                                  <div
+                                    key={proc.id}
+                                    onClick={() => navigate(`/consultant/processes/${proc.id}`)}
+                                    className="flex items-center justify-between bg-surface rounded-lg px-4 py-3 border border-border-soft hover:border-border cursor-pointer transition-colors"
+                                  >
+                                    <div className="flex items-center gap-3">
+                                      <StatusBadge status={proc.status} />
+                                      <span className="text-sm text-muted">
+                                        {proc.product_type ?? "Consultoria"} •{" "}
+                                        {proc.specialist ? `${proc.specialist.name} ${proc.specialist.surname}` : "—"}
+                                      </span>
+                                    </div>
+                                    <span className="text-xs text-subtle">
+                                      {new Date(proc.created_at).toLocaleDateString("pt-BR")}
+                                    </span>
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </td>
+                        </tr>
                       )}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+                    </Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
         )}
-      </div>
+      </Card>
 
       {/* Modais */}
-      <Modal isOpen={isInviteModalOpen} onClose={() => setIsInviteModalOpen(false)}>
-        <InviteClientForm onSuccess={() => { setIsInviteModalOpen(false); fetchClients(); }} />
-      </Modal>
+      <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
+        <DialogContent title="Convidar cliente">
+          <InviteClientForm onSuccess={() => { setIsInviteModalOpen(false); fetchClients(); }} />
+        </DialogContent>
+      </Dialog>
 
-      <Modal isOpen={isBatchModalOpen} onClose={() => setIsBatchModalOpen(false)}>
-        <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
-      </Modal>
+      <Dialog open={isBatchModalOpen} onOpenChange={setIsBatchModalOpen}>
+        <DialogContent title="Convite de clientes em lote">
+          <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
+        </DialogContent>
+      </Dialog>
 
-      <Modal isOpen={!!clientToEdit} onClose={() => setClientToEdit(null)}>
-        {clientToEdit && (
-          <EditClientForm client={clientToEdit} onSuccess={() => { setClientToEdit(null); fetchClients(); }} />
-        )}
-      </Modal>
+      <Dialog open={!!clientToEdit} onOpenChange={(open) => !open && setClientToEdit(null)}>
+        <DialogContent title="Editar cliente">
+          {clientToEdit && (
+            <EditClientForm client={clientToEdit} onSuccess={() => { setClientToEdit(null); fetchClients(); }} />
+          )}
+        </DialogContent>
+      </Dialog>
 
-      <Modal isOpen={!!clientToDelete} onClose={() => setClientToDelete(null)}>
-        <div className="text-center">
-          <h2 className="h2-style mb-4">Confirmar Remoção</h2>
-          <p className="text-text-secondary mb-8">
-            Remover <strong>{clientToDelete?.name} {clientToDelete?.surname}</strong>? O cliente não será apagado, apenas desvinculado.
-          </p>
-          <div className="flex justify-center gap-4">
-            <Button onClick={() => setClientToDelete(null)}>Cancelar</Button>
-            <Button onClick={handleDelete}>Confirmar</Button>
+      <Dialog open={!!clientToDelete} onOpenChange={(open) => !open && setClientToDelete(null)}>
+        <DialogContent title="Confirmar remoção">
+          <div>
+            <p className="text-muted mb-6">
+              Remover <strong className="text-ink">{clientToDelete?.name} {clientToDelete?.surname}</strong>? O cliente não será apagado, apenas desvinculado.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="light" onClick={() => setClientToDelete(null)}>Cancelar</Button>
+              <Button variant="danger" onClick={handleDelete}>Confirmar</Button>
+            </div>
           </div>
-        </div>
-      </Modal>
+        </DialogContent>
+      </Dialog>
 
     </div>
   );

--- a/frontend/src/pages/consultant/ConsultantClientsPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantClientsPage.tsx
@@ -250,19 +250,19 @@ export default function ConsultantClientsPage() {
 
       {/* Modais */}
       <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
-        <DialogContent title="Convidar cliente" hideTitle>
+        <DialogContent open={isInviteModalOpen} title="Convidar cliente" hideTitle>
           <InviteClientForm onSuccess={() => { setIsInviteModalOpen(false); fetchClients(); }} />
         </DialogContent>
       </Dialog>
 
       <Dialog open={isBatchModalOpen} onOpenChange={setIsBatchModalOpen}>
-        <DialogContent title="Convite de clientes em lote" hideTitle>
+        <DialogContent open={isBatchModalOpen} title="Convite de clientes em lote" hideTitle>
           <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
         </DialogContent>
       </Dialog>
 
       <Dialog open={!!clientToEdit} onOpenChange={(open) => !open && setClientToEdit(null)}>
-        <DialogContent title="Editar cliente" hideTitle>
+        <DialogContent open={!!clientToEdit} title="Editar cliente" hideTitle>
           {clientToEdit && (
             <EditClientForm client={clientToEdit} onSuccess={() => { setClientToEdit(null); fetchClients(); }} />
           )}
@@ -270,7 +270,7 @@ export default function ConsultantClientsPage() {
       </Dialog>
 
       <Dialog open={!!clientToDelete} onOpenChange={(open) => !open && setClientToDelete(null)}>
-        <DialogContent title="Confirmar remoção">
+        <DialogContent open={!!clientToDelete} title="Confirmar remoção">
           <div>
             <p className="text-muted mb-6">
               Remover <strong className="text-ink">{clientToDelete?.name} {clientToDelete?.surname}</strong>? O cliente não será apagado, apenas desvinculado.

--- a/frontend/src/pages/consultant/ConsultantClientsPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantClientsPage.tsx
@@ -96,8 +96,8 @@ export default function ConsultantClientsPage() {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex flex-col items-center gap-4">
-          <div className="w-12 h-12 border-3 border-gray-200 border-t-primary rounded-full animate-spin" />
-          <p className="text-gray-600">Carregando clientes...</p>
+          <div className="w-12 h-12 border-3 border-border-soft border-t-primary rounded-full animate-spin" />
+          <p className="text-muted">Carregando clientes...</p>
         </div>
       </div>
     );
@@ -250,19 +250,19 @@ export default function ConsultantClientsPage() {
 
       {/* Modais */}
       <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
-        <DialogContent title="Convidar cliente">
+        <DialogContent title="Convidar cliente" hideTitle>
           <InviteClientForm onSuccess={() => { setIsInviteModalOpen(false); fetchClients(); }} />
         </DialogContent>
       </Dialog>
 
       <Dialog open={isBatchModalOpen} onOpenChange={setIsBatchModalOpen}>
-        <DialogContent title="Convite de clientes em lote">
+        <DialogContent title="Convite de clientes em lote" hideTitle>
           <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
         </DialogContent>
       </Dialog>
 
       <Dialog open={!!clientToEdit} onOpenChange={(open) => !open && setClientToEdit(null)}>
-        <DialogContent title="Editar cliente">
+        <DialogContent title="Editar cliente" hideTitle>
           {clientToEdit && (
             <EditClientForm client={clientToEdit} onSuccess={() => { setClientToEdit(null); fetchClients(); }} />
           )}
@@ -276,8 +276,8 @@ export default function ConsultantClientsPage() {
               Remover <strong className="text-ink">{clientToDelete?.name} {clientToDelete?.surname}</strong>? O cliente não será apagado, apenas desvinculado.
             </p>
             <div className="flex justify-end gap-2">
-              <Button variant="light" onClick={() => setClientToDelete(null)}>Cancelar</Button>
-              <Button variant="danger" onClick={handleDelete}>Confirmar</Button>
+              <Button type="button" variant="light" onClick={() => setClientToDelete(null)}>Cancelar</Button>
+              <Button type="button" variant="danger" onClick={handleDelete}>Confirmar</Button>
             </div>
           </div>
         </DialogContent>

--- a/frontend/src/pages/consultant/ConsultantDashboard.tsx
+++ b/frontend/src/pages/consultant/ConsultantDashboard.tsx
@@ -45,7 +45,8 @@ export default function ConsultantDashboard() {
       setClients(clientsData);
       setProcesses(processesData);
       setError(null);
-    } catch {
+    } catch (err) {
+      console.error(err);
       setError("Não foi possível carregar os dados do dashboard.");
     } finally {
       setIsLoading(false);
@@ -218,25 +219,33 @@ export default function ConsultantDashboard() {
         <div className="flex flex-col gap-4">
           <Card>
             <h2 className="text-h2 font-semibold text-ink mb-4">Distribuição por status</h2>
-            <ResponsiveContainer width="100%" height={220}>
-              <BarChart data={statusDistribution} layout="vertical" margin={{ left: 8, right: 16 }}>
-                <XAxis type="number" hide allowDecimals={false} />
-                <YAxis
-                  type="category"
-                  dataKey="label"
-                  width={100}
-                  tick={{ fontSize: 12, fill: "#6b6b6b" }}
-                  axisLine={false}
-                  tickLine={false}
-                />
-                <Tooltip cursor={{ fill: "#e9e9e9" }} />
-                <Bar dataKey="count" radius={[0, 4, 4, 0]} barSize={16}>
-                  {statusDistribution.map((entry) => (
-                    <Cell key={entry.value} fill={entry.hex} />
-                  ))}
-                </Bar>
-              </BarChart>
-            </ResponsiveContainer>
+            {processes.length === 0 ? (
+              <EmptyState
+                icon={TrendingUp}
+                title="Sem dados ainda"
+                description="A distribuição por status aparece aqui quando houver processos."
+              />
+            ) : (
+              <ResponsiveContainer width="100%" height={220}>
+                <BarChart data={statusDistribution} layout="vertical" margin={{ left: 8, right: 16 }}>
+                  <XAxis type="number" hide allowDecimals={false} />
+                  <YAxis
+                    type="category"
+                    dataKey="label"
+                    width={100}
+                    tick={{ fontSize: 12, fill: "#6b6b6b" }}
+                    axisLine={false}
+                    tickLine={false}
+                  />
+                  <Tooltip cursor={{ fill: "#e9e9e9" }} />
+                  <Bar dataKey="count" radius={[0, 4, 4, 0]} barSize={16}>
+                    {statusDistribution.map((entry) => (
+                      <Cell key={entry.value} fill={entry.hex} />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            )}
           </Card>
 
           <Card>
@@ -287,7 +296,12 @@ export default function ConsultantDashboard() {
 
       <Dialog open={isBatchModalOpen} onOpenChange={setIsBatchModalOpen}>
         <DialogContent open={isBatchModalOpen} title="Convite de clientes em lote" hideTitle>
-          <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
+          <BatchInviteClients
+            onClose={() => {
+              setIsBatchModalOpen(false);
+              fetchData();
+            }}
+          />
         </DialogContent>
       </Dialog>
     </div>

--- a/frontend/src/pages/consultant/ConsultantDashboard.tsx
+++ b/frontend/src/pages/consultant/ConsultantDashboard.tsx
@@ -1,207 +1,295 @@
-// Página principal do painel do Assessor (Consultant)
-
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Bar, BarChart, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { CheckCircle2, FilePen, Plus, TrendingUp, Users } from "lucide-react";
 import {
+  getAllConsultantProcesses,
   getClients,
-  removeClient,
   type Client,
+  type ConsultantProcess,
 } from "../../services/consultant.service";
 import Button from "../../components/ui/button";
-import EditIcon from "../../assets/icons/edit.svg";
-import TrashIcon from "../../assets/icons/trash.svg";
-import Modal from "../../components/ui/Modal";
+import { Card } from "../../components/ui/card";
+import { Alert } from "../../components/ui/alert";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge, PROCESS_STATUS_META } from "../../components/patterns/StatusBadge";
+import { EmptyState } from "../../components/patterns/EmptyState";
 import InviteClientForm from "./InviteClientForm";
-import EditClientForm from "./EditClientForm";
+import BatchInviteClients from "./BatchInviteClients";
 
-function formatCPF(cpf: string | null): string {
-  if (!cpf) return "-";
-  const cleaned = cpf.replace(/\D/g, "");
-  if (cleaned.length !== 11) return cpf;
-  return cleaned.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, "$1.$2.$3-$4");
+const TERMINAL_STATUSES = ["COMPLETED", "REJECTED"];
+
+function daysSince(dateString: string): number {
+  const diffMs = Date.now() - new Date(dateString).getTime();
+  return Math.max(0, Math.floor(diffMs / (1000 * 60 * 60 * 24)));
 }
 
 export default function ConsultantDashboard() {
+  const navigate = useNavigate();
   const [clients, setClients] = useState<Client[]>([]);
+  const [processes, setProcesses] = useState<ConsultantProcess[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const hasFetched = useRef(false);
 
   const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
-  const [clientToEdit, setClientToEdit] = useState<Client | null>(null);
-  const [clientToDelete, setClientToDelete] = useState<Client | null>(null);
+  const [isBatchModalOpen, setIsBatchModalOpen] = useState(false);
 
-  async function fetchData() {
+  const fetchData = async () => {
     try {
       setIsLoading(true);
-      
-      const data = await getClients();
-      setClients(data);
+      const [clientsData, processesData] = await Promise.all([
+        getClients(),
+        getAllConsultantProcesses(),
+      ]);
+      setClients(clientsData);
+      setProcesses(processesData);
       setError(null);
-    } catch (err) {
-      setError("Não foi possível carregar os clientes.");
-      console.error("Erro ao carregar clientes:", err);
+    } catch {
+      setError("Não foi possível carregar os dados do dashboard.");
     } finally {
       setIsLoading(false);
-    }
-  }
-
-  const handleInviteSuccess = () => {
-    setIsInviteModalOpen(false);
-    fetchData();
-  };
-
-  const handleEditSuccess = () => {
-    setClientToEdit(null);
-    fetchData();
-  };
-
-  const handleConfirmDelete = async () => {
-    if (!clientToDelete) return;
-    try {
-      await removeClient(clientToDelete.id);
-      fetchData();
-    } catch (err) {
-      alert("Erro ao remover o cliente. Tente novamente.");
-      console.error("Erro ao remover cliente:", err);
-    } finally {
-      setClientToDelete(null);
     }
   };
 
   useEffect(() => {
-    if (hasFetched.current) return; // Evita dupla chamada com StrictMode
-    hasFetched.current = true;
     fetchData();
   }, []);
+
+  const activeProcesses = useMemo(
+    () => processes.filter((p) => !TERMINAL_STATUSES.includes(p.status)),
+    [processes],
+  );
+  const completedCount = useMemo(
+    () => processes.filter((p) => p.status === "COMPLETED").length,
+    [processes],
+  );
+  const rejectedCount = useMemo(
+    () => processes.filter((p) => p.status === "REJECTED").length,
+    [processes],
+  );
+  const conversionRate = useMemo(() => {
+    const finalized = completedCount + rejectedCount;
+    return finalized > 0 ? Math.round((completedCount / finalized) * 100) : 0;
+  }, [completedCount, rejectedCount]);
+
+  const pendingProcesses = useMemo(
+    () =>
+      [...activeProcesses]
+        .sort((a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime())
+        .slice(0, 5),
+    [activeProcesses],
+  );
+
+  const statusDistribution = useMemo(
+    () =>
+      PROCESS_STATUS_META.map((meta) => ({
+        ...meta,
+        count: processes.filter((p) => p.status === meta.value).length,
+      })),
+    [processes],
+  );
+
+  const recentClients = useMemo(
+    () =>
+      [...clients]
+        .sort(
+          (a, b) =>
+            new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+        )
+        .slice(0, 5),
+    [clients],
+  );
+
+  const handleQuickActionSuccess = () => {
+    setIsInviteModalOpen(false);
+    fetchData();
+  };
 
   if (isLoading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex flex-col items-center gap-4">
-          <div className="w-12 h-12 border-3 border-gray-200 border-t-primary rounded-full animate-spin" />
-          <p className="text-gray-600">Carregando dashboard...</p>
+          <div className="w-12 h-12 border-3 border-border-soft border-t-primary rounded-full animate-spin" />
+          <p className="text-muted">Carregando dashboard...</p>
         </div>
       </div>
     );
   }
 
-  if (error) {
-    return <p className="text-red-500">{error}</p>;
-  }
-
   return (
     <div className="text-text-main w-full">
-      {/* --- CABEÇALHO DA PÁGINA --- */}
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <h1 className="h1-style">Meus Clientes</h1>
-        <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
-          + Convidar Cliente
-        </Button>
+      <PageHeader
+        title="Dashboard"
+        actions={
+          <>
+            <Button type="button" variant="light" onClick={() => setIsBatchModalOpen(true)}>
+              Convite em lote
+            </Button>
+            <Button type="button" onClick={() => setIsInviteModalOpen(true)}>
+              <Plus size={16} />
+              Convidar cliente
+            </Button>
+          </>
+        }
+      />
+
+      {error && (
+        <Alert variant="danger" className="mb-4">
+          {error}
+        </Alert>
+      )}
+
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <Users size={14} />
+            Clientes
+          </div>
+          <p className="text-2xl font-bold text-ink">{clients.length}</p>
+        </Card>
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <FilePen size={14} />
+            Processos ativos
+          </div>
+          <p className="text-2xl font-bold text-ink">{activeProcesses.length}</p>
+        </Card>
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <CheckCircle2 size={14} />
+            Concluídos
+          </div>
+          <p className="text-2xl font-bold text-ink">{completedCount}</p>
+        </Card>
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+            <TrendingUp size={14} />
+            Taxa de conversão
+          </div>
+          <p className="text-2xl font-bold text-ink">{conversionRate}%</p>
+        </Card>
       </div>
 
-      {/* --- TABELA DE CLIENTES --- */}
-      <div className="p-6 rounded-lg shadow bg-white">
-        <h2 className="h2-style">Clientes</h2>
-        <p className="text-base mb-6 mt-2 text-gray-600">
-          Lista completa de clientes vinculados a você
-        </p>
-
-        {clients.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
-            Nenhum cliente cadastrado ainda. Clique em "Convidar Cliente" para começar.
+      <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-4">
+        <Card>
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-h2 font-semibold text-ink">Processos vigentes</h2>
+            <button
+              type="button"
+              onClick={() => navigate("/consultant/processes")}
+              className="text-sm font-semibold text-ink-soft hover:text-ink"
+            >
+              Ver todos
+            </button>
           </div>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-gray-200">
-                  <th className="text-left py-3 px-4 font-semibold text-sm text-gray-700">Nome</th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm text-gray-700">Email</th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm text-gray-700">CPF</th>
-                  <th className="text-left py-3 px-4 font-semibold text-sm text-gray-700">Data de Cadastro</th>
-                  <th className="text-right py-3 px-4 font-semibold text-sm text-gray-700">Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                {clients.map((client) => (
-                  <tr key={client.id} className="border-b border-gray-100 hover:bg-gray-50 transition-colors">
-                    <td className="py-4 px-4">
+          {pendingProcesses.length === 0 ? (
+            <EmptyState
+              icon={FilePen}
+              title="Nenhum processo em andamento"
+              description="Processos ativos dos seus clientes aparecem aqui."
+            />
+          ) : (
+            <div className="flex flex-col gap-2">
+              {pendingProcesses.map((proc) => (
+                <div
+                  key={proc.id}
+                  onClick={() => navigate(`/consultant/processes/${proc.id}`)}
+                  className="flex items-center justify-between gap-3 bg-surface rounded-lg px-4 py-3 border border-border-soft hover:border-border cursor-pointer transition-colors"
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <StatusBadge status={proc.status} />
+                    <span className="text-sm text-muted truncate">
+                      {proc.client ? `${proc.client.name} ${proc.client.surname}` : "—"}
+                      {proc.specialist
+                        ? ` • ${proc.specialist.name} ${proc.specialist.surname}`
+                        : ""}
+                    </span>
+                  </div>
+                  <span className="text-xs text-subtle whitespace-nowrap">
+                    {daysSince(proc.updated_at)}d sem atualização
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </Card>
+
+        <div className="flex flex-col gap-4">
+          <Card>
+            <h2 className="text-h2 font-semibold text-ink mb-4">Distribuição por status</h2>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={statusDistribution} layout="vertical" margin={{ left: 8, right: 16 }}>
+                <XAxis type="number" hide allowDecimals={false} />
+                <YAxis
+                  type="category"
+                  dataKey="label"
+                  width={100}
+                  tick={{ fontSize: 12, fill: "#6b6b6b" }}
+                  axisLine={false}
+                  tickLine={false}
+                />
+                <Tooltip cursor={{ fill: "#e9e9e9" }} />
+                <Bar dataKey="count" radius={[0, 4, 4, 0]} barSize={16}>
+                  {statusDistribution.map((entry) => (
+                    <Cell key={entry.value} fill={entry.hex} />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </Card>
+
+          <Card>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-h2 font-semibold text-ink">Clientes recentes</h2>
+              <button
+                type="button"
+                onClick={() => navigate("/consultant/clients")}
+                className="text-sm font-semibold text-ink-soft hover:text-ink"
+              >
+                Ver todos
+              </button>
+            </div>
+            {recentClients.length === 0 ? (
+              <EmptyState
+                icon={Users}
+                title="Nenhum cliente ainda"
+                description='Clique em "Convidar cliente" para começar.'
+              />
+            ) : (
+              <div className="flex flex-col gap-2">
+                {recentClients.map((client) => (
+                  <div
+                    key={client.id}
+                    className="flex items-center justify-between gap-3 px-1 py-2 border-b border-border-soft last:border-b-0"
+                  >
+                    <span className="text-sm font-medium text-ink truncate">
                       {client.name} {client.surname}
-                    </td>
-                    <td className="py-4 px-4 text-gray-600">{client.email}</td>
-                    <td className="py-4 px-4 text-gray-600">{formatCPF(client.cpf)}</td>
-                    <td className="py-4 px-4 text-gray-600">
-                      {client.created_at 
+                    </span>
+                    <span className="text-xs text-subtle whitespace-nowrap">
+                      {client.created_at
                         ? new Date(client.created_at).toLocaleDateString("pt-BR")
                         : "-"}
-                    </td>
-                    <td className="py-4 px-4">
-                      <div className="flex justify-end items-center gap-3">
-                        <button 
-                          onClick={() => setClientToEdit(client)}
-                          className="p-2 hover:bg-gray-200 rounded transition-colors"
-                          title="Editar"
-                        >
-                          <img src={EditIcon} alt="Editar" className="h-5 w-5" />
-                        </button>
-                        <button 
-                          onClick={() => setClientToDelete(client)}
-                          className="p-2 hover:bg-red-100 rounded transition-colors"
-                          title="Remover"
-                        >
-                          <img src={TrashIcon} alt="Remover" className="h-5 w-5" />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
+                    </span>
+                  </div>
                 ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+              </div>
+            )}
+          </Card>
+        </div>
       </div>
 
-      {/* --- MODAIS --- */}
+      <Dialog open={isInviteModalOpen} onOpenChange={setIsInviteModalOpen}>
+        <DialogContent open={isInviteModalOpen} title="Convidar cliente" hideTitle>
+          <InviteClientForm onSuccess={handleQuickActionSuccess} />
+        </DialogContent>
+      </Dialog>
 
-      {/* Modal para convidar novo cliente */}
-      <Modal
-        isOpen={isInviteModalOpen}
-        onClose={() => setIsInviteModalOpen(false)}
-      >
-        <InviteClientForm onSuccess={handleInviteSuccess} />
-      </Modal>
-
-      {/* Modal para editar cliente */}
-      <Modal
-        isOpen={!!clientToEdit}
-        onClose={() => setClientToEdit(null)}
-      >
-        {clientToEdit && (
-          <EditClientForm client={clientToEdit} onSuccess={handleEditSuccess} />
-        )}
-      </Modal>
-
-      {/* Modal para confirmação de exclusão */}
-      <Modal
-        isOpen={!!clientToDelete}
-        onClose={() => setClientToDelete(null)}
-      >
-        <div className="text-center">
-          <h2 className="h2-style mb-4">Confirmar Remoção</h2>
-          <p className="text-text-secondary mb-8">
-            Tem a certeza que deseja remover o cliente{" "}
-            <span className="font-bold">
-              {clientToDelete?.name} {clientToDelete?.surname}
-            </span>
-            ? O cliente será desvinculado de você, mas não será apagado do sistema.
-          </p>
-          <div className="flex justify-center gap-4">
-            <Button onClick={() => setClientToDelete(null)}>Cancelar</Button>
-            <Button onClick={handleConfirmDelete}>Confirmar Remoção</Button>
-          </div>
-        </div>
-      </Modal>
+      <Dialog open={isBatchModalOpen} onOpenChange={setIsBatchModalOpen}>
+        <DialogContent open={isBatchModalOpen} title="Convite de clientes em lote" hideTitle>
+          <BatchInviteClients onClose={() => setIsBatchModalOpen(false)} />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
-

--- a/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
@@ -32,24 +32,12 @@ import {
   type Process,
 } from "../../services/processes.service";
 import { useAuth } from "../../store/authStateManager";
-
-const STATUS_LABELS: Record<string, string> = {
-  SCHEDULING: "Agendamento",
-  NEGOTIATION: "Negociação",
-  PROCESSING_CONTRACT: "Contrato",
-  DOCUMENTATION: "Documentação",
-  COMPLETED: "Concluído",
-  REJECTED: "Rejeitado",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  SCHEDULING: "bg-blue-100 text-blue-700",
-  NEGOTIATION: "bg-yellow-100 text-yellow-700",
-  PROCESSING_CONTRACT: "bg-orange-100 text-orange-700",
-  DOCUMENTATION: "bg-purple-100 text-purple-700",
-  COMPLETED: "bg-green-100 text-green-700",
-  REJECTED: "bg-red-100 text-red-700",
-};
+import { Card } from "../../components/ui/card";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge } from "../../components/patterns/StatusBadge";
+import { ProposalStatusBadge } from "../../components/patterns/ProposalStatusBadge";
 
 const PRODUCT_LABELS: Record<string, string> = {
   CAR: "Carro",
@@ -72,41 +60,6 @@ function formatDate(dateString: string): string {
     hour: "2-digit",
     minute: "2-digit",
   });
-}
-
-function ProposalStatusBadge({ status }: { status: string }) {
-  switch (status) {
-    case "PENDING":
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-full">
-          <Loader2 size={12} className="animate-spin" />
-          Aguardando resposta
-        </span>
-      );
-    case "ACCEPTED":
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-1 bg-green-100 text-green-800 text-xs font-medium rounded-full">
-          <Check size={12} />
-          Aceita
-        </span>
-      );
-    case "REJECTED":
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-1 bg-red-100 text-red-800 text-xs font-medium rounded-full">
-          <X size={12} />
-          Rejeitada
-        </span>
-      );
-    case "COUNTERED":
-      return (
-        <span className="inline-flex items-center gap-1 px-2 py-1 bg-blue-100 text-blue-800 text-xs font-medium rounded-full">
-          <RefreshCw size={12} />
-          Contraproposta enviada
-        </span>
-      );
-    default:
-      return null;
-  }
 }
 
 export default function ConsultantProcessDetailPage() {
@@ -330,20 +283,17 @@ export default function ConsultantProcessDetailPage() {
   if (error || !process) {
     return (
       <div className="flex flex-col items-center justify-center py-24 text-center">
-        <AlertCircle className="text-red-500 mb-3" size={40} />
-        <h2 className="text-lg font-semibold text-gray-900 mb-1">
+        <AlertCircle className="text-status-bad mb-3" size={40} />
+        <h2 className="text-lg font-semibold text-ink mb-1">
           Não foi possível carregar o processo
         </h2>
-        <p className="text-sm text-gray-600 mb-4">
+        <p className="text-sm text-muted mb-4">
           {error ?? "Processo não encontrado."}
         </p>
-        <button
-          onClick={() => navigate("/consultant/processes")}
-          className="inline-flex items-center gap-2 px-4 py-2 bg-slate-700 text-white rounded-lg hover:bg-slate-800 transition-colors"
-        >
+        <Button type="button" onClick={() => navigate("/consultant/processes")}>
           <ArrowLeft size={18} />
           Voltar para processos
-        </button>
+        </Button>
       </div>
     );
   }
@@ -351,9 +301,6 @@ export default function ConsultantProcessDetailPage() {
   const productLabel = process.product_type
     ? PRODUCT_LABELS[process.product_type] ?? process.product_type
     : "Consultoria";
-  const statusLabel = STATUS_LABELS[process.status] ?? process.status;
-  const statusColor =
-    STATUS_COLORS[process.status] ?? "bg-gray-100 text-gray-600";
 
   const acceptedProposal = proposals.find((p) => p.status === "ACCEPTED");
   const isAwaitingProduct = !process.product_type || !process.product_id;
@@ -365,143 +312,133 @@ export default function ConsultantProcessDetailPage() {
 
   return (
     <div className="text-text-main w-full">
-      <div className="flex items-center justify-between mb-6 gap-3 flex-wrap">
-        <div className="flex items-center gap-3">
+      <PageHeader
+        title="Detalhes do processo"
+        showBack
+        backTo="/consultant/processes"
+        actions={
           <button
-            onClick={() => navigate("/consultant/processes")}
-            className="p-2 hover:bg-gray-100 rounded-lg transition-colors"
-            aria-label="Voltar"
+            onClick={load}
+            className="inline-flex items-center gap-2 px-3 py-2 text-sm border border-border rounded-lg hover:bg-border-soft"
           >
-            <ArrowLeft size={20} className="text-gray-600" />
+            <RefreshCw size={16} />
+            Atualizar
           </button>
-          <div>
-            <h1 className="h1-style">Detalhes do processo</h1>
-            <p className="text-sm text-gray-500 mt-1">
-              Acompanhe e atue na negociação em nome do cliente.
-            </p>
-          </div>
-        </div>
-        <button
-          onClick={load}
-          className="inline-flex items-center gap-2 px-3 py-2 text-sm border border-gray-200 rounded-lg hover:bg-gray-50"
-        >
-          <RefreshCw size={16} />
-          Atualizar
-        </button>
-      </div>
+        }
+      />
+      <p className="text-sm text-muted -mt-4 mb-6">
+        Acompanhe e atue na negociação em nome do cliente.
+      </p>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-6">
-        <div className="p-4 rounded-lg shadow bg-white">
-          <div className="flex items-center gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wider mb-2">
             <User size={14} />
             Cliente
           </div>
-          <p className="text-sm font-medium text-gray-900">
+          <p className="text-sm font-medium text-ink">
             {process.client?.name ?? "—"}
           </p>
           {process.client?.email && (
-            <p className="text-xs text-gray-500 mt-1">{process.client.email}</p>
+            <p className="text-xs text-muted mt-1">{process.client.email}</p>
           )}
-        </div>
+        </Card>
 
-        <div className="p-4 rounded-lg shadow bg-white">
-          <div className="flex items-center gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wider mb-2">
             <UserCog size={14} />
             Especialista
           </div>
-          <p className="text-sm font-medium text-gray-900">
+          <p className="text-sm font-medium text-ink">
             {process.specialist?.name ?? "—"}
           </p>
           {process.specialist?.especialidade && (
-            <p className="text-xs text-gray-500 mt-1">
+            <p className="text-xs text-muted mt-1">
               {process.specialist.especialidade}
             </p>
           )}
-        </div>
+        </Card>
 
-        <div className="p-4 rounded-lg shadow bg-white">
-          <div className="flex items-center gap-2 text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+        <Card className="p-4">
+          <div className="flex items-center gap-2 text-xs font-semibold text-muted uppercase tracking-wider mb-2">
             <Package size={14} />
             Produto
           </div>
-          <p className="text-sm font-medium text-gray-900">{productLabel}</p>
+          <p className="text-sm font-medium text-ink">{productLabel}</p>
           {process.product && (
-            <p className="text-xs text-gray-500 mt-1 truncate">
+            <p className="text-xs text-muted mt-1 truncate">
               {[process.product.marca, process.product.modelo]
                 .filter(Boolean)
                 .join(" ")}
               {process.product.ano ? ` • ${process.product.ano}` : ""}
             </p>
           )}
-        </div>
+        </Card>
       </div>
 
-      <div className="p-4 rounded-lg shadow bg-white mb-6 flex flex-wrap items-center gap-4">
+      <Card className="mb-6 flex flex-wrap items-center gap-4">
         <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold text-gray-500 uppercase tracking-wider">
+          <span className="text-xs font-semibold text-muted uppercase tracking-wider">
             Status
           </span>
-          <span
-            className={`text-xs font-medium px-2 py-1 rounded-full ${statusColor}`}
-          >
-            {statusLabel}
-          </span>
+          <StatusBadge status={process.status} />
         </div>
-        <div className="flex items-center gap-2 text-sm text-gray-600">
-          <Calendar size={14} className="text-gray-400" />
+        <div className="flex items-center gap-2 text-sm text-muted">
+          <Calendar size={14} className="text-subtle" />
           Criado em {formatDate(process.created_at)}
         </div>
         {process.appointment_datetime && (
-          <div className="flex items-center gap-2 text-sm text-gray-600">
-            <Calendar size={14} className="text-gray-400" />
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <Calendar size={14} className="text-subtle" />
             Reunião: {formatDate(process.appointment_datetime)}
           </div>
         )}
         {process.rejection_reason && (
-          <div className="flex items-center gap-2 text-sm text-red-600">
+          <div className="flex items-center gap-2 text-sm text-status-bad">
             <AlertCircle size={14} />
             Motivo da rejeição: {process.rejection_reason}
           </div>
         )}
-      </div>
+      </Card>
 
       {!isScheduling && processInfo && (
-        <div className="p-4 rounded-lg shadow bg-white mb-6 flex flex-wrap items-center gap-6 text-sm">
+        <Card className="mb-6 flex flex-wrap items-center gap-6 text-sm">
           <div className="flex items-center gap-2">
-            <DollarSign size={16} className="text-green-600" />
-            <span className="text-gray-500">Valor do produto:</span>
-            <span className="font-semibold text-gray-900">
+            <DollarSign size={16} className="text-status-ok" />
+            <span className="text-muted">Valor do produto:</span>
+            <span className="font-semibold text-ink">
               {formatCurrency(processInfo.product_value)}
             </span>
           </div>
           <div className="flex items-center gap-2">
+            {/* laranja mantido de propósito — destaque de atenção ao valor, não é um dos 6 status de processo */}
             <AlertCircle size={16} className="text-orange-500" />
-            <span className="text-gray-500">Valor mínimo:</span>
+            <span className="text-muted">Valor mínimo:</span>
             <span className="font-semibold text-orange-600">
               {formatCurrency(processInfo.minimum_value)}
             </span>
           </div>
           {acceptedProposal && (
             <div className="flex items-center gap-2">
-              <Check size={16} className="text-green-600" />
-              <span className="text-gray-500">Valor aceito:</span>
-              <span className="font-semibold text-green-700">
+              <Check size={16} className="text-status-ok" />
+              <span className="text-muted">Valor aceito:</span>
+              <span className="font-semibold text-status-ok">
                 {formatCurrency(acceptedProposal.proposed_value)}
               </span>
             </div>
           )}
           {meta && (
-            <div className="ml-auto text-xs text-gray-400">
+            <div className="ml-auto text-xs text-subtle">
               {meta.total} {meta.total === 1 ? "proposta" : "propostas"}
             </div>
           )}
-        </div>
+        </Card>
       )}
 
       {isScheduling ? (
-        <div className="p-6 rounded-lg shadow bg-white">
+        <Card>
           <div className="flex items-center justify-between mb-4">
-            <h2 className="h2-style">Agendamento</h2>
+            <h2 className="text-h2 font-semibold text-ink">Agendamento</h2>
           </div>
 
           <div className="mb-4">
@@ -524,72 +461,72 @@ export default function ConsultantProcessDetailPage() {
           </div>
 
           {process.appointment_datetime ? (
-            <div className="flex items-center gap-2 text-sm text-gray-700 mb-4">
+            <div className="flex items-center gap-2 text-sm text-ink-soft mb-4">
               <Calendar size={16} className="text-gray-400" />
               Reunião marcada para {formatDate(process.appointment_datetime)}
             </div>
           ) : (
-            <p className="text-sm text-gray-500 mb-4">
+            <p className="text-sm text-muted mb-4">
               Data e horário ainda não definidos.
             </p>
           )}
 
           {isAppointmentConfirmed ? (
-            <div className="p-4 bg-slate-50 border border-slate-200 rounded-lg">
+            <div className="p-4 bg-border-soft border border-border rounded-lg">
               {isLoadingMeeting ? (
-                <p className="inline-flex items-center gap-2 text-sm text-gray-600">
+                <p className="inline-flex items-center gap-2 text-sm text-muted">
                   <Loader2 size={16} className="animate-spin" />
                   Verificando reunião...
                 </p>
               ) : meetingSession && !meetingSession.ended_at ? (
                 <>
-                  <p className="text-sm text-slate-800 mb-3">
+                  <p className="text-sm text-ink-soft mb-3">
                     O especialista iniciou a reunião. Entre para acompanhar em
                     nome do cliente.
                   </p>
-                  <button
+                  <Button
+                    type="button"
                     onClick={() =>
                       navigate(`/processes/${process.id}/meeting`)
                     }
-                    className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-cyan-700 text-white rounded-lg font-medium hover:bg-cyan-800 transition-colors"
                   >
                     <Video size={16} />
                     Entrar na reunião
-                  </button>
+                  </Button>
                 </>
               ) : meetingSession?.ended_at ? (
-                <p className="text-sm text-slate-700">
+                <p className="text-sm text-ink-soft">
                   A reunião foi encerrada pelo especialista.
                 </p>
               ) : (
-                <p className="text-sm text-slate-700">
+                <p className="text-sm text-ink-soft">
                   Aguardando o especialista iniciar a reunião. O acesso aparece
                   aqui assim que ela começar.
                 </p>
               )}
             </div>
           ) : (
-            <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-600">
+            <div className="p-4 bg-border-soft border border-border rounded-lg text-sm text-muted">
               A reunião ficará disponível assim que o agendamento for
               confirmado.
             </div>
           )}
-        </div>
+        </Card>
       ) : (
-      <div className="p-6 rounded-lg shadow bg-white">
+      <Card>
         <div className="flex items-center justify-between mb-4">
-          <h2 className="h2-style">Histórico de propostas</h2>
+          <h2 className="text-h2 font-semibold text-ink">Histórico de propostas</h2>
         </div>
 
         {isAwaitingProduct ? (
-          <div className="text-center py-10 text-gray-500 text-sm">
+          <div className="text-center py-10 text-muted text-sm">
             A negociação ainda não foi iniciada. O especialista precisa
             associar um produto ao processo.
           </div>
         ) : proposals.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-10 text-center">
-            <MessageSquare size={40} className="text-gray-300 mb-3" />
-            <p className="text-sm text-gray-500">
+            <MessageSquare size={40} className="text-subtle mb-3" />
+            <p className="text-sm text-muted">
               Nenhuma proposta enviada até o momento.
             </p>
           </div>
@@ -601,18 +538,18 @@ export default function ConsultantProcessDetailPage() {
             {proposals.map((proposal) => (
               <div
                 key={proposal.id}
-                className="border border-gray-200 rounded-lg p-3"
+                className="border border-border rounded-lg p-3"
               >
                 <div className="flex items-center justify-between gap-3 mb-2">
-                  <span className="text-xs font-medium text-gray-500">
+                  <span className="text-xs font-medium text-muted">
                     {proposal.proposed_by.name} {proposal.proposed_by.surname}
-                    <span className="text-gray-400">
+                    <span className="text-subtle">
                       {" "}
                       → {proposal.proposed_to.name}{" "}
                       {proposal.proposed_to.surname}
                     </span>
                   </span>
-                  <span className="text-xs text-gray-400">
+                  <span className="text-xs text-subtle">
                     {formatDate(proposal.created_at)}
                   </span>
                 </div>
@@ -623,18 +560,19 @@ export default function ConsultantProcessDetailPage() {
                   </span>
                 </div>
                 {proposal.message && (
-                  <p className="text-sm text-gray-600 mb-2">
+                  <p className="text-sm text-muted mb-2">
                     {proposal.message}
                   </p>
                 )}
                 <ProposalStatusBadge status={proposal.status} />
 
                 {canRespondToProposal(proposal) && (
-                  <div className="flex gap-2 mt-3 pt-3 border-t border-gray-100">
-                    <button
+                  <div className="flex gap-2 mt-3 pt-3 border-t border-border-soft">
+                    <Button
+                      type="button"
                       onClick={() => handleAccept(proposal.id)}
                       disabled={pendingActionProposalId !== null}
-                      className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-2 bg-green-600 text-white text-sm font-medium rounded-lg hover:bg-green-700 transition-colors disabled:opacity-50"
+                      className="flex-1"
                     >
                       {pendingActionProposalId === proposal.id ? (
                         <Loader2 size={16} className="animate-spin" />
@@ -642,11 +580,13 @@ export default function ConsultantProcessDetailPage() {
                         <Check size={16} />
                       )}
                       Aceitar
-                    </button>
-                    <button
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="danger"
                       onClick={() => handleReject(proposal.id)}
                       disabled={pendingActionProposalId !== null}
-                      className="flex-1 inline-flex items-center justify-center gap-1 px-3 py-2 bg-red-600 text-white text-sm font-medium rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50"
+                      className="flex-1"
                     >
                       {pendingActionProposalId === proposal.id ? (
                         <Loader2 size={16} className="animate-spin" />
@@ -654,7 +594,7 @@ export default function ConsultantProcessDetailPage() {
                         <X size={16} />
                       )}
                       Rejeitar
-                    </button>
+                    </Button>
                   </div>
                 )}
               </div>
@@ -663,15 +603,15 @@ export default function ConsultantProcessDetailPage() {
         )}
 
         {showCreateForm && (
-          <div className="mt-6 pt-4 border-t border-gray-200">
+          <div className="mt-6 pt-4 border-t border-border">
             <h3 className="text-sm font-semibold text-gray-900 mb-3">
               Enviar nova proposta
             </h3>
             {formError && (
-              <div className="mb-3 p-3 bg-red-50 border border-red-200 rounded-lg flex items-center gap-2 text-sm text-red-700">
+              <Alert variant="danger" className="mb-3">
                 <AlertCircle size={16} />
                 {formError}
-              </div>
+              </Alert>
             )}
             <form
               onSubmit={handleSubmitProposal}
@@ -687,7 +627,7 @@ export default function ConsultantProcessDetailPage() {
                     value={proposedValue}
                     onChange={handleValueChange}
                     placeholder="0,00"
-                    className="w-full pl-10 pr-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-slate-500 text-right font-medium"
+                    className="w-full pl-10 pr-4 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring text-right font-medium"
                     disabled={isSending}
                   />
                 </div>
@@ -696,25 +636,21 @@ export default function ConsultantProcessDetailPage() {
                   value={message}
                   onChange={(e) => setMessage(e.target.value)}
                   placeholder="Mensagem (opcional)"
-                  className="flex-1 px-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-slate-500"
+                  className="flex-1 px-4 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring"
                   disabled={isSending}
                 />
               </div>
-              <button
-                type="submit"
-                disabled={isSending || !proposedValue}
-                className="inline-flex items-center justify-center gap-2 px-6 py-2.5 bg-slate-700 text-white font-medium rounded-lg hover:bg-slate-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="submit" disabled={isSending || !proposedValue}>
                 {isSending ? (
                   <Loader2 size={18} className="animate-spin" />
                 ) : (
                   <Send size={18} />
                 )}
                 Enviar proposta
-              </button>
+              </Button>
             </form>
             {processInfo && (
-              <p className="mt-2 text-xs text-gray-500">
+              <p className="mt-2 text-xs text-muted">
                 Valor mínimo aceito: {formatCurrency(processInfo.minimum_value)}
               </p>
             )}
@@ -724,11 +660,11 @@ export default function ConsultantProcessDetailPage() {
         {!showCreateForm &&
           processInfo?.status === "NEGOTIATION" &&
           !isAwaitingProduct && (
-            <div className="mt-6 p-3 bg-gray-50 border border-gray-200 rounded-lg text-center text-sm text-gray-600">
+            <div className="mt-6 p-3 bg-border-soft border border-border rounded-lg text-center text-sm text-muted">
               Aguardando resposta do especialista.
             </div>
           )}
-      </div>
+      </Card>
       )}
     </div>
   );

--- a/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantProcessDetailPage.tsx
@@ -462,7 +462,7 @@ export default function ConsultantProcessDetailPage() {
 
           {process.appointment_datetime ? (
             <div className="flex items-center gap-2 text-sm text-ink-soft mb-4">
-              <Calendar size={16} className="text-gray-400" />
+              <Calendar size={16} className="text-subtle" />
               Reunião marcada para {formatDate(process.appointment_datetime)}
             </div>
           ) : (
@@ -555,7 +555,7 @@ export default function ConsultantProcessDetailPage() {
                 </div>
                 <div className="flex items-center gap-2 mb-1">
                   <DollarSign size={16} className="text-green-600" />
-                  <span className="text-lg font-bold text-gray-900">
+                  <span className="text-lg font-bold text-ink">
                     {formatCurrency(proposal.proposed_value)}
                   </span>
                 </div>
@@ -604,7 +604,7 @@ export default function ConsultantProcessDetailPage() {
 
         {showCreateForm && (
           <div className="mt-6 pt-4 border-t border-border">
-            <h3 className="text-sm font-semibold text-gray-900 mb-3">
+            <h3 className="text-sm font-semibold text-ink mb-3">
               Enviar nova proposta
             </h3>
             {formError && (
@@ -620,7 +620,7 @@ export default function ConsultantProcessDetailPage() {
               <div className="flex-1 flex flex-col md:flex-row gap-3">
                 <div className="relative flex-1 min-w-0">
                   <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <span className="text-gray-500">R$</span>
+                    <span className="text-muted">R$</span>
                   </div>
                   <input
                     type="text"

--- a/frontend/src/pages/consultant/ConsultantProcessesPage.tsx
+++ b/frontend/src/pages/consultant/ConsultantProcessesPage.tsx
@@ -2,24 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { getAllConsultantProcesses, getClients, type ConsultantProcess, type Client } from "../../services/consultant.service";
 import { Loader2, Search, X, ChevronDown } from "lucide-react";
-
-const STATUS_LABELS: Record<string, string> = {
-  SCHEDULING: "Agendamento",
-  NEGOTIATION: "Negociação",
-  PROCESSING_CONTRACT: "Contrato",
-  DOCUMENTATION: "Documentação",
-  COMPLETED: "Concluído",
-  REJECTED: "Rejeitado",
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  SCHEDULING: "bg-blue-100 text-blue-700",
-  NEGOTIATION: "bg-yellow-100 text-yellow-700",
-  PROCESSING_CONTRACT: "bg-orange-100 text-orange-700",
-  DOCUMENTATION: "bg-purple-100 text-purple-700",
-  COMPLETED: "bg-green-100 text-green-700",
-  REJECTED: "bg-red-100 text-red-700",
-};
+import { Card } from "../../components/ui/card";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { StatusBadge, PROCESS_STATUS_META } from "../../components/patterns/StatusBadge";
+import { EmptyState } from "../../components/patterns/EmptyState";
 
 const PRODUCT_LABELS: Record<string, string> = {
   CAR: "Carro",
@@ -44,12 +30,10 @@ export default function ConsultantProcessesPage() {
 
   const dropdownRef = useRef<HTMLDivElement>(null);
 
-  // Fetch clients once (for the filter dropdown)
   useEffect(() => {
     getClients().then(setClients).catch(() => setClients([]));
   }, []);
 
-  // Fetch processes whenever server-side filters change
   const fetchProcesses = useCallback(async () => {
     try {
       setIsLoading(true);
@@ -69,7 +53,6 @@ export default function ConsultantProcessesPage() {
 
   useEffect(() => { fetchProcesses(); }, [fetchProcesses]);
 
-  // Close client dropdown on outside click
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
@@ -88,7 +71,6 @@ export default function ConsultantProcessesPage() {
     );
   }, [clientSearch, clients]);
 
-  // Client-side pagination over filtered (server-filtered) processes
   const totalPages = Math.max(1, Math.ceil(processes.length / PAGE_SIZE));
   const pageProcesses = processes.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
 
@@ -102,54 +84,49 @@ export default function ConsultantProcessesPage() {
 
   return (
     <div className="text-text-main w-full">
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
-        <h1 className="h1-style">Processos dos Clientes</h1>
-      </div>
+      <PageHeader title="Processos dos Clientes" />
 
-      {/* Filtros */}
-      <div className="p-4 rounded-lg shadow bg-white mb-4 flex flex-wrap items-center gap-3">
-        {/* Status */}
+      <Card className="mb-4 flex flex-wrap items-center gap-3 p-4">
         <div className="flex flex-col gap-1">
-          <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">Status</label>
+          <label className="text-xs font-medium text-muted uppercase tracking-wider">Status</label>
           <select
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
-            className="text-sm px-3 py-2 border border-gray-300 rounded-md bg-white min-w-[180px]"
+            className="text-sm px-3 py-2 border border-border rounded-md bg-surface min-w-[180px]"
           >
             <option value="">Todos</option>
-            {Object.entries(STATUS_LABELS).map(([value, label]) => (
+            {PROCESS_STATUS_META.map(({ value, label }) => (
               <option key={value} value={value}>{label}</option>
             ))}
           </select>
         </div>
 
-        {/* Cliente */}
         <div className="flex flex-col gap-1 relative" ref={dropdownRef}>
-          <label className="text-xs font-medium text-gray-500 uppercase tracking-wider">Cliente</label>
+          <label className="text-xs font-medium text-muted uppercase tracking-wider">Cliente</label>
           <button
             type="button"
             onClick={() => setIsClientDropdownOpen((v) => !v)}
-            className="flex items-center justify-between gap-2 text-sm px-3 py-2 border border-gray-300 rounded-md bg-white min-w-[240px] hover:border-gray-400"
+            className="flex items-center justify-between gap-2 text-sm px-3 py-2 border border-border rounded-md bg-surface min-w-[240px] hover:border-ink-soft"
           >
-            <span className={selectedClient ? "text-gray-900" : "text-gray-400"}>
+            <span className={selectedClient ? "text-ink" : "text-subtle"}>
               {selectedClient
                 ? `${selectedClient.name} ${selectedClient.surname}`
                 : "Todos os clientes"}
             </span>
-            <ChevronDown className="w-4 h-4 text-gray-500" />
+            <ChevronDown className="w-4 h-4 text-muted" />
           </button>
 
           {isClientDropdownOpen && (
-            <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-md shadow-lg z-20 max-h-72 overflow-hidden flex flex-col">
-              <div className="p-2 border-b border-gray-100">
+            <div className="absolute top-full left-0 right-0 mt-1 bg-surface border border-border rounded-md shadow-ds-floating z-20 max-h-72 overflow-hidden flex flex-col">
+              <div className="p-2 border-b border-border-soft">
                 <div className="relative">
-                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <Search className="absolute left-2 top-1/2 -translate-y-1/2 w-4 h-4 text-subtle" />
                   <input
                     type="text"
                     value={clientSearch}
                     onChange={(e) => setClientSearch(e.target.value)}
                     placeholder="Buscar cliente..."
-                    className="w-full text-sm pl-8 pr-2 py-1.5 border border-gray-200 rounded"
+                    className="w-full text-sm pl-8 pr-2 py-1.5 border border-border-soft rounded"
                     autoFocus
                   />
                 </div>
@@ -162,12 +139,12 @@ export default function ConsultantProcessesPage() {
                     setIsClientDropdownOpen(false);
                     setClientSearch("");
                   }}
-                  className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50 text-gray-500 border-b border-gray-100"
+                  className="w-full text-left px-3 py-2 text-sm hover:bg-border-soft text-subtle border-b border-border-soft"
                 >
                   Todos os clientes
                 </button>
                 {filteredClients.length === 0 ? (
-                  <p className="px-3 py-2 text-sm text-gray-400">Nenhum cliente.</p>
+                  <p className="px-3 py-2 text-sm text-subtle">Nenhum cliente.</p>
                 ) : (
                   filteredClients.map((c) => (
                     <button
@@ -178,10 +155,10 @@ export default function ConsultantProcessesPage() {
                         setIsClientDropdownOpen(false);
                         setClientSearch("");
                       }}
-                      className="w-full text-left px-3 py-2 text-sm hover:bg-gray-50"
+                      className="w-full text-left px-3 py-2 text-sm hover:bg-border-soft"
                     >
-                      <div className="font-medium text-gray-900">{c.name} {c.surname}</div>
-                      <div className="text-xs text-gray-400">{c.email}</div>
+                      <div className="font-medium text-ink">{c.name} {c.surname}</div>
+                      <div className="text-xs text-subtle">{c.email}</div>
                     </button>
                   ))
                 )}
@@ -194,99 +171,100 @@ export default function ConsultantProcessesPage() {
           <button
             type="button"
             onClick={clearFilters}
-            className="inline-flex items-center gap-1 text-xs text-gray-600 hover:text-gray-900 px-3 py-2 self-end"
+            className="inline-flex items-center gap-1 text-xs text-muted hover:text-ink px-3 py-2 self-end"
           >
             <X className="w-3.5 h-3.5" />
             Limpar filtros
           </button>
         )}
-      </div>
+      </Card>
 
-      {/* Lista de processos */}
-      <div className="p-6 rounded-lg shadow bg-white">
+      <Card>
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h2 className="h2-style">Processos</h2>
-            <p className="text-sm text-gray-500 mt-1">
+            <h2 className="text-h2 font-semibold text-ink">Processos</h2>
+            <p className="text-sm text-muted mt-1">
               Clique em um processo para ver os detalhes.
             </p>
           </div>
-          <span className="text-sm text-gray-500">
+          <span className="text-sm text-muted">
             {processes.length} {processes.length === 1 ? "processo" : "processos"}
           </span>
         </div>
 
         {error ? (
-          <p className="text-red-500">{error}</p>
+          <p className="text-status-bad">{error}</p>
         ) : isLoading ? (
           <div className="flex items-center justify-center py-16">
             <div className="flex flex-col items-center gap-3">
-              <Loader2 className="w-8 h-8 animate-spin text-gray-400" />
-              <p className="text-sm text-gray-500">Carregando processos...</p>
+              <Loader2 className="w-8 h-8 animate-spin text-subtle" />
+              <p className="text-sm text-muted">Carregando processos...</p>
             </div>
           </div>
         ) : processes.length === 0 ? (
-          <div className="text-center py-12 text-gray-500">
-            {hasFilters
-              ? "Nenhum processo com esses filtros."
-              : "Nenhum processo ainda. Crie processos na página de Clientes."}
-          </div>
+          <EmptyState
+            icon={Search}
+            title={hasFilters ? "Nenhum processo com esses filtros" : "Nenhum processo ainda"}
+            description={hasFilters ? undefined : "Crie processos na página de Clientes."}
+          />
         ) : (
           <>
-            <div className="flex flex-col gap-2">
-              <div className="grid grid-cols-[1.5fr_1.5fr_1fr_1fr_1fr] gap-4 px-4 py-2 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                <div>Cliente</div>
-                <div>Especialista</div>
-                <div>Produto</div>
-                <div>Status</div>
-                <div>Data</div>
-              </div>
-
-              {pageProcesses.map((proc) => (
-                <div
-                  key={proc.id}
-                  onClick={() => navigate(`/consultant/processes/${proc.id}`)}
-                  className="grid grid-cols-[1.5fr_1.5fr_1fr_1fr_1fr] gap-4 items-center px-4 py-3 bg-white rounded-lg border border-gray-100 hover:border-gray-300 cursor-pointer transition-colors"
-                >
-                  <div className="text-sm font-medium text-gray-900">
-                    {proc.client ? `${proc.client.name} ${proc.client.surname}` : "—"}
-                  </div>
-                  <div className="text-sm text-gray-600">
-                    {proc.specialist ? `${proc.specialist.name} ${proc.specialist.surname}` : "—"}
-                  </div>
-                  <div className="text-sm text-gray-600">
-                    {PRODUCT_LABELS[proc.product_type ?? ""] ?? proc.product_type ?? "Consultoria"}
-                  </div>
-                  <div>
-                    <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${STATUS_COLORS[proc.status] ?? "bg-gray-100 text-gray-600"}`}>
-                      {STATUS_LABELS[proc.status] ?? proc.status}
-                    </span>
-                  </div>
-                  <div className="text-xs text-gray-400">
-                    {new Date(proc.created_at).toLocaleDateString("pt-BR")}
-                  </div>
-                </div>
-              ))}
+            <div className="overflow-x-auto rounded-lg border border-border">
+              <table className="w-full min-w-[720px] text-sm">
+                <thead>
+                  <tr className="border-b border-border">
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Cliente</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Especialista</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Produto</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Status</th>
+                    <th className="text-left text-xs uppercase tracking-wide text-muted font-semibold px-4 py-3">Data</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {pageProcesses.map((proc) => (
+                    <tr
+                      key={proc.id}
+                      onClick={() => navigate(`/consultant/processes/${proc.id}`)}
+                      className="border-b border-border-soft hover:bg-border-soft/50 cursor-pointer transition-colors"
+                    >
+                      <td className="px-4 py-3 text-sm font-medium text-ink">
+                        {proc.client ? `${proc.client.name} ${proc.client.surname}` : "—"}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-muted">
+                        {proc.specialist ? `${proc.specialist.name} ${proc.specialist.surname}` : "—"}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-muted">
+                        {PRODUCT_LABELS[proc.product_type ?? ""] ?? proc.product_type ?? "Consultoria"}
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusBadge status={proc.status} />
+                      </td>
+                      <td className="px-4 py-3 text-xs text-subtle">
+                        {new Date(proc.created_at).toLocaleDateString("pt-BR")}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
 
-            {/* Paginação */}
             {totalPages > 1 && (
-              <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-200">
-                <span className="text-xs text-gray-500">
+              <div className="flex items-center justify-between mt-4 pt-3 border-t border-border">
+                <span className="text-xs text-muted">
                   Página {page} de {totalPages}
                 </span>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => setPage((p) => Math.max(1, p - 1))}
                     disabled={page === 1}
-                    className="px-3 py-1.5 text-sm rounded border border-gray-200 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+                    className="px-3 py-1.5 text-sm rounded border border-border hover:bg-border-soft disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     Anterior
                   </button>
                   <button
                     onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                     disabled={page === totalPages}
-                    className="px-3 py-1.5 text-sm rounded border border-gray-200 hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed"
+                    className="px-3 py-1.5 text-sm rounded border border-border hover:bg-border-soft disabled:opacity-30 disabled:cursor-not-allowed"
                   >
                     Próxima
                   </button>
@@ -295,7 +273,7 @@ export default function ConsultantProcessesPage() {
             )}
           </>
         )}
-      </div>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/pages/customer/ConsultoriaPage.tsx
+++ b/frontend/src/pages/customer/ConsultoriaPage.tsx
@@ -1,23 +1,22 @@
-import { useEffect, useState, useContext, useRef } from "react";
+import { useEffect, useState, useContext } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Car, Ship, Plane, Calendar, UserCircle2, Loader2 } from "lucide-react";
-import { PopupModal, useCalendlyEventListener } from "react-calendly";
+import { PopupModal } from "react-calendly";
 import {
   getSpecialistsGroupedByCategory,
   type Specialist,
   type GroupedSpecialists,
 } from "../../services/specialists.service";
-import {
-  cancelPendingAppointment,
-  createConsultancyAppointment,
-  getCalendlySyncStatus,
-  registerCalendlyScheduledEvent,
-} from "../../services/appointments.service";
+import { createConsultancyAppointment } from "../../services/appointments.service";
 import { AuthContext } from "../../contexts/AuthContext";
 import Button from "../../components/ui/button";
+import { Card } from "../../components/ui/card";
+import { Alert } from "../../components/ui/alert";
+import { EmptyState } from "../../components/patterns/EmptyState";
 import ProductTypePreferenceModal, {
   type PreferredProductType,
 } from "../../components/product/ProductTypePreferenceModal";
+import { useCalendlyScheduling } from "../../hooks/useCalendlyScheduling";
 
 type SpecialityType = "CAR" | "BOAT" | "AIRCRAFT";
 
@@ -48,17 +47,19 @@ export default function ConsultoriaPage() {
     string | null
   >(null);
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [isCalendlyModalOpen, setIsCalendlyModalOpen] = useState(false);
-  const [calendlyModalUrl, setCalendlyModalUrl] = useState<string | null>(null);
-  const [pendingAppointmentId, setPendingAppointmentId] = useState<
-    string | null
-  >(null);
-  const [syncMessage, setSyncMessage] = useState("");
-  const [syncState, setSyncState] = useState<
-    "idle" | "waiting_event" | "syncing" | "done" | "error"
-  >("idle");
   const [isTypeModalOpen, setIsTypeModalOpen] = useState(false);
-  const schedulingActuallyConfirmed = useRef(false);
+
+  const {
+    isModalOpen: isCalendlyModalOpen,
+    modalUrl: calendlyModalUrl,
+    syncState,
+    syncMessage,
+    openPopup,
+    closePopup,
+  } = useCalendlyScheduling({
+    successRedirectMessage:
+      "Solicitação de consultoria registrada com sucesso! Verifique seus processos.",
+  });
 
   const typeFromUrl = searchParams.get("type") as PreferredProductType | null;
   const selectedType: PreferredProductType | null =
@@ -109,84 +110,6 @@ export default function ConsultoriaPage() {
     setIsTypeModalOpen(false);
   };
 
-  const pollCalendlySyncStatus = async (appointmentId: string) => {
-    const maxAttempts = 8;
-    const intervalMs = 3500;
-
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const syncStatus = await getCalendlySyncStatus(appointmentId);
-
-      if (
-        syncStatus.calendly_sync_status === "SYNCED" ||
-        syncStatus.appointment_datetime
-      ) {
-        setSyncState("done");
-        setSyncMessage(
-          "Agendamento recebido! Você pode acompanhar os detalhes em Meus Processos."
-        );
-
-        setTimeout(() => {
-          navigate("/customer/processes", {
-            state: {
-              message:
-                "Solicitação de consultoria registrada com sucesso! Verifique seus processos.",
-            },
-          });
-        }, 900);
-        return;
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    }
-
-    setSyncState("done");
-    setSyncMessage(
-      "Solicitação registrada. Estamos finalizando a sincronização do horário com o calendário."
-    );
-  };
-
-  useCalendlyEventListener({
-    onEventScheduled: async (event) => {
-      if (!pendingAppointmentId) {
-        return;
-      }
-
-      const payload = (event as any)?.data?.payload;
-      const eventUri = payload?.event?.uri;
-      const inviteeUri = payload?.invitee?.uri;
-
-      if (!eventUri || !inviteeUri) {
-        setSyncState("error");
-        setSyncMessage(
-          "Não foi possível capturar os dados do agendamento. Verifique seus processos para confirmar."
-        );
-        return;
-      }
-
-      try {
-        setSyncState("syncing");
-        setSyncMessage("Sincronizando seu agendamento...");
-
-        await registerCalendlyScheduledEvent(pendingAppointmentId, {
-          event_uri: eventUri,
-          invitee_uri: inviteeUri,
-          client_event: "calendly.event_scheduled",
-          client_observed_at: new Date().toISOString(),
-        });
-
-        schedulingActuallyConfirmed.current = true;
-        setIsCalendlyModalOpen(false);
-        await pollCalendlySyncStatus(pendingAppointmentId);
-      } catch (error) {
-        console.error("Erro ao sincronizar evento do Calendly:", error);
-        setSyncState("error");
-        setSyncMessage(
-          "Agendamento criado, mas houve falha na sincronização automática. Você pode seguir em Meus Processos."
-        );
-      }
-    },
-  });
-
   const handleRequestMeeting = async (specialist: Specialist) => {
     if (!user || requestingSpecialistId) return;
 
@@ -215,14 +138,7 @@ export default function ConsultoriaPage() {
         ? rawCalendlyUrl
         : `https://${rawCalendlyUrl}`;
 
-      schedulingActuallyConfirmed.current = false;
-      setPendingAppointmentId(pendingAppointment.id);
-      setCalendlyModalUrl(formattedUrl);
-      setSyncState("waiting_event");
-      setSyncMessage(
-        "Conclua seu agendamento no Calendly para sincronizar automaticamente com a plataforma."
-      );
-      setIsCalendlyModalOpen(true);
+      openPopup(pendingAppointment.id, formattedUrl);
     } catch (error: any) {
       const message =
         error?.response?.data?.error?.message ||
@@ -234,28 +150,12 @@ export default function ConsultoriaPage() {
     }
   };
 
-  const handleCalendlyModalClose = async () => {
-    setIsCalendlyModalOpen(false);
-
-    if (!schedulingActuallyConfirmed.current && pendingAppointmentId) {
-      try {
-        await cancelPendingAppointment(pendingAppointmentId);
-      } catch (err) {
-        console.error("Erro ao cancelar agendamento ao fechar modal", err);
-      } finally {
-        setPendingAppointmentId(null);
-        setSyncState("idle");
-        setSyncMessage("");
-      }
-    }
-  };
-
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
         <div className="flex flex-col items-center gap-4">
           <div className="w-12 h-12 border-3 border-gray-200 border-t-primary rounded-full animate-spin" />
-          <p className="text-gray-600">Carregando especialistas...</p>
+          <p className="text-muted">Carregando especialistas...</p>
         </div>
       </div>
     );
@@ -265,10 +165,10 @@ export default function ConsultoriaPage() {
     <div className="flex flex-col gap-8 w-full max-w-6xl mx-auto py-8 px-4">
       {/* Header */}
       <div className="space-y-4">
-        <h1 className="text-3xl sm:text-4xl font-bold text-gray-900">
+        <h1 className="text-3xl sm:text-4xl font-bold text-ink">
           Consultoria Especializada
         </h1>
-        <p className="text-lg text-gray-600 max-w-3xl">
+        <p className="text-lg text-muted max-w-3xl">
           Nossos especialistas estão prontos para ajudá-lo a encontrar o produto
           perfeito. Escolha um especialista na categoria de seu interesse para
           agendar uma consultoria.
@@ -287,24 +187,20 @@ export default function ConsultoriaPage() {
             Trocar categoria
           </Button>
         </div>
-        {errorMessage && (
-          <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {errorMessage}
-          </div>
-        )}
+        {errorMessage && <Alert variant="danger">{errorMessage}</Alert>}
 
         {syncState !== "idle" && syncMessage && (
-          <div
-            className={`rounded-lg border px-4 py-3 text-sm ${
+          <Alert
+            variant={
               syncState === "error"
-                ? "border-red-200 bg-red-50 text-red-700"
+                ? "danger"
                 : syncState === "done"
-                  ? "border-green-200 bg-green-50 text-green-700"
-                  : "border-amber-200 bg-amber-50 text-amber-700"
-            }`}
+                  ? "success"
+                  : "warning"
+            }
           >
             {syncMessage}
-          </div>
+          </Alert>
         )}
       </div>
 
@@ -313,14 +209,14 @@ export default function ConsultoriaPage() {
         {visibleGroups.map((group) => (
           <div key={group.type} className="space-y-6">
             {/* Category Header */}
-            <div className="flex items-center gap-4 border-b-2 border-gray-200 pb-4">
+            <div className="flex items-center gap-4 border-b-2 border-border pb-4">
               <div className="p-3 bg-brand-primary/10 rounded-full text-brand-primary">
                 {group.icon}
               </div>
-              <h2 className="text-2xl font-bold text-gray-900">
+              <h2 className="text-2xl font-bold text-ink">
                 {group.label}
               </h2>
-              <span className="text-sm text-gray-500">
+              <span className="text-sm text-muted">
                 ({group.specialists.length} especialista
                 {group.specialists.length !== 1 ? "s" : ""})
               </span>
@@ -339,9 +235,10 @@ export default function ConsultoriaPage() {
                 ))}
               </div>
             ) : (
-              <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-xl">
-                Nenhum especialista disponível nesta categoria no momento.
-              </div>
+              <EmptyState
+                icon={UserCircle2}
+                title="Nenhum especialista disponível nesta categoria no momento."
+              />
             )}
           </div>
         ))}
@@ -351,7 +248,7 @@ export default function ConsultoriaPage() {
         <PopupModal
           url={calendlyModalUrl}
           open={isCalendlyModalOpen}
-          onModalClose={handleCalendlyModalClose}
+          onModalClose={closePopup}
           rootElement={document.getElementById("root") ?? document.body}
           prefill={{
             name: user ? `${user.name} ${user.surname}`.trim() : undefined,
@@ -387,16 +284,16 @@ function SpecialistCard({
   isRequesting,
 }: SpecialistCardProps) {
   return (
-    <div className="bg-white border border-gray-200 rounded-xl p-6 hover:shadow-lg transition-shadow">
+    <Card className="hover:shadow-lg transition-shadow">
       <div className="flex flex-col items-center text-center space-y-4">
-        <div className="p-4 bg-gray-100 rounded-full">
-          <UserCircle2 size={64} className="text-gray-400" />
+        <div className="p-4 bg-border-soft rounded-full">
+          <UserCircle2 size={64} className="text-subtle" />
         </div>
         <div>
-          <h3 className="text-lg font-semibold text-gray-900">
+          <h3 className="text-lg font-semibold text-ink">
             {specialist.name} {specialist.surname}
           </h3>
-          <p className="text-sm text-gray-500">{specialist.email}</p>
+          <p className="text-sm text-muted">{specialist.email}</p>
         </div>
         <Button
           onClick={() => onRequestMeeting(specialist)}
@@ -417,6 +314,6 @@ function SpecialistCard({
           )}
         </Button>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/frontend/src/pages/customer/CustomerHomePage.tsx
+++ b/frontend/src/pages/customer/CustomerHomePage.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../store/authStateManager";
 import { Search, BookOpen, Car, Ship, Plane } from "lucide-react";
+import Button from "../../components/ui/button";
 import ProductTypePreferenceModal, {
   type PreferredProductType,
 } from "../../components/product/ProductTypePreferenceModal";
@@ -38,10 +39,10 @@ export default function CustomerHomePage() {
     <div className="flex flex-col w-full max-w-6xl mx-auto py-8 px-4">
       {/* Welcome Section */}
       <div className="text-center space-y-2">
-        <h1 className="text-3xl sm:text-4xl font-bold text-gray-900">
+        <h1 className="text-3xl sm:text-4xl font-bold text-ink">
           Bem-vindo{user?.name ? `, ${user.name}` : ''}!
         </h1>
-        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+        <p className="text-lg text-muted max-w-2xl mx-auto">
           O que você gostaria de fazer hoje? Escolha uma das opções abaixo para começar.
         </p>
       </div>
@@ -49,102 +50,105 @@ export default function CustomerHomePage() {
       {/* Main Options Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-8">
         {/* Explorar Catálogo Card */}
-        <div 
+        <div
           onClick={() => handleOpenInterestModal("catalog")}
-          className="bg-white border-2 border-gray-200 rounded-2xl p-8 cursor-pointer hover:border-primary hover:shadow-xl transition-all duration-300 group"
+          className="bg-surface border-2 border-border rounded-2xl p-8 cursor-pointer hover:border-ink hover:shadow-xl transition-all duration-300 group"
         >
           <div className="flex flex-col items-center text-center space-y-6">
-            <div className="p-4 bg-primary/10 rounded-full group-hover:bg-primary/20 transition-colors">
-              <Search size={48} className="text-primary" />
+            <div className="p-4 bg-ink/10 rounded-full group-hover:bg-ink/20 transition-colors">
+              <Search size={48} className="text-ink" />
             </div>
             <div className="space-y-2">
-              <h2 className="text-2xl font-bold text-gray-900">Explorar o Catálogo</h2>
-              <p className="text-gray-600">
+              <h2 className="text-2xl font-bold text-ink">Explorar o Catálogo</h2>
+              <p className="text-muted">
                 Navegue por nossa coleção exclusiva de produtos de luxo.
                 Encontre carros, embarcações ou aeronaves perfeitos para você.
               </p>
             </div>
-            
+
             {/* Category Icons */}
             <div className="flex gap-6 pt-4">
-              <div className="flex flex-col items-center gap-2 text-gray-500">
+              <div className="flex flex-col items-center gap-2 text-muted">
                 <Car size={24} />
                 <span className="text-xs">Carros</span>
               </div>
-              <div className="flex flex-col items-center gap-2 text-gray-500">
+              <div className="flex flex-col items-center gap-2 text-muted">
                 <Ship size={24} />
                 <span className="text-xs">Embarcações</span>
               </div>
-              <div className="flex flex-col items-center gap-2 text-gray-500">
+              <div className="flex flex-col items-center gap-2 text-muted">
                 <Plane size={24} />
                 <span className="text-xs">Aeronaves</span>
               </div>
             </div>
-            
-            <button className="mt-4 px-6 py-3 bg-brand-primary text-brand-primary-fg font-semibold rounded-lg hover:opacity-90 transition-colors">
+
+            <Button variant="brand" className="mt-4">
               Explorar Agora
-            </button>
+            </Button>
           </div>
         </div>
 
         {/* Pedir Consultoria Card */}
-        <div 
+        <div
           onClick={() => handleOpenInterestModal("consultoria")}
-          className="bg-white border-2 border-gray-200 rounded-2xl p-8 cursor-pointer hover:border-primary hover:shadow-xl transition-all duration-300 group"
+          className="bg-surface border-2 border-border rounded-2xl p-8 cursor-pointer hover:border-ink hover:shadow-xl transition-all duration-300 group"
         >
           <div className="flex flex-col items-center text-center space-y-6">
-            <div className="p-4 bg-primary/10 rounded-full group-hover:bg-primary/20 transition-colors">
-              <BookOpen size={48} className="text-primary" />
+            <div className="p-4 bg-ink/10 rounded-full group-hover:bg-ink/20 transition-colors">
+              <BookOpen size={48} className="text-ink" />
             </div>
             <div className="space-y-2">
-              <h2 className="text-2xl font-bold text-gray-900">Pedir Consultoria</h2>
-              <p className="text-gray-600">
-                Agende uma consulta com nossos especialistas. 
+              <h2 className="text-2xl font-bold text-ink">Pedir Consultoria</h2>
+              <p className="text-muted">
+                Agende uma consulta com nossos especialistas.
                 Receba orientação personalizada para sua compra.
               </p>
             </div>
-            
+
             {/* Features */}
-            <div className="flex flex-col gap-2 pt-4 text-sm text-gray-500">
+            <div className="flex flex-col gap-2 pt-4 text-sm text-muted">
               <p>✓ Especialistas em cada categoria</p>
               <p>✓ Consultoria personalizada</p>
               <p>✓ Agendamento flexível</p>
             </div>
-            
-            <button className="mt-4 px-6 py-3 bg-brand-primary text-brand-primary-fg font-semibold rounded-lg hover:opacity-90 transition-colors">
+
+            <Button variant="brand" className="mt-4">
               Agendar Consultoria
-            </button>
+            </Button>
           </div>
         </div>
       </div>
 
       {/* Quick Access to Categories */}
       <div className="mt-12">
-        <h3 className="text-xl font-semibold text-gray-900 mb-6 text-center">
+        <h3 className="text-xl font-semibold text-ink mb-6 text-center">
           Acesso Rápido às Categorias
         </h3>
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <button
+          <Button
             onClick={() => navigate("/catalog/cars")}
-            className="flex items-center justify-center gap-3 p-4 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors"
+            variant="light"
+            className="justify-center gap-3 p-4 rounded-xl"
           >
-            <Car size={24} className="text-primary" />
+            <Car size={24} className="text-ink" />
             <span className="font-medium">Carros</span>
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={() => navigate("/catalog/boats")}
-            className="flex items-center justify-center gap-3 p-4 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors"
+            variant="light"
+            className="justify-center gap-3 p-4 rounded-xl"
           >
-            <Ship size={24} className="text-primary" />
+            <Ship size={24} className="text-ink" />
             <span className="font-medium">Embarcações</span>
-          </button>
-          <button
+          </Button>
+          <Button
             onClick={() => navigate("/catalog/aircrafts")}
-            className="flex items-center justify-center gap-3 p-4 bg-gray-100 rounded-xl hover:bg-gray-200 transition-colors"
+            variant="light"
+            className="justify-center gap-3 p-4 rounded-xl"
           >
-            <Plane size={24} className="text-primary" />
+            <Plane size={24} className="text-ink" />
             <span className="font-medium">Aeronaves</span>
-          </button>
+          </Button>
         </div>
       </div>
 

--- a/frontend/src/pages/customer/CustomerProcessesPage.tsx
+++ b/frontend/src/pages/customer/CustomerProcessesPage.tsx
@@ -4,6 +4,10 @@ import { useAuth } from "../../store/authStateManager";
 import Loading from "../../components/ui/Loading";
 import ProcessCard from "../../components/processes/ProcessCard";
 import api from "../../services/api";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { EmptyState } from "../../components/patterns/EmptyState";
 
 interface ProcessClient {
   id: string;
@@ -160,87 +164,71 @@ export default function CustomerProcessesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-5xl mx-auto px-4 py-6">
-          <h1 className="text-2xl md:text-3xl font-bold text-gray-900">
-            Meus Processos
-          </h1>
-          <p className="text-sm text-gray-600 mt-1">
-            Acompanhe o andamento das suas negociações
-          </p>
+    <div className="w-full">
+      <PageHeader title="Meus Processos" />
+
+      {/* Error */}
+      {error && (
+        <Alert variant="danger" className="mb-6">
+          <AlertCircle size={20} />
+          <p>{error}</p>
+        </Alert>
+      )}
+
+      {/* Empty State */}
+      {processes.length === 0 && !error && (
+        <EmptyState
+          icon={FileText}
+          title="Nenhum processo encontrado"
+          description="Você ainda não possui processos de negociação. Explore o catálogo e agende uma reunião com um especialista!"
+        />
+      )}
+
+      {/* Processes List */}
+      {processes.length > 0 && (
+        <div className="space-y-4">
+          {processes.map((process) => (
+            <ProcessCard
+              key={process.id}
+              process={process as any}
+              product={process.product}
+              isClientView={true}
+            />
+          ))}
         </div>
-      </div>
+      )}
 
-      {/* Content */}
-      <div className="max-w-5xl mx-auto px-4 py-6">
-        {/* Error */}
-        {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-center gap-3">
-            <AlertCircle size={20} className="text-red-600" />
-            <p className="text-sm text-red-700">{error}</p>
+      {/* Pagination */}
+      {processes.length > 0 && totalPages > 1 && (
+        <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-muted">
+            Página <span className="font-semibold">{currentPage}</span> de{" "}
+            <span className="font-semibold">{totalPages}</span>
+          </p>
+
+          <div className="flex gap-2 justify-center">
+            <Button
+              onClick={handlePreviousPage}
+              disabled={!hasPreviousPage}
+              variant="light"
+              className="text-sm"
+            >
+              <ChevronLeft size={18} />
+              Anterior
+            </Button>
+
+            <Button
+              onClick={handleNextPage}
+              disabled={!hasNextPage}
+              variant="light"
+              className="text-sm"
+            >
+              Próximo
+              <ChevronRight size={18} />
+            </Button>
           </div>
-        )}
-
-        {/* Empty State */}
-        {processes.length === 0 && !error && (
-          <div className="text-center py-12">
-            <FileText size={48} className="mx-auto text-gray-400 mb-4" />
-            <h3 className="text-lg font-semibold text-gray-900 mb-2">
-              Nenhum processo encontrado
-            </h3>
-            <p className="text-sm text-gray-600">
-              Você ainda não possui processos de negociação. Explore o catálogo
-              e agende uma reunião com um especialista!
-            </p>
-          </div>
-        )}
-
-        {/* Processes List */}
-        {processes.length > 0 && (
-          <div className="space-y-4">
-            {processes.map((process) => (
-              <ProcessCard
-                key={process.id}
-                process={process as any}
-                product={process.product}
-                isClientView={true}
-              />
-            ))}
-          </div>
-        )}
-
-        {/* Pagination */}
-        {processes.length > 0 && totalPages > 1 && (
-          <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-sm text-gray-600">
-              Página <span className="font-semibold">{currentPage}</span> de{" "}
-              <span className="font-semibold">{totalPages}</span>
-            </p>
-
-            <div className="flex gap-2 justify-center">
-              <button
-                onClick={handlePreviousPage}
-                disabled={!hasPreviousPage}
-                className="inline-flex items-center gap-1 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-              >
-                <ChevronLeft size={18} />
-                Anterior
-              </button>
-
-              <button
-                onClick={handleNextPage}
-                disabled={!hasNextPage}
-                className="inline-flex items-center gap-1 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-              >
-                Próximo
-                <ChevronRight size={18} />
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/office/OfficeClientsPage.tsx
+++ b/frontend/src/pages/office/OfficeClientsPage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
+import { Users } from "lucide-react";
 import { officeService, type OfficeClient } from "../../services/office";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { EmptyState } from "../../components/patterns/EmptyState";
 
 export default function OfficeClientsPage() {
   const [clients, setClients] = useState<OfficeClient[]>([]);
@@ -25,8 +28,7 @@ export default function OfficeClientsPage() {
 
   return (
     <div className="p-8">
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">Clientes do escritório</h1>
-      <p className="text-sm text-gray-500 mb-4">Visualização somente leitura.</p>
+      <PageHeader title="Clientes do escritório" />
 
       <div className="flex gap-2 mb-4">
         <input
@@ -35,34 +37,32 @@ export default function OfficeClientsPage() {
           onChange={(e) => setQ(e.target.value)}
           onKeyDown={(e) => e.key === "Enter" && load()}
           placeholder="Buscar por nome ou email..."
-          className="flex-1 px-3 py-2 border border-gray-300 rounded-md"
+          className="flex-1 px-3 py-2 border border-border rounded-md"
         />
       </div>
 
-      {loading && <p className="text-gray-500">Carregando...</p>}
-      {error && <p className="text-red-600">{error}</p>}
+      {loading && <p className="text-muted">Carregando...</p>}
+      {error && <p className="text-status-bad">{error}</p>}
       {!loading && clients.length === 0 && (
-        <div className="bg-white p-8 rounded-lg shadow text-center text-gray-500">
-          Nenhum cliente ainda.
-        </div>
+        <EmptyState icon={Users} title="Nenhum cliente ainda." />
       )}
 
       {clients.length > 0 && (
-        <div className="bg-white rounded-lg shadow overflow-x-auto">
+        <div className="bg-surface rounded-lg shadow overflow-x-auto">
           <table className="w-full min-w-[640px]">
-            <thead className="bg-gray-50 border-b">
+            <thead className="bg-border-soft border-b border-border">
               <tr>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Cliente</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">E-mail</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Consultor</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Cadastrado</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">Cliente</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">E-mail</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">Consultor</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">Cadastrado</th>
               </tr>
             </thead>
             <tbody>
               {clients.map((c) => (
-                <tr key={c.id} className="border-b">
+                <tr key={c.id} className="border-b border-border-soft">
                   <td className="px-4 py-3 text-sm">{c.name} {c.surname}</td>
-                  <td className="px-4 py-3 text-sm text-gray-600">{c.email}</td>
+                  <td className="px-4 py-3 text-sm text-muted">{c.email}</td>
                   <td className="px-4 py-3 text-sm">
                     {c.consultant ? `${c.consultant.name} ${c.consultant.surname}` : "—"}
                   </td>

--- a/frontend/src/pages/office/OfficeCompanySettingsPage.tsx
+++ b/frontend/src/pages/office/OfficeCompanySettingsPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { officeService, type OfficeCompany } from "../../services/office";
 import Button from "../../components/ui/button";
+import { Card } from "../../components/ui/card";
+import { PageHeader } from "../../components/patterns/PageHeader";
 import { resolveCompanyLogo } from "../../utils/branding";
 
 const DEFAULT_COLORS = ["#1a1a1a", "#3b82f6", "#10b981", "#f59e0b"];
@@ -88,19 +90,19 @@ export default function OfficeCompanySettingsPage() {
     setForm({ ...form, color_identity: next });
   };
 
-  if (loading) return <div className="p-8 text-gray-500">Carregando...</div>;
+  if (loading) return <div className="p-8 text-muted">Carregando...</div>;
   if (!company) return null;
 
   return (
     <div className="p-8 max-w-3xl">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">Configurações do escritório</h1>
+      <PageHeader title="Configurações do escritório" />
 
       {msg && (
-        <p className={`mb-4 text-sm ${msg.ok ? "text-green-600" : "text-red-600"}`}>{msg.text}</p>
+        <p className={`mb-4 text-sm ${msg.ok ? "text-status-ok" : "text-status-bad"}`}>{msg.text}</p>
       )}
 
-      <section className="bg-white p-6 rounded-lg shadow mb-6">
-        <h2 className="text-lg font-semibold mb-4">Logo</h2>
+      <Card className="mb-6">
+        <h2 className="text-h2 font-semibold text-ink mb-4">Logo</h2>
         <div className="flex items-center gap-4">
           {(() => {
             const src = resolveCompanyLogo(company);
@@ -108,10 +110,10 @@ export default function OfficeCompanySettingsPage() {
               <img
                 src={src}
                 alt={`Logo ${company.name}`}
-                className="w-24 h-24 border border-gray-200 rounded object-contain bg-gray-50"
+                className="w-24 h-24 border border-border rounded object-contain bg-border-soft"
               />
             ) : (
-              <div className="w-24 h-24 border border-dashed border-gray-300 rounded bg-gray-50 flex items-center justify-center text-xs text-gray-400">
+              <div className="w-24 h-24 border border-dashed border-border rounded bg-border-soft flex items-center justify-center text-xs text-subtle">
                 Sem logo
               </div>
             );
@@ -124,95 +126,97 @@ export default function OfficeCompanySettingsPage() {
             className="text-sm"
           />
         </div>
-        <p className="text-xs text-gray-500 mt-2">
+        <p className="text-xs text-muted mt-2">
           PNG, JPEG, WebP (≤2MB) ou SVG sanitizado (≤500KB). SVG passa por DOMPurify antes de salvar.
         </p>
-      </section>
+      </Card>
 
-      <form onSubmit={save} className="bg-white p-6 rounded-lg shadow space-y-4">
-        <Field label="Nome do escritório">
-          <input
-            type="text"
-            value={form.name ?? ""}
-            onChange={(e) => setForm({ ...form, name: e.target.value })}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md"
-            required
-          />
-        </Field>
-
-        <Field label="Descrição">
-          <textarea
-            value={form.description ?? ""}
-            onChange={(e) => setForm({ ...form, description: e.target.value })}
-            rows={3}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md"
-          />
-        </Field>
-
-        <Field label="CNPJ">
-          <input
-            type="text"
-            value={form.cnpj ?? ""}
-            onChange={(e) => setForm({ ...form, cnpj: e.target.value })}
-            placeholder="14 dígitos ou XX.XXX.XXX/XXXX-XX"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md"
-          />
-        </Field>
-
-        <div className="grid grid-cols-3 gap-4">
-          <Field label="Banco">
+      <Card>
+        <form onSubmit={save} className="space-y-4">
+          <Field label="Nome do escritório">
             <input
               type="text"
-              value={form.bank ?? ""}
-              onChange={(e) => setForm({ ...form, bank: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              value={form.name ?? ""}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              className="w-full px-3 py-2 border border-border rounded-md"
+              required
             />
           </Field>
-          <Field label="Agência">
+
+          <Field label="Descrição">
+            <textarea
+              value={form.description ?? ""}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              rows={3}
+              className="w-full px-3 py-2 border border-border rounded-md"
+            />
+          </Field>
+
+          <Field label="CNPJ">
             <input
               type="text"
-              value={form.agency ?? ""}
-              onChange={(e) => setForm({ ...form, agency: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
+              value={form.cnpj ?? ""}
+              onChange={(e) => setForm({ ...form, cnpj: e.target.value })}
+              placeholder="14 dígitos ou XX.XXX.XXX/XXXX-XX"
+              className="w-full px-3 py-2 border border-border rounded-md"
             />
           </Field>
-          <Field label="Conta corrente">
-            <input
-              type="text"
-              value={form.checking_account ?? ""}
-              onChange={(e) => setForm({ ...form, checking_account: e.target.value })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md"
-            />
-          </Field>
-        </div>
 
-        <Field label="Comissão padrão (%)">
-          <div className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-md text-gray-700">
-            {company.commission_rate != null ? `${company.commission_rate}%` : "—"}
-          </div>
-          <p className="text-xs text-gray-500 mt-1">
-            Somente o administrador pode alterar a comissão do escritório.
-          </p>
-        </Field>
-
-        <Field label="Identidade visual (até 4 cores hex)">
-          <div className="grid grid-cols-4 gap-3">
-            {[0, 1, 2, 3].map((i) => (
+          <div className="grid grid-cols-3 gap-4">
+            <Field label="Banco">
               <input
-                key={i}
-                type="color"
-                value={form.color_identity?.[i] ?? DEFAULT_COLORS[i]}
-                onChange={(e) => setColor(i, e.target.value)}
-                className="h-10 w-full border border-gray-300 rounded"
+                type="text"
+                value={form.bank ?? ""}
+                onChange={(e) => setForm({ ...form, bank: e.target.value })}
+                className="w-full px-3 py-2 border border-border rounded-md"
               />
-            ))}
+            </Field>
+            <Field label="Agência">
+              <input
+                type="text"
+                value={form.agency ?? ""}
+                onChange={(e) => setForm({ ...form, agency: e.target.value })}
+                className="w-full px-3 py-2 border border-border rounded-md"
+              />
+            </Field>
+            <Field label="Conta corrente">
+              <input
+                type="text"
+                value={form.checking_account ?? ""}
+                onChange={(e) => setForm({ ...form, checking_account: e.target.value })}
+                className="w-full px-3 py-2 border border-border rounded-md"
+              />
+            </Field>
           </div>
-        </Field>
 
-        <Button type="submit" disabled={saving}>
-          {saving ? "Salvando..." : "Salvar"}
-        </Button>
-      </form>
+          <Field label="Comissão padrão (%)">
+            <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-md text-ink-soft">
+              {company.commission_rate != null ? `${company.commission_rate}%` : "—"}
+            </div>
+            <p className="text-xs text-muted mt-1">
+              Somente o administrador pode alterar a comissão do escritório.
+            </p>
+          </Field>
+
+          <Field label="Identidade visual (até 4 cores hex)">
+            <div className="grid grid-cols-4 gap-3">
+              {[0, 1, 2, 3].map((i) => (
+                <input
+                  key={i}
+                  type="color"
+                  value={form.color_identity?.[i] ?? DEFAULT_COLORS[i]}
+                  onChange={(e) => setColor(i, e.target.value)}
+                  className="h-10 w-full border border-border rounded"
+                />
+              ))}
+            </div>
+          </Field>
+
+          <Button type="submit" disabled={saving}>
+            {saving ? "Salvando..." : "Salvar"}
+          </Button>
+        </form>
+      </Card>
     </div>
   );
 }
@@ -220,7 +224,7 @@ export default function OfficeCompanySettingsPage() {
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      <label className="block text-sm font-medium text-ink-soft mb-1">{label}</label>
       {children}
     </div>
   );

--- a/frontend/src/pages/office/OfficeConsultantsPage.tsx
+++ b/frontend/src/pages/office/OfficeConsultantsPage.tsx
@@ -1,11 +1,16 @@
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
+import { Users } from "lucide-react";
 import {
   officeService,
   type OfficeConsultant,
   type InviteJobDetail,
 } from "../../services/office";
 import Button from "../../components/ui/button";
+import { Card } from "../../components/ui/card";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { EmptyState } from "../../components/patterns/EmptyState";
 
 export default function OfficeConsultantsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -13,7 +18,7 @@ export default function OfficeConsultantsPage() {
 
   return (
     <div className="p-8">
-      <div className="flex items-center gap-6 border-b border-gray-200 mb-6">
+      <div className="flex items-center gap-6 border-b border-border mb-6">
         <TabButton
           active={tab === "list"}
           onClick={() => setSearchParams({})}
@@ -47,8 +52,8 @@ function TabButton({
       onClick={onClick}
       className={`pb-3 text-sm font-medium border-b-2 -mb-px ${
         active
-          ? "border-slate-700 text-slate-900"
-          : "border-transparent text-gray-500 hover:text-gray-700"
+          ? "border-ink text-ink"
+          : "border-transparent text-muted hover:text-ink-soft"
       }`}
     >
       {children}
@@ -65,6 +70,7 @@ function ConsultantsList() {
   const [inviteEmail, setInviteEmail] = useState("");
   const [inviteMsg, setInviteMsg] = useState<{ ok: boolean; text: string } | null>(null);
   const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [consultantToDeactivate, setConsultantToDeactivate] = useState<OfficeConsultant | null>(null);
 
   const load = () => {
     setLoading(true);
@@ -97,8 +103,10 @@ function ConsultantsList() {
     }
   };
 
-  const deactivate = async (c: OfficeConsultant) => {
-    if (!confirm(`Desativar ${c.name} ${c.surname}? Clientes serão desvinculados.`)) return;
+  const confirmDeactivate = async () => {
+    if (!consultantToDeactivate) return;
+    const c = consultantToDeactivate;
+    setConsultantToDeactivate(null);
     setBusyAction(c.id);
     try {
       await officeService.deactivateConsultant(c.id);
@@ -124,28 +132,30 @@ function ConsultantsList() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Consultores</h1>
-        <Button onClick={() => setShowInvite((v) => !v)}>
-          {showInvite ? "Fechar" : "Convidar consultor"}
-        </Button>
-      </div>
+      <PageHeader
+        title="Consultores"
+        actions={
+          <Button onClick={() => setShowInvite((v) => !v)}>
+            {showInvite ? "Fechar" : "Convidar consultor"}
+          </Button>
+        }
+      />
 
       {showInvite && (
-        <form onSubmit={submitInvite} className="bg-white p-4 rounded-lg shadow mb-6 flex gap-2">
+        <form onSubmit={submitInvite} className="bg-surface p-4 rounded-lg shadow mb-6 flex gap-2">
           <input
             type="email"
             value={inviteEmail}
             onChange={(e) => setInviteEmail(e.target.value)}
             placeholder="email@exemplo.com"
             required
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-md"
+            className="flex-1 px-3 py-2 border border-border rounded-md"
           />
           <Button type="submit">Enviar convite</Button>
         </form>
       )}
       {inviteMsg && (
-        <p className={`mb-4 text-sm ${inviteMsg.ok ? "text-green-600" : "text-red-600"}`}>
+        <p className={`mb-4 text-sm ${inviteMsg.ok ? "text-status-ok" : "text-status-bad"}`}>
           {inviteMsg.text}
         </p>
       )}
@@ -156,54 +166,56 @@ function ConsultantsList() {
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="Buscar por nome ou email..."
-          className="flex-1 px-3 py-2 border border-gray-300 rounded-md"
+          className="flex-1 px-3 py-2 border border-border rounded-md"
         />
         <Button onClick={load}>Buscar</Button>
       </div>
 
-      {loading && <p className="text-gray-500">Carregando...</p>}
-      {error && <p className="text-red-600">{error}</p>}
+      {loading && <p className="text-muted">Carregando...</p>}
+      {error && <p className="text-status-bad">{error}</p>}
       {!loading && consultants.length === 0 && (
-        <div className="bg-white p-8 rounded-lg shadow text-center text-gray-500">
-          Nenhum consultor ainda. Use "Convidar consultor" acima para começar.
-        </div>
+        <EmptyState
+          icon={Users}
+          title="Nenhum consultor ainda."
+          description='Use "Convidar consultor" acima para começar.'
+        />
       )}
 
       {consultants.length > 0 && (
-        <div className="bg-white rounded-lg shadow overflow-x-auto">
+        <div className="bg-surface rounded-lg shadow overflow-x-auto">
           <table className="w-full min-w-[640px]">
-            <thead className="bg-gray-50 border-b">
+            <thead className="bg-border-soft border-b border-border">
               <tr>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Nome</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">E-mail</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Clientes</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Comissão</th>
-                <th className="text-left text-xs font-medium text-gray-500 uppercase px-4 py-3">Status</th>
-                <th className="text-right text-xs font-medium text-gray-500 uppercase px-4 py-3">Ações</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">Nome</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">E-mail</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">Clientes</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">Comissão</th>
+                <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">Status</th>
+                <th className="text-right text-xs font-medium text-muted uppercase px-4 py-3">Ações</th>
               </tr>
             </thead>
             <tbody>
               {consultants.map((c) => (
-                <tr key={c.id} className="border-b">
+                <tr key={c.id} className="border-b border-border-soft">
                   <td className="px-4 py-3 text-sm">{c.name} {c.surname}</td>
-                  <td className="px-4 py-3 text-sm text-gray-600">{c.email}</td>
+                  <td className="px-4 py-3 text-sm text-muted">{c.email}</td>
                   <td className="px-4 py-3 text-sm">{c.clients_count}</td>
                   <td className="px-4 py-3 text-sm">
                     {c.commission_rate != null ? `${c.commission_rate}%` : "—"}
                   </td>
                   <td className="px-4 py-3 text-sm">
                     {c.is_active ? (
-                      <span className="text-green-600">Ativo</span>
+                      <span className="text-status-ok">Ativo</span>
                     ) : (
-                      <span className="text-gray-500">Inativo</span>
+                      <span className="text-muted">Inativo</span>
                     )}
                   </td>
                   <td className="px-4 py-3 text-right">
                     {c.is_active ? (
                       <button
                         disabled={busyAction === c.id}
-                        onClick={() => deactivate(c)}
-                        className="text-red-600 hover:underline text-sm"
+                        onClick={() => setConsultantToDeactivate(c)}
+                        className="text-status-bad hover:underline text-sm"
                       >
                         Desativar
                       </button>
@@ -211,7 +223,7 @@ function ConsultantsList() {
                       <button
                         disabled={busyAction === c.id}
                         onClick={() => reactivate(c)}
-                        className="text-blue-600 hover:underline text-sm"
+                        className="text-status-ok hover:underline text-sm"
                       >
                         Reativar
                       </button>
@@ -223,6 +235,25 @@ function ConsultantsList() {
           </table>
         </div>
       )}
+
+      <Dialog open={!!consultantToDeactivate} onOpenChange={(open) => !open && setConsultantToDeactivate(null)}>
+        <DialogContent open={!!consultantToDeactivate} title="Confirmar Desativação" hideTitle>
+          <div className="text-center">
+            <h2 className="text-h2 font-semibold text-ink mb-4">Confirmar Desativação</h2>
+            <p className="text-text-secondary mb-8">
+              Desativar{" "}
+              <span className="font-bold">
+                {consultantToDeactivate?.name} {consultantToDeactivate?.surname}
+              </span>
+              ? Clientes serão desvinculados.
+            </p>
+            <div className="flex justify-center gap-4">
+              <Button variant="light" onClick={() => setConsultantToDeactivate(null)}>Cancelar</Button>
+              <Button variant="danger" onClick={confirmDeactivate}>Confirmar</Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
@@ -276,40 +307,42 @@ function BatchInvite() {
 
   return (
     <div className="max-w-4xl">
-      <p className="text-gray-600 mb-6">
+      <p className="text-muted mb-6">
         Envie um CSV com colunas <strong>name</strong> e <strong>email</strong>. Cada linha gera um
         convite individual ao consultor.
       </p>
 
-      <form onSubmit={submit} className="bg-white p-6 rounded-lg shadow mb-6">
-        <label className="block text-sm font-medium text-gray-700 mb-2">Arquivo CSV (máx. 5MB)</label>
-        <input
-          type="file"
-          accept=".csv,text/csv"
-          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
-          className="block w-full text-sm text-gray-700 border border-gray-300 rounded-md p-2"
-        />
-        <div className="mt-4">
-          <Button type="submit" disabled={submitting}>
-            {submitting ? "Enviando..." : "Iniciar convite em lote"}
-          </Button>
-        </div>
-      </form>
+      <Card className="mb-6">
+        <form onSubmit={submit}>
+          <label className="block text-sm font-medium text-ink-soft mb-2">Arquivo CSV (máx. 5MB)</label>
+          <input
+            type="file"
+            accept=".csv,text/csv"
+            onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+            className="block w-full text-sm text-ink-soft border border-border rounded-md p-2"
+          />
+          <div className="mt-4">
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Enviando..." : "Iniciar convite em lote"}
+            </Button>
+          </div>
+        </form>
+      </Card>
 
-      {error && <p className="text-red-600 mb-4">{error}</p>}
+      {error && <p className="text-status-bad mb-4">{error}</p>}
 
       {job && (
-        <div className="bg-white p-6 rounded-lg shadow">
+        <Card>
           <h2 className="text-lg font-bold mb-2">Job: {job.jobId.slice(0, 8)}…</h2>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted">
             Status: <strong>{job.status}</strong> — {job.processedItems}/{job.totalItems} processados
             ({job.successItems} ok, {job.failedItems} falhas, {job.duplicateItems} duplicatas)
           </p>
-          {job.errorMessage && <p className="text-red-600 text-sm mt-2">{job.errorMessage}</p>}
+          {job.errorMessage && <p className="text-status-bad text-sm mt-2">{job.errorMessage}</p>}
 
-          <div className="mt-4 max-h-96 overflow-auto border rounded">
+          <div className="mt-4 max-h-96 overflow-auto border border-border rounded">
             <table className="w-full text-sm">
-              <thead className="bg-gray-50 sticky top-0">
+              <thead className="bg-border-soft sticky top-0">
                 <tr>
                   <th className="px-3 py-2 text-left">Linha</th>
                   <th className="px-3 py-2 text-left">Nome</th>
@@ -320,20 +353,20 @@ function BatchInvite() {
               </thead>
               <tbody>
                 {job.items.map((it) => (
-                  <tr key={it.row_number} className="border-t">
+                  <tr key={it.row_number} className="border-t border-border-soft">
                     <td className="px-3 py-2">{it.row_number}</td>
                     <td className="px-3 py-2">{it.name}</td>
-                    <td className="px-3 py-2 text-gray-600">{it.email}</td>
+                    <td className="px-3 py-2 text-muted">{it.email}</td>
                     <td className="px-3 py-2">
                       <StatusBadge s={it.status} />
                     </td>
-                    <td className="px-3 py-2 text-red-600">{it.error_message || "—"}</td>
+                    <td className="px-3 py-2 text-status-bad">{it.error_message || "—"}</td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-        </div>
+        </Card>
       )}
     </div>
   );
@@ -341,14 +374,14 @@ function BatchInvite() {
 
 function StatusBadge({ s }: { s: string }) {
   const map: Record<string, string> = {
-    SENT: "bg-green-100 text-green-700",
-    ACCEPTED: "bg-emerald-100 text-emerald-700",
-    PENDING: "bg-gray-100 text-gray-700",
-    PROCESSING: "bg-blue-100 text-blue-700",
-    DUPLICATE: "bg-yellow-100 text-yellow-700",
-    FAILED: "bg-red-100 text-red-700",
+    SENT: "bg-status-ok-wash text-status-ok",
+    ACCEPTED: "bg-status-ok-wash text-status-ok",
+    PENDING: "bg-border-soft text-ink-soft",
+    PROCESSING: "bg-status-sched-wash text-status-sched",
+    DUPLICATE: "bg-status-neg-wash text-status-neg",
+    FAILED: "bg-status-bad-wash text-status-bad",
   };
   return (
-    <span className={`px-2 py-0.5 rounded text-xs font-medium ${map[s] || "bg-gray-100"}`}>{s}</span>
+    <span className={`px-2 py-0.5 rounded text-xs font-medium ${map[s] || "bg-border-soft text-ink-soft"}`}>{s}</span>
   );
 }

--- a/frontend/src/pages/office/OfficeDashboardPage.tsx
+++ b/frontend/src/pages/office/OfficeDashboardPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { officeService } from "../../services/office";
+import { Card } from "../../components/ui/card";
+import { PageHeader } from "../../components/patterns/PageHeader";
 
 interface Stats {
   companyId: string;
@@ -25,22 +27,31 @@ export default function OfficeDashboardPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <div className="p-8 text-gray-500">Carregando...</div>;
-  if (error) return <div className="p-8 text-red-600">{error}</div>;
+  if (loading) return <div className="p-8 text-muted">Carregando...</div>;
+  if (error) return <div className="p-8 text-status-bad">{error}</div>;
   if (!stats) return null;
 
   return (
     <div className="w-full p-8">
-      <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">Painel do Escritório</h1>
-        <p className="text-gray-600">Gerencie consultores, clientes e configurações da empresa.</p>
-      </div>
+      <PageHeader title="Painel do Escritório" />
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
-        <Card title="Consultores ativos" value={stats.activeConsultants} />
-        <Card title="Consultores inativos" value={stats.inactiveConsultants} />
-        <Card title="Clientes" value={stats.clientsCount} />
-        <Card title="Processos abertos" value={stats.openProcesses} />
+        <Card>
+          <p className="text-sm text-muted">Consultores ativos</p>
+          <p className="text-3xl font-bold text-ink mt-2">{stats.activeConsultants}</p>
+        </Card>
+        <Card>
+          <p className="text-sm text-muted">Consultores inativos</p>
+          <p className="text-3xl font-bold text-ink mt-2">{stats.inactiveConsultants}</p>
+        </Card>
+        <Card>
+          <p className="text-sm text-muted">Clientes</p>
+          <p className="text-3xl font-bold text-ink mt-2">{stats.clientsCount}</p>
+        </Card>
+        <Card>
+          <p className="text-sm text-muted">Processos abertos</p>
+          <p className="text-3xl font-bold text-ink mt-2">{stats.openProcesses}</p>
+        </Card>
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -52,20 +63,11 @@ export default function OfficeDashboardPage() {
   );
 }
 
-function Card({ title, value }: { title: string; value: number }) {
-  return (
-    <div className="bg-white p-6 rounded-lg shadow border border-gray-100">
-      <p className="text-sm text-gray-500">{title}</p>
-      <p className="text-3xl font-bold text-gray-900 mt-2">{value}</p>
-    </div>
-  );
-}
-
 function ActionCard({ to, label }: { to: string; label: string }) {
   return (
     <Link
       to={to}
-      className="block bg-gray-900 hover:bg-gray-800 text-white font-medium py-4 px-6 rounded-lg shadow text-center"
+      className="block bg-action hover:bg-ink text-white font-medium py-4 px-6 rounded-lg shadow-ds-card text-center"
     >
       {label}
     </Link>

--- a/frontend/src/pages/specialist/ContractPreviewCallback.tsx
+++ b/frontend/src/pages/specialist/ContractPreviewCallback.tsx
@@ -145,7 +145,7 @@ export default function ContractPreviewCallback() {
             <p className="text-sm text-slate-500 mb-4">
               Esta janela será fechada automaticamente...
             </p>
-            <Button variant="light" onClick={() => navigate("/specialist/processes")}>
+            <Button type="button" variant="light" onClick={() => navigate("/specialist/processes")}>
               Voltar para processos
             </Button>
           </>
@@ -158,7 +158,7 @@ export default function ContractPreviewCallback() {
               Cancelado
             </h1>
             <p className="text-slate-600 mb-6">{message}</p>
-            <Button onClick={handleClose}>Fechar</Button>
+            <Button type="button" onClick={handleClose}>Fechar</Button>
           </>
         )}
 
@@ -167,7 +167,7 @@ export default function ContractPreviewCallback() {
             <AlertTriangle className="w-16 h-16 text-red-500 mx-auto mb-4" />
             <h1 className="text-xl font-semibold text-slate-800 mb-2">Erro</h1>
             <p className="text-slate-600 mb-6">{message}</p>
-            <Button onClick={handleClose}>Fechar</Button>
+            <Button type="button" onClick={handleClose}>Fechar</Button>
           </>
         )}
       </div>

--- a/frontend/src/pages/specialist/ContractPreviewCallback.tsx
+++ b/frontend/src/pages/specialist/ContractPreviewCallback.tsx
@@ -123,26 +123,26 @@ export default function ContractPreviewCallback() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-slate-50 p-4">
-      <div className="max-w-md w-full bg-white rounded-xl shadow-lg p-8 text-center">
+    <div className="min-h-screen flex items-center justify-center bg-bg p-4">
+      <div className="max-w-md w-full bg-surface rounded-xl shadow-lg p-8 text-center">
         {status === "loading" && (
           <>
             <Loader className="w-16 h-16 text-blue-500 animate-spin mx-auto mb-4" />
-            <h1 className="text-xl font-semibold text-slate-800 mb-2">
+            <h1 className="text-xl font-semibold text-ink mb-2">
               Processando...
             </h1>
-            <p className="text-slate-600">{message}</p>
+            <p className="text-muted">{message}</p>
           </>
         )}
 
         {status === "success" && (
           <>
             <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
-            <h1 className="text-xl font-semibold text-slate-800 mb-2">
+            <h1 className="text-xl font-semibold text-ink mb-2">
               Sucesso!
             </h1>
-            <p className="text-slate-600 mb-6">{message}</p>
-            <p className="text-sm text-slate-500 mb-4">
+            <p className="text-muted mb-6">{message}</p>
+            <p className="text-sm text-muted mb-4">
               Esta janela será fechada automaticamente...
             </p>
             <Button type="button" variant="light" onClick={() => navigate("/specialist/processes")}>
@@ -153,11 +153,11 @@ export default function ContractPreviewCallback() {
 
         {status === "cancelled" && (
           <>
-            <XCircle className="w-16 h-16 text-slate-400 mx-auto mb-4" />
-            <h1 className="text-xl font-semibold text-slate-800 mb-2">
+            <XCircle className="w-16 h-16 text-subtle mx-auto mb-4" />
+            <h1 className="text-xl font-semibold text-ink mb-2">
               Cancelado
             </h1>
-            <p className="text-slate-600 mb-6">{message}</p>
+            <p className="text-muted mb-6">{message}</p>
             <Button type="button" onClick={handleClose}>Fechar</Button>
           </>
         )}
@@ -165,8 +165,8 @@ export default function ContractPreviewCallback() {
         {status === "error" && (
           <>
             <AlertTriangle className="w-16 h-16 text-red-500 mx-auto mb-4" />
-            <h1 className="text-xl font-semibold text-slate-800 mb-2">Erro</h1>
-            <p className="text-slate-600 mb-6">{message}</p>
+            <h1 className="text-xl font-semibold text-ink mb-2">Erro</h1>
+            <p className="text-muted mb-6">{message}</p>
             <Button type="button" onClick={handleClose}>Fechar</Button>
           </>
         )}

--- a/frontend/src/pages/specialist/ContractPreviewCallback.tsx
+++ b/frontend/src/pages/specialist/ContractPreviewCallback.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { CheckCircle, XCircle, AlertTriangle, Loader } from "lucide-react";
+import Button from "../../components/ui/button";
 
 /**
  * Página de callback para o DocuSign Sender View
@@ -108,10 +109,16 @@ export default function ContractPreviewCallback() {
     }
   }, [searchParams]);
 
-  // Tentar fechar a janela/tab se aberta em popup
+  const navigate = useNavigate();
+
+  // Tentar fechar a janela/tab se aberta em popup; se não for popup
+  // (acesso direto à URL, ou postMessage/iframe falhou), navega de volta
+  // em vez de deixar a tela sem nenhuma saída.
   const handleClose = () => {
     if (window.opener) {
       window.close();
+    } else {
+      navigate("/specialist/processes");
     }
   };
 
@@ -135,9 +142,12 @@ export default function ContractPreviewCallback() {
               Sucesso!
             </h1>
             <p className="text-slate-600 mb-6">{message}</p>
-            <p className="text-sm text-slate-500">
+            <p className="text-sm text-slate-500 mb-4">
               Esta janela será fechada automaticamente...
             </p>
+            <Button variant="light" onClick={() => navigate("/specialist/processes")}>
+              Voltar para processos
+            </Button>
           </>
         )}
 
@@ -148,12 +158,7 @@ export default function ContractPreviewCallback() {
               Cancelado
             </h1>
             <p className="text-slate-600 mb-6">{message}</p>
-            <button
-              onClick={handleClose}
-              className="px-6 py-2.5 bg-slate-700 text-white rounded-lg hover:bg-slate-800 transition"
-            >
-              Fechar
-            </button>
+            <Button onClick={handleClose}>Fechar</Button>
           </>
         )}
 
@@ -162,12 +167,7 @@ export default function ContractPreviewCallback() {
             <AlertTriangle className="w-16 h-16 text-red-500 mx-auto mb-4" />
             <h1 className="text-xl font-semibold text-slate-800 mb-2">Erro</h1>
             <p className="text-slate-600 mb-6">{message}</p>
-            <button
-              onClick={handleClose}
-              className="px-6 py-2.5 bg-slate-700 text-white rounded-lg hover:bg-slate-800 transition"
-            >
-              Fechar
-            </button>
+            <Button onClick={handleClose}>Fechar</Button>
           </>
         )}
       </div>

--- a/frontend/src/pages/specialist/CreateContractPage.tsx
+++ b/frontend/src/pages/specialist/CreateContractPage.tsx
@@ -18,6 +18,8 @@ import {
   formatBRL,
 } from "../../services/contracts.service";
 import DocuSignPreviewModal from "../../components/contracts/DocuSignPreviewModal";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
 
 interface ContractFormData {
   // Vendedor
@@ -592,16 +594,13 @@ export default function CreateContractPage() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <AlertCircle className="w-12 h-12 text-red-600 mx-auto mb-4" />
-          <p className="text-red-600 font-semibold mb-4">
+          <AlertCircle className="w-12 h-12 text-status-bad mx-auto mb-4" />
+          <p className="text-status-bad font-semibold mb-4">
             Nenhum processo selecionado
           </p>
-          <button
-            onClick={() => navigate("/specialist/processes")}
-            className="px-4 py-2 bg-slate-700 text-white rounded-lg hover:bg-slate-800 transition"
-          >
+          <Button onClick={() => navigate("/specialist/processes")}>
             Voltar ao Dashboard
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -625,16 +624,13 @@ export default function CreateContractPage() {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
-          <AlertCircle className="w-12 h-12 text-red-600 mx-auto mb-4" />
-          <p className="text-red-600 font-semibold mb-4">
+          <AlertCircle className="w-12 h-12 text-status-bad mx-auto mb-4" />
+          <p className="text-status-bad font-semibold mb-4">
             {submitStatus.message || "Erro ao carregar dados do processo"}
           </p>
-          <button
-            onClick={() => window.location.reload()}
-            className="px-4 py-2 bg-slate-700 text-white rounded-lg hover:bg-slate-800 transition"
-          >
+          <Button onClick={() => window.location.reload()}>
             Tentar novamente
-          </button>
+          </Button>
         </div>
       </div>
     );
@@ -646,7 +642,7 @@ export default function CreateContractPage() {
         {/* Header */}
         <div className="mb-8">
           <div className="flex items-center gap-3 mb-2">
-            <FileText className="w-8 h-8 text-slate-700" />
+            <FileText className="w-8 h-8 text-ink" />
             <h1
               className={`${isMobile ? "text-2xl" : "text-4xl"} font-bold text-gray-900`}
             >
@@ -667,28 +663,17 @@ export default function CreateContractPage() {
 
         {/* Status Messages */}
         {submitStatus.type && (
-          <div
-            className={`mb-6 p-4 rounded-lg flex items-start gap-3 ${
-              submitStatus.type === "success"
-                ? "bg-green-50 border border-green-200"
-                : "bg-red-50 border border-red-200"
-            }`}
+          <Alert
+            variant={submitStatus.type === "success" ? "success" : "danger"}
+            className="mb-6"
           >
             {submitStatus.type === "success" ? (
-              <CheckCircle className="w-5 h-5 text-green-600 mt-0.5" />
+              <CheckCircle className="w-5 h-5 mt-0.5" />
             ) : (
-              <AlertCircle className="w-5 h-5 text-red-600 mt-0.5" />
+              <AlertCircle className="w-5 h-5 mt-0.5" />
             )}
-            <p
-              className={`text-sm ${
-                submitStatus.type === "success"
-                  ? "text-green-800"
-                  : "text-red-800"
-              }`}
-            >
-              {submitStatus.message}
-            </p>
-          </div>
+            <p className="text-sm">{submitStatus.message}</p>
+          </Alert>
         )}
 
         {/* Form */}
@@ -1736,9 +1721,9 @@ export default function CreateContractPage() {
           <div className="flex flex-col gap-3 pt-2 pb-8">
             {/* Resumo de erros de validação (campos obrigatórios faltando) */}
             {Object.keys(errors).length > 0 && (
-              <div className="flex items-start gap-2 p-4 rounded-lg bg-red-50 border border-red-200">
-                <AlertCircle className="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
-                <div className="text-sm text-red-700">
+              <Alert variant="danger">
+                <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
+                <div className="text-sm">
                   <p className="font-semibold mb-1">
                     Corrija os campos abaixo antes de pré-visualizar:
                   </p>
@@ -1750,43 +1735,25 @@ export default function CreateContractPage() {
                     ))}
                   </ul>
                 </div>
-              </div>
+              </Alert>
             )}
             {/* Mensagem de erro/sucesso próximo aos botões */}
             {submitStatus.type && (
-              <div
-                className={`flex items-start gap-2 p-4 rounded-lg ${
-                  submitStatus.type === "success"
-                    ? "bg-green-50 border border-green-200"
-                    : "bg-red-50 border border-red-200"
-                }`}
-              >
+              <Alert variant={submitStatus.type === "success" ? "success" : "danger"}>
                 {submitStatus.type === "success" ? (
-                  <CheckCircle className="w-5 h-5 text-green-600 shrink-0 mt-0.5" />
+                  <CheckCircle className="w-5 h-5 shrink-0 mt-0.5" />
                 ) : (
-                  <AlertCircle className="w-5 h-5 text-red-600 shrink-0 mt-0.5" />
+                  <AlertCircle className="w-5 h-5 shrink-0 mt-0.5" />
                 )}
-                <p
-                  className={`text-sm ${
-                    submitStatus.type === "success"
-                      ? "text-green-700"
-                      : "text-red-700"
-                  }`}
-                >
-                  {submitStatus.message}
-                </p>
-              </div>
+                <p className="text-sm">{submitStatus.message}</p>
+              </Alert>
             )}
 
             <div className="flex flex-col sm:flex-row gap-3">
-              <button
+              <Button
                 type="submit"
                 disabled={isSubmitting || submitStatus.type === "success"}
-                className={`flex-1 px-8 py-4 rounded-lg font-semibold text-white text-base transition shadow-sm ${
-                  isSubmitting || submitStatus.type === "success"
-                    ? "bg-gray-400 cursor-not-allowed"
-                    : "bg-slate-700 hover:bg-slate-800 active:bg-slate-900"
-                }`}
+                className="flex-1 px-8 py-4 text-base shadow-sm"
               >
                 {isSubmitting ? (
                   <span className="flex items-center justify-center gap-2">
@@ -1804,15 +1771,16 @@ export default function CreateContractPage() {
                     Pré-visualizar e Enviar Contrato
                   </span>
                 )}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="button"
+                variant="light"
                 onClick={() => navigate(-1)}
                 disabled={isSubmitting}
-                className="sm:w-auto px-8 py-4 rounded-lg font-medium text-gray-700 bg-gray-100 border border-gray-300 hover:bg-gray-200 transition disabled:opacity-50 disabled:cursor-not-allowed"
+                className="sm:w-auto px-8 py-4"
               >
                 Cancelar
-              </button>
+              </Button>
             </div>
           </div>
         </form>

--- a/frontend/src/pages/specialist/CreateContractPage.tsx
+++ b/frontend/src/pages/specialist/CreateContractPage.tsx
@@ -609,8 +609,8 @@ export default function CreateContractPage() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <Loader className="w-8 h-8 animate-spin text-slate-700" />
-        <span className="ml-2 text-slate-600">
+        <Loader className="w-8 h-8 animate-spin text-ink-soft" />
+        <span className="ml-2 text-muted">
           Carregando dados do contrato...
         </span>
       </div>
@@ -644,18 +644,18 @@ export default function CreateContractPage() {
           <div className="flex items-center gap-3 mb-2">
             <FileText className="w-8 h-8 text-ink" />
             <h1
-              className={`${isMobile ? "text-2xl" : "text-4xl"} font-bold text-gray-900`}
+              className={`${isMobile ? "text-2xl" : "text-4xl"} font-bold text-ink`}
             >
               Gerar Contrato de Venda
             </h1>
           </div>
-          <p className="text-gray-600">
+          <p className="text-muted">
             {prefillData
               ? `${getProductTypeLabel(prefillData.product_type)}: ${prefillData.product.brand} ${prefillData.product.model} | Cliente: ${prefillData.buyer.name}`
               : "Carregando..."}
           </p>
           {prefillData?.proposal && (
-            <p className="text-sm text-green-600 mt-1">
+            <p className="text-sm text-status-ok mt-1">
               Proposta aceita: {formatBRL(prefillData.proposal.value)}
             </p>
           )}
@@ -681,24 +681,24 @@ export default function CreateContractPage() {
 
           {/* ── Grupo: Dados das partes ── */}
           <div>
-            <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3 px-1">
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-subtle mb-3 px-1">
               Dados das partes
             </h2>
 
           {/* Seção: Vendedor */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+          <section className="bg-surface rounded-lg border border-border p-6 mb-6">
             <div className="flex items-center justify-between border-b pb-2 mb-4">
-              <h3 className="text-base font-semibold text-gray-900">
+              <h3 className="text-base font-semibold text-ink">
                 Vendedor
               </h3>
-              <span className="text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">
+              <span className="text-xs text-subtle bg-border-soft rounded px-2 py-0.5">
                 Preenchido automaticamente — edite se necessário
               </span>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Nome Completo *
                 </label>
                 <input
@@ -706,17 +706,17 @@ export default function CreateContractPage() {
                   {...register("seller_name", {
                     required: "Nome é obrigatório",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.seller_name && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_name.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   E-mail *
                 </label>
                 <input
@@ -728,17 +728,17 @@ export default function CreateContractPage() {
                       message: "E-mail inválido",
                     },
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.seller_email && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_email.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CPF *
                 </label>
                 <Controller
@@ -754,30 +754,30 @@ export default function CreateContractPage() {
                       }
                       maxLength={14}
                       placeholder="000.000.000-00"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                      className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                     />
                   )}
                 />
                 {errors.seller_cpf && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_cpf.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   RG
                 </label>
                 <input
                   type="text"
                   {...register("seller_rg")}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CEP *
                 </label>
                 <Controller
@@ -793,19 +793,19 @@ export default function CreateContractPage() {
                       }
                       maxLength={9}
                       placeholder="00000-000"
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                      className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                     />
                   )}
                 />
                 {errors.seller_cep && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_cep.message}
                   </p>
                 )}
               </div>
 
               <div className="md:col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Endereço Completo *
                 </label>
                 <input
@@ -814,23 +814,23 @@ export default function CreateContractPage() {
                     required: "Endereço é obrigatório",
                   })}
                   placeholder="Rua, número, complemento, bairro, cidade - UF"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.seller_address && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_address.message}
                   </p>
                 )}
               </div>
 
               <div className="md:col-span-2 border-t pt-4 mt-2">
-                <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-subtle mb-3">
                   Dados bancários do vendedor
                 </p>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Banco *
                 </label>
                 <input
@@ -839,17 +839,17 @@ export default function CreateContractPage() {
                     required: "Banco é obrigatório",
                   })}
                   placeholder="Ex: Itaú, Bradesco, Nubank"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.seller_bank && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_bank.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Agência *
                 </label>
                 <input
@@ -857,17 +857,17 @@ export default function CreateContractPage() {
                   {...register("seller_agency", {
                     required: "Agência é obrigatória",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.seller_agency && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_agency.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Conta Corrente *
                 </label>
                 <input
@@ -875,10 +875,10 @@ export default function CreateContractPage() {
                   {...register("seller_checking_account", {
                     required: "Conta é obrigatória",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.seller_checking_account && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.seller_checking_account.message}
                   </p>
                 )}
@@ -887,105 +887,105 @@ export default function CreateContractPage() {
           </section>
 
           {/* Seção: Comprador */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6">
+          <section className="bg-surface rounded-lg border border-border p-6">
             <div className="flex items-center justify-between border-b pb-2 mb-4">
-              <h3 className="text-base font-semibold text-gray-900">
+              <h3 className="text-base font-semibold text-ink">
                 Comprador
               </h3>
-              <span className="text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">
+              <span className="text-xs text-subtle bg-border-soft rounded px-2 py-0.5">
                 Preenchido automaticamente — edite se necessário
               </span>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Nome Completo *
                 </label>
                 <input
                   type="text"
                   {...register("buyer_name", { required: "Nome é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.buyer_name && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.buyer_name.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   E-mail *
                 </label>
                 <input
                   type="email"
                   {...register("buyer_email", { required: "E-mail é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.buyer_email && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.buyer_email.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CPF *
                 </label>
                 <input
                   type="text"
                   {...register("buyer_cpf", { required: "CPF é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.buyer_cpf && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.buyer_cpf.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   RG
                 </label>
                 <input
                   type="text"
                   {...register("buyer_rg")}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CEP *
                 </label>
                 <input
                   type="text"
                   {...register("buyer_cep", { required: "CEP é obrigatório" })}
                   placeholder="00000-000"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.buyer_cep && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.buyer_cep.message}
                   </p>
                 )}
               </div>
 
               <div className="md:col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Endereço Completo *
                 </label>
                 <input
                   type="text"
                   {...register("buyer_address", { required: "Endereço é obrigatório" })}
                   placeholder="Rua, número, bairro, cidade — UF"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.buyer_address && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.buyer_address.message}
                   </p>
                 )}
@@ -996,24 +996,24 @@ export default function CreateContractPage() {
 
           {/* ── Grupo: Dados do produto ── */}
           <div>
-            <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3 px-1">
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-subtle mb-3 px-1">
               Dados do produto
             </h2>
 
           {/* Seção: Veículo/Produto */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6">
+          <section className="bg-surface rounded-lg border border-border p-6">
             <div className="flex items-center justify-between border-b pb-2 mb-4">
-              <h3 className="text-base font-semibold text-gray-900">
+              <h3 className="text-base font-semibold text-ink">
                 {getProductTypeLabel(prefillData?.product_type)}
               </h3>
-              <span className="text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">
+              <span className="text-xs text-subtle bg-border-soft rounded px-2 py-0.5">
                 Preenchido automaticamente — edite se necessário
               </span>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Marca e Modelo *
                 </label>
                 <input
@@ -1021,17 +1021,17 @@ export default function CreateContractPage() {
                   {...register("vehicle_model", {
                     required: "Modelo é obrigatório",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.vehicle_model && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.vehicle_model.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Ano *
                 </label>
                 <input
@@ -1039,17 +1039,17 @@ export default function CreateContractPage() {
                   {...register("vehicle_year", {
                     required: "Ano é obrigatório",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.vehicle_year && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.vehicle_year.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   {getRegistrationLabel(prefillData?.product_type)} *
                 </label>
                 <input
@@ -1064,17 +1064,17 @@ export default function CreateContractPage() {
                         ? "PT-ABC"
                         : "Número de inscrição"
                   }
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.vehicle_registration_id && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.vehicle_registration_id.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   {getSerialLabel(prefillData?.product_type)} *
                 </label>
                 <input
@@ -1082,24 +1082,24 @@ export default function CreateContractPage() {
                   {...register("vehicle_serial_number", {
                     required: "Número serial é obrigatório",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.vehicle_serial_number && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.vehicle_serial_number.message}
                   </p>
                 )}
               </div>
 
               <div className="md:col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Informações Técnicas
                 </label>
                 <textarea
                   {...register("vehicle_technical_info")}
                   rows={2}
                   placeholder="Motor, cor, quilometragem, acessórios, etc."
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent resize-none bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent resize-none bg-surface"
                 />
               </div>
             </div>
@@ -1108,39 +1108,39 @@ export default function CreateContractPage() {
 
           {/* ── Grupo: Condições comerciais ── */}
           <div>
-            <h2 className="text-xs font-semibold uppercase tracking-widest text-gray-400 mb-3 px-1">
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-subtle mb-3 px-1">
               Condições comerciais
             </h2>
 
           {/* Seção: Valores */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+          <section className="bg-surface rounded-lg border border-border p-6 mb-6">
             <div className="flex items-center justify-between border-b pb-2 mb-4">
-              <h3 className="text-base font-semibold text-gray-900">
+              <h3 className="text-base font-semibold text-ink">
                 Valores da Transação
               </h3>
-              <span className="text-xs text-gray-400 bg-gray-100 rounded px-2 py-0.5">
+              <span className="text-xs text-subtle bg-border-soft rounded px-2 py-0.5">
                 Calculado automaticamente
               </span>
             </div>
             <input type="hidden" {...register("vehicle_price", { required: "Valor é obrigatório", valueAsNumber: true, min: { value: 0, message: "Valor deve ser positivo" } })} />
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-500 mb-1">
+                <label className="block text-sm font-medium text-muted mb-1">
                   Valor Total do{" "}
                   {getProductTypeLabel(prefillData?.product_type)}
                 </label>
-                <div className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg text-gray-700 cursor-default text-sm min-h-[38px] font-medium">
-                  {vehiclePrice > 0 ? formatBRL(vehiclePrice) : <span className="text-gray-400">—</span>}
+                <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-lg text-ink-soft cursor-default text-sm min-h-[38px] font-medium">
+                  {vehiclePrice > 0 ? formatBRL(vehiclePrice) : <span className="text-subtle">—</span>}
                 </div>
                 {errors.vehicle_price && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.vehicle_price.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Comissão Total da Venda (%) *
                 </label>
                 <input
@@ -1151,88 +1151,88 @@ export default function CreateContractPage() {
                     valueAsNumber: true,
                     min: { value: 0, message: "Valor deve ser positivo" },
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
-                <p className="text-xs text-gray-400 mt-1">
+                <p className="text-xs text-subtle mt-1">
                   Único valor editável — plataforma e escritório ficam travados nas
                   taxas cadastradas; seu corte é o restante.
                 </p>
                 {totalCommissionValue > 0 && (
-                  <p className="text-sm text-gray-500 mt-1">
+                  <p className="text-sm text-muted mt-1">
                     {formatBRL(totalCommissionValue)}
                   </p>
                 )}
                 {errors.total_commission_rate && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.total_commission_rate.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Comissão da Plataforma
                   {prefillData?.platform?.rate != null && (
-                    <span className="text-xs text-gray-500 ml-1">
+                    <span className="text-xs text-muted ml-1">
                       ({prefillData.platform.rate}%)
                     </span>
                   )}
                 </label>
-                <div className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg text-gray-700 cursor-default text-sm min-h-[38px] font-medium">
+                <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-lg text-ink-soft cursor-default text-sm min-h-[38px] font-medium">
                   {formatBRL(platformValue)}
                 </div>
-                <p className="text-xs text-gray-400 mt-1">
+                <p className="text-xs text-subtle mt-1">
                   Taxa travada — não editável neste formulário.
                 </p>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Comissão do Escritório
                   {prefillData?.office?.rate != null && (
-                    <span className="text-xs text-gray-500 ml-1">
+                    <span className="text-xs text-muted ml-1">
                       ({prefillData.office.rate}%)
                     </span>
                   )}
                 </label>
-                <div className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg text-gray-700 cursor-default text-sm min-h-[38px] font-medium">
+                <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-lg text-ink-soft cursor-default text-sm min-h-[38px] font-medium">
                   {formatBRL(officeValue)}
                 </div>
-                <p className="text-xs text-gray-400 mt-1">
+                <p className="text-xs text-subtle mt-1">
                   Taxa travada — não editável neste formulário.
                 </p>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Comissão do Especialista
-                  <span className="text-xs text-gray-500 ml-1">
+                  <span className="text-xs text-muted ml-1">
                     ({specialistRate.toFixed(2)}%)
                   </span>
                 </label>
-                <div className="w-full px-3 py-2 bg-gray-50 border border-gray-200 rounded-lg text-gray-700 cursor-default text-sm min-h-[38px] font-medium">
+                <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-lg text-ink-soft cursor-default text-sm min-h-[38px] font-medium">
                   {formatBRL(specialistValue)}
                 </div>
-                <p className="text-xs text-gray-400 mt-1">
+                <p className="text-xs text-subtle mt-1">
                   Resíduo do total — plataforma e escritório subtraídos.
                 </p>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Valor Líquido do Vendedor
                 </label>
                 <input
                   type="number"
                   step="0.01"
                   {...register("payment_seller_value", { valueAsNumber: true })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
-                <p className="text-xs text-gray-400 mt-1">
+                <p className="text-xs text-subtle mt-1">
                   Calculado automaticamente, edite se necessário.
                 </p>
                 {sellerNetPreviewValue > 0 && (
-                  <p className="text-sm text-green-600 mt-1">
+                  <p className="text-sm text-status-ok mt-1">
                     {formatBRL(sellerNetPreviewValue)}
                   </p>
                 )}
@@ -1241,96 +1241,96 @@ export default function CreateContractPage() {
           </section>
 
           {/* Seção: Dados da Plataforma */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+          <section className="bg-surface rounded-lg border border-border p-6 mb-6">
             <div className="flex items-center justify-between border-b pb-2 mb-4">
-              <h3 className="text-base font-semibold text-gray-900">
+              <h3 className="text-base font-semibold text-ink">
                 Dados da Plataforma
               </h3>
-              <span className="text-xs text-gray-500 bg-gray-100 rounded px-2 py-0.5">
+              <span className="text-xs text-muted bg-border-soft rounded px-2 py-0.5">
                 Pré-preenchido (editável)
               </span>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Razão Social *
                 </label>
                 <input
                   type="text"
                   {...register("platform_name", { required: "Razão social é obrigatória" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Razão social da plataforma"
                 />
                 {errors.platform_name && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.platform_name.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CNPJ *
                 </label>
                 <input
                   type="text"
                   {...register("platform_cnpj", { required: "CNPJ é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="00.000.000/0000-00"
                 />
                 {errors.platform_cnpj && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.platform_cnpj.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Banco *
                 </label>
                 <input
                   type="text"
                   {...register("platform_bank", { required: "Banco é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Banco"
                 />
                 {errors.platform_bank && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.platform_bank.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Agência *
                 </label>
                 <input
                   type="text"
                   {...register("platform_agency", { required: "Agência é obrigatória" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Agência"
                 />
                 {errors.platform_agency && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.platform_agency.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Conta Corrente *
                 </label>
                 <input
                   type="text"
                   {...register("platform_checking_account", { required: "Conta é obrigatória" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Conta corrente"
                 />
                 {errors.platform_checking_account && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.platform_checking_account.message}
                   </p>
                 )}
@@ -1339,82 +1339,82 @@ export default function CreateContractPage() {
           </section>
 
           {/* Seção: Dados do Escritório */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
+          <section className="bg-surface rounded-lg border border-border p-6 mb-6">
             <div className="flex items-center justify-between border-b pb-2 mb-4">
-              <h3 className="text-base font-semibold text-gray-900">
+              <h3 className="text-base font-semibold text-ink">
                 Dados do Escritório
               </h3>
-              <span className="text-xs text-gray-500 bg-gray-100 rounded px-2 py-0.5">
+              <span className="text-xs text-muted bg-border-soft rounded px-2 py-0.5">
                 Pré-preenchido (editável)
               </span>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Razão Social *
                 </label>
                 <input
                   type="text"
                   {...register("office_name", { required: "Razão social é obrigatória" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Razão social do escritório"
                 />
                 {errors.office_name && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.office_name.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CNPJ *
                 </label>
                 <input
                   type="text"
                   {...register("office_cnpj", { required: "CNPJ é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="00.000.000/0000-00"
                 />
                 {errors.office_cnpj && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.office_cnpj.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Banco
                 </label>
                 <input
                   type="text"
                   {...register("office_bank")}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Banco"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Agência
                 </label>
                 <input
                   type="text"
                   {...register("office_agency")}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Agência"
                 />
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Conta Corrente
                 </label>
                 <input
                   type="text"
                   {...register("office_checking_account")}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Conta corrente"
                 />
               </div>
@@ -1422,75 +1422,75 @@ export default function CreateContractPage() {
           </section>
 
           {/* Seção: Dados do Especialista */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6">
+          <section className="bg-surface rounded-lg border border-border p-6">
             <div className="flex items-center justify-between border-b pb-2 mb-4">
-              <h3 className="text-base font-semibold text-gray-900">
+              <h3 className="text-base font-semibold text-ink">
                 Dados do Especialista
               </h3>
-              <span className="text-xs text-gray-500 bg-gray-100 rounded px-2 py-0.5">
+              <span className="text-xs text-muted bg-border-soft rounded px-2 py-0.5">
                 Pré-preenchido (editável)
               </span>
             </div>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Nome *
                 </label>
                 <input
                   type="text"
                   {...register("specialist_name", { required: "Nome do especialista é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="Nome completo"
                 />
                 {errors.specialist_name && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.specialist_name.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   E-mail *
                 </label>
                 <input
                   type="email"
                   {...register("specialist_email", { required: "E-mail do especialista é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="email@exemplo.com"
                 />
                 {errors.specialist_email && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.specialist_email.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CNPJ *
                 </label>
                 <input
                   type="text"
                   {...register("specialist_document", { required: "CNPJ do especialista é obrigatório" })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white text-sm"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface text-sm"
                   placeholder="00.000.000/0000-00"
                 />
                 {errors.specialist_document && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.specialist_document.message}
                   </p>
                 )}
               </div>
 
               <div className="md:col-span-2 border-t pt-4 mt-2">
-                <p className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-subtle mb-3">
                   Dados bancários do especialista — preencha abaixo
                 </p>
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Banco *
                 </label>
                 <input
@@ -1498,18 +1498,18 @@ export default function CreateContractPage() {
                   {...register("specialist_bank", {
                     required: "Banco do especialista é obrigatório",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                   placeholder="Banco do especialista"
                 />
                 {errors.specialist_bank && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.specialist_bank.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Agência *
                 </label>
                 <input
@@ -1517,18 +1517,18 @@ export default function CreateContractPage() {
                   {...register("specialist_agency", {
                     required: "Agência do especialista é obrigatória",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                   placeholder="Agência"
                 />
                 {errors.specialist_agency && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.specialist_agency.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Conta Corrente *
                 </label>
                 <input
@@ -1536,29 +1536,29 @@ export default function CreateContractPage() {
                   {...register("specialist_checking_account", {
                     required: "Conta corrente do especialista é obrigatória",
                   })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                   placeholder="Conta corrente"
                 />
                 {errors.specialist_checking_account && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.specialist_checking_account.message}
                   </p>
                 )}
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Valor da Comissão *
                 </label>
                 <div className="relative">
-                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">
+                  <span className="absolute left-3 top-1/2 -translate-y-1/2 text-muted">
                     R$
                   </span>
                   <input
                     type="text"
                     value={formatBRL(specialistValue)}
                     readOnly
-                    className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg bg-gray-50 cursor-not-allowed"
+                    className="w-full pl-10 pr-3 py-2 border border-border rounded-lg bg-border-soft cursor-not-allowed"
                   />
                 </div>
               </div>
@@ -1567,34 +1567,34 @@ export default function CreateContractPage() {
           </div>{/* end Condições comerciais */}
 
           {/* Seção: Testemunhas (Opcional) */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6">
-            <h2 className="text-base font-semibold text-gray-900 mb-4 border-b pb-2">
+          <section className="bg-surface rounded-lg border border-border p-6">
+            <h2 className="text-base font-semibold text-ink mb-4 border-b pb-2">
               Testemunhas (Opcional)
             </h2>
-            <p className="text-sm text-gray-500 mb-4">
+            <p className="text-sm text-muted mb-4">
               Adicione até duas testemunhas para o contrato. Ambos os campos são
               opcionais.
             </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {/* Testemunha 1 */}
               <div className="md:col-span-2">
-                <h3 className="text-sm font-semibold text-gray-700 mb-2">
+                <h3 className="text-sm font-semibold text-ink-soft mb-2">
                   Testemunha 1
                 </h3>
               </div>
               <div className="md:col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Nome
                 </label>
                 <input
                   type="text"
                   {...register("testimonial1_name")}
                   placeholder="Nome completo da testemunha 1"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CPF
                 </label>
                 <Controller
@@ -1610,42 +1610,42 @@ export default function CreateContractPage() {
                         const masked = applyCpfMask(e.target.value);
                         field.onChange(masked);
                       }}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                      className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                     />
                   )}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   E-mail
                 </label>
                 <input
                   type="email"
                   {...register("testimonial1_email")}
                   placeholder="testemunha1@email.com"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 />
               </div>
 
               {/* Testemunha 2 */}
               <div className="md:col-span-2 mt-4">
-                <h3 className="text-sm font-semibold text-gray-700 mb-2">
+                <h3 className="text-sm font-semibold text-ink-soft mb-2">
                   Testemunha 2
                 </h3>
               </div>
               <div className="md:col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Nome
                 </label>
                 <input
                   type="text"
                   {...register("testimonial2_name")}
                   placeholder="Nome completo da testemunha 2"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   CPF
                 </label>
                 <Controller
@@ -1661,57 +1661,57 @@ export default function CreateContractPage() {
                         const masked = applyCpfMask(e.target.value);
                         field.onChange(masked);
                       }}
-                      className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                      className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                     />
                   )}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   E-mail
                 </label>
                 <input
                   type="email"
                   {...register("testimonial2_email")}
                   placeholder="testemunha2@email.com"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                 />
               </div>
             </div>
           </section>
 
           {/* Seção: Cidade e Descrição */}
-          <section className="bg-white rounded-lg border border-gray-200 p-6">
-            <h2 className="text-base font-semibold text-gray-900 mb-4 border-b pb-2">
+          <section className="bg-surface rounded-lg border border-border p-6">
+            <h2 className="text-base font-semibold text-ink mb-4 border-b pb-2">
               Informações Adicionais
             </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Cidade de Assinatura *
                 </label>
                 <input
                   type="text"
                   {...register("city", { required: "Cidade é obrigatória" })}
                   placeholder="Ex: São Paulo"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
                 {errors.city && (
-                  <p className="text-red-500 text-sm mt-1">
+                  <p className="text-status-bad text-sm mt-1">
                     {errors.city.message}
                   </p>
                 )}
               </div>
 
               <div className="md:col-span-2">
-                <label className="block text-sm font-medium text-gray-700 mb-1">
+                <label className="block text-sm font-medium text-ink-soft mb-1">
                   Observações
                 </label>
                 <textarea
                   {...register("description")}
                   rows={3}
                   placeholder="Informações adicionais sobre o contrato..."
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-slate-500 focus:border-transparent resize-none bg-white"
+                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent resize-none bg-surface"
                 />
               </div>
             </div>

--- a/frontend/src/pages/specialist/ProcessesPage.tsx
+++ b/frontend/src/pages/specialist/ProcessesPage.tsx
@@ -395,7 +395,7 @@ export default function ProcessesPage() {
         {isLoading && (
           <div className="flex items-center justify-center py-8 sm:py-12">
             <div className="text-center">
-              <div className="inline-block animate-spin rounded-full h-10 w-10 sm:h-12 sm:w-12 border-b-2 border-border"></div>
+              <div className="inline-block animate-spin rounded-full h-10 w-10 sm:h-12 sm:w-12 border-b-2 border-ink"></div>
               <p className="mt-3 sm:mt-4 text-sm sm:text-base text-muted">
                 Carregando processos...
               </p>

--- a/frontend/src/pages/specialist/ProcessesPage.tsx
+++ b/frontend/src/pages/specialist/ProcessesPage.tsx
@@ -11,6 +11,9 @@ import {
 import ProcessCard from "../../components/processes/ProcessCard";
 import CreateProcessModal from "../../components/processes/CreateProcessModal";
 import ProductSelectorModal from "../../components/product/ProductSelectorModal";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { PageHeader } from "../../components/patterns/PageHeader";
 import {
   getProcessesBySpecialist,
   type ProcessFilters,
@@ -47,9 +50,9 @@ export default function ProcessesPage() {
   // Validate user is logged in
   if (!user?.id) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="min-h-screen bg-border-soft flex items-center justify-center">
         <div className="text-center">
-          <p className="text-gray-600">Carregando...</p>
+          <p className="text-muted">Carregando...</p>
         </div>
       </div>
     );
@@ -246,71 +249,49 @@ export default function ProcessesPage() {
   const hasActiveFilters = statusFilter || searchQuery;
 
   return (
-    <div className="min-h-screen bg-gray-50">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200 sticky top-0 z-40">
-        <div className="max-w-7xl mx-auto px-3 py-3 sm:px-6 sm:py-4 lg:px-8 lg:py-6">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="min-w-0">
-              <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 truncate">
-                Dashboard de Processos
-              </h1>
-              <p className="text-xs sm:text-sm text-gray-600 mt-1">
-                Gerencie seus processos de negociação
-              </p>
-            </div>
-            <div className="flex gap-2 shrink-0">
-              {/* Filter Button */}
-              <button
+    <div className="min-h-screen bg-border-soft">
+      <div className="max-w-7xl mx-auto px-3 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
+        <PageHeader
+          title="Dashboard de Processos"
+          actions={
+            <>
+              <Button
+                type="button"
+                variant={showFilters || hasActiveFilters ? "solid" : "light"}
                 onClick={() => setShowFilters(!showFilters)}
-                className={`inline-flex items-center justify-center gap-1 sm:gap-2 px-3 sm:px-4 py-2 border rounded-lg font-medium transition text-xs sm:text-sm ${
-                  showFilters || hasActiveFilters
-                    ? "border-slate-700 bg-slate-700 text-white hover:bg-slate-800"
-                    : "border-gray-300 text-gray-700 hover:bg-gray-50"
-                }`}
                 aria-label="Filter processes"
                 title="Filtrar"
               >
-                <Filter size={16} className="sm:hidden" />
-                <Filter size={18} className="hidden sm:block" />
+                <Filter size={16} />
                 <span className="hidden sm:inline">Filtrar</span>
                 {hasActiveFilters && (
-                  <span className="ml-1 w-2 h-2 bg-red-500 rounded-full"></span>
+                  <span className="ml-1 w-2 h-2 bg-status-bad rounded-full" />
                 )}
-              </button>
-
-              {/* Create Process Button */}
-              <button
-                onClick={() => setShowCreateModal(true)}
-                className="inline-flex items-center justify-center gap-1 sm:gap-2 px-3 sm:px-4 py-2 bg-slate-700 text-white rounded-lg font-medium hover:bg-slate-800 transition text-xs sm:text-sm whitespace-nowrap"
-              >
-                <Plus size={16} className="sm:hidden" />
-                <Plus size={18} className="hidden sm:block" />
+              </Button>
+              <Button type="button" onClick={() => setShowCreateModal(true)}>
+                <Plus size={16} />
                 <span className="hidden sm:inline">Novo Processo</span>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+              </Button>
+            </>
+          }
+        />
 
-      {/* Main Content */}
-      <div className="max-w-7xl mx-auto px-3 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
         {/* Filter Panel */}
         {showFilters && (
-          <div className="mb-4 sm:mb-6 p-4 bg-white rounded-lg border border-gray-200 shadow-sm">
+          <div className="mb-4 sm:mb-6 p-4 bg-surface rounded-lg border border-border shadow-sm">
             <div className="flex flex-col sm:flex-row gap-4">
               {/* Search Input */}
               <div className="flex-1">
                 <label
                   htmlFor="search"
-                  className="block text-xs sm:text-sm font-medium text-gray-700 mb-1"
+                  className="block text-xs sm:text-sm font-medium text-ink-soft mb-1"
                 >
                   Pesquisar
                 </label>
                 <div className="relative">
                   <Search
                     size={18}
-                    className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                    className="absolute left-3 top-1/2 -translate-y-1/2 text-subtle"
                   />
                   <input
                     type="text"
@@ -318,7 +299,7 @@ export default function ProcessesPage() {
                     value={searchInput}
                     onChange={(e) => setSearchInput(e.target.value)}
                     placeholder="Nome do cliente, e-mail ou produto..."
-                    className="w-full pl-10 pr-10 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-slate-500 focus:border-transparent"
+                    className="w-full pl-10 pr-10 py-2 border border-border rounded-lg text-sm focus:ring-2 focus:ring-focus-ring focus:border-transparent"
                   />
                   {searchInput && (
                     <button
@@ -326,7 +307,7 @@ export default function ProcessesPage() {
                         setSearchInput("");
                         setSearchQuery("");
                       }}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5 rounded hover:bg-border-soft text-ink-soft"
                     >
                       <X size={16} />
                     </button>
@@ -338,7 +319,7 @@ export default function ProcessesPage() {
               <div className="w-full sm:w-48">
                 <label
                   htmlFor="status"
-                  className="block text-xs sm:text-sm font-medium text-gray-700 mb-1"
+                  className="block text-xs sm:text-sm font-medium text-ink-soft mb-1"
                 >
                   Status
                 </label>
@@ -346,7 +327,7 @@ export default function ProcessesPage() {
                   id="status"
                   value={statusFilter}
                   onChange={(e) => setStatusFilter(e.target.value)}
-                  className="w-full py-2 px-3 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-slate-500 focus:border-transparent bg-white"
+                  className="w-full py-2 px-3 border border-border rounded-lg text-sm focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 >
                   {STATUS_OPTIONS.map((option) => (
                     <option key={option.value} value={option.value}>
@@ -359,39 +340,40 @@ export default function ProcessesPage() {
               {/* Clear Filters Button */}
               {hasActiveFilters && (
                 <div className="flex items-end">
-                  <button
-                    onClick={handleClearFilters}
-                    className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition"
-                  >
+                  <Button type="button" variant="light" onClick={handleClearFilters}>
                     Limpar filtros
-                  </button>
+                  </Button>
                 </div>
               )}
             </div>
 
             {/* Active Filters Summary */}
             {hasActiveFilters && (
-              <div className="mt-3 pt-3 border-t border-gray-100 text-xs sm:text-sm text-gray-600">
+              <div className="mt-3 pt-3 border-t border-border-soft text-xs sm:text-sm text-muted">
                 Filtros ativos:{" "}
                 {statusFilter && (
-                  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-slate-100 text-slate-700 rounded mr-2">
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-border-soft text-ink-soft rounded mr-2">
                     {
                       STATUS_OPTIONS.find((o) => o.value === statusFilter)
                         ?.label
                     }
-                    <button onClick={() => setStatusFilter("")}>
+                    <button
+                      onClick={() => setStatusFilter("")}
+                      className="hover:bg-border-soft text-ink-soft rounded"
+                    >
                       <X size={12} />
                     </button>
                   </span>
                 )}
                 {searchQuery && (
-                  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-slate-100 text-slate-700 rounded">
+                  <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-border-soft text-ink-soft rounded">
                     "{searchQuery}"
                     <button
                       onClick={() => {
                         setSearchInput("");
                         setSearchQuery("");
                       }}
+                      className="hover:bg-border-soft text-ink-soft rounded"
                     >
                       <X size={12} />
                     </button>
@@ -404,17 +386,17 @@ export default function ProcessesPage() {
 
         {/* Error Alert */}
         {error && (
-          <div className="mb-4 sm:mb-6 p-3 sm:p-4 bg-red-50 border border-red-200 rounded-lg">
-            <p className="text-xs sm:text-sm text-red-700">{error}</p>
-          </div>
+          <Alert variant="danger" className="mb-4 sm:mb-6">
+            {error}
+          </Alert>
         )}
 
         {/* Loading State */}
         {isLoading && (
           <div className="flex items-center justify-center py-8 sm:py-12">
             <div className="text-center">
-              <div className="inline-block animate-spin rounded-full h-10 w-10 sm:h-12 sm:w-12 border-b-2 border-slate-700"></div>
-              <p className="mt-3 sm:mt-4 text-sm sm:text-base text-gray-600">
+              <div className="inline-block animate-spin rounded-full h-10 w-10 sm:h-12 sm:w-12 border-b-2 border-border"></div>
+              <p className="mt-3 sm:mt-4 text-sm sm:text-base text-muted">
                 Carregando processos...
               </p>
             </div>
@@ -424,45 +406,39 @@ export default function ProcessesPage() {
         {/* Empty State */}
         {!isLoading && processes.length === 0 && (
           <div className="text-center py-8 sm:py-12">
-            <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 bg-gray-100 rounded-full mb-3 sm:mb-4">
+            <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 bg-border-soft rounded-full mb-3 sm:mb-4">
               {hasActiveFilters ? (
                 <>
-                  <Search size={28} className="sm:hidden text-gray-400" />
-                  <Search size={32} className="hidden sm:block text-gray-400" />
+                  <Search size={28} className="sm:hidden text-subtle" />
+                  <Search size={32} className="hidden sm:block text-subtle" />
                 </>
               ) : (
                 <>
-                  <Plus size={28} className="sm:hidden text-gray-400" />
-                  <Plus size={32} className="hidden sm:block text-gray-400" />
+                  <Plus size={28} className="sm:hidden text-subtle" />
+                  <Plus size={32} className="hidden sm:block text-subtle" />
                 </>
               )}
             </div>
-            <h3 className="text-base sm:text-lg font-semibold text-gray-900 mb-2">
+            <h3 className="text-base sm:text-lg font-semibold text-ink mb-2">
               {hasActiveFilters
                 ? "Nenhum processo encontrado"
                 : "Nenhum processo encontrado"}
             </h3>
-            <p className="text-xs sm:text-sm text-gray-600 mb-4 sm:mb-6">
+            <p className="text-xs sm:text-sm text-muted mb-4 sm:mb-6">
               {hasActiveFilters
                 ? "Tente ajustar os filtros para encontrar mais resultados"
                 : "Crie seu primeiro processo para começar"}
             </p>
             {hasActiveFilters ? (
-              <button
-                onClick={handleClearFilters}
-                className="inline-flex items-center justify-center gap-2 px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition text-xs sm:text-sm"
-              >
+              <Button type="button" variant="light" onClick={handleClearFilters}>
                 <X size={18} />
                 Limpar Filtros
-              </button>
+              </Button>
             ) : (
-              <button
-                onClick={() => setShowCreateModal(true)}
-                className="inline-flex items-center justify-center gap-2 px-4 py-2 bg-slate-700 text-white rounded-lg font-medium hover:bg-slate-800 transition text-xs sm:text-sm"
-              >
+              <Button type="button" onClick={() => setShowCreateModal(true)}>
                 <Plus size={18} />
                 Criar Novo Processo
-              </button>
+              </Button>
             )}
           </div>
         )}
@@ -489,33 +465,33 @@ export default function ProcessesPage() {
         {/* Pagination Controls */}
         {!isLoading && processes.length > 0 && (
           <div className="mt-6 sm:mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="text-xs sm:text-sm text-gray-600">
+            <div className="text-xs sm:text-sm text-muted">
               Página <span className="font-semibold">{currentPage}</span> de{" "}
               <span className="font-semibold">{totalPages}</span>
             </div>
 
             <div className="flex gap-2 justify-center sm:justify-end">
-              <button
+              <Button
+                type="button"
+                variant="light"
                 onClick={handlePreviousPage}
                 disabled={!hasPreviousPage}
-                className="inline-flex items-center justify-center gap-1 px-3 sm:px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition disabled:opacity-50 disabled:cursor-not-allowed text-xs sm:text-sm"
                 title="Anterior"
               >
-                <ChevronLeft size={16} className="sm:hidden" />
-                <ChevronLeft size={18} className="hidden sm:block" />
+                <ChevronLeft size={16} />
                 <span className="hidden sm:inline">Anterior</span>
-              </button>
+              </Button>
 
-              <button
+              <Button
+                type="button"
+                variant="light"
                 onClick={handleNextPage}
                 disabled={!hasNextPage}
-                className="inline-flex items-center justify-center gap-1 px-3 sm:px-4 py-2 border border-gray-300 rounded-lg text-gray-700 font-medium hover:bg-gray-50 transition disabled:opacity-50 disabled:cursor-not-allowed text-xs sm:text-sm"
                 title="Próximo"
               >
                 <span className="hidden sm:inline">Próximo</span>
-                <ChevronRight size={16} className="sm:hidden" />
-                <ChevronRight size={18} className="hidden sm:block" />
-              </button>
+                <ChevronRight size={16} />
+              </Button>
             </div>
           </div>
         )}

--- a/frontend/src/pages/specialist/ProductsPage.tsx
+++ b/frontend/src/pages/specialist/ProductsPage.tsx
@@ -1,11 +1,16 @@
 import { useState, useEffect, useContext } from "react";
 import { useNavigate } from "react-router-dom";
+import { Plus, Pencil, Trash2 } from "lucide-react";
 import { useAuth } from "../../store/authStateManager";
 import { AppContext } from "../../contexts/AppContext";
 import { getCars, deleteCar } from "../../services/cars.service";
 import { getBoats, deleteBoat } from "../../services/boats.service";
 import { getAircrafts, deleteAircraft } from "../../services/aircrafts.service";
 import type { SpecialityType } from "../../types/types";
+import Button from "../../components/ui/button";
+import { Alert } from "../../components/ui/alert";
+import { Card } from "../../components/ui/card";
+import { PageHeader } from "../../components/patterns/PageHeader";
 
 type ProductType = "cars" | "boats" | "aircrafts";
 
@@ -123,47 +128,46 @@ export default function ProductsPage() {
   });
 
   return (
-    <div className="flex flex-col gap-6">
-      {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-2xl sm:text-3xl font-bold text-text-primary">Gestão de Produtos</h1>
-        <button
-          onClick={() => navigate("/specialist/products/new")}
-          className="px-4 py-2 bg-gray-700 text-white text-sm rounded hover:bg-gray-800 transition"
-        >
-          + Novo Produto
-        </button>
-      </div>
+    <div className="w-full">
+      <PageHeader
+        title="Gestão de Produtos"
+        actions={
+          <Button type="button" onClick={() => navigate("/specialist/products/new")}>
+            <Plus size={16} />
+            Novo Produto
+          </Button>
+        }
+      />
 
       {/* Filtro de Tipo (apenas se não tiver especialidade definida) */}
       {!userSpeciality && (
-        <div className="flex gap-4">
+        <div className="flex gap-4 mb-4">
           <button
             onClick={() => setProductType("cars")}
-            className={`px-6 py-2 rounded-md transition ${
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition ${
               productType === "cars"
-                ? "bg-blue-600 text-white"
-                : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                ? "border-ink text-ink"
+                : "border-transparent text-muted hover:text-ink-soft"
             }`}
           >
             Carros
           </button>
           <button
             onClick={() => setProductType("boats")}
-            className={`px-6 py-2 rounded-md transition ${
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition ${
               productType === "boats"
-                ? "bg-blue-600 text-white"
-                : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                ? "border-ink text-ink"
+                : "border-transparent text-muted hover:text-ink-soft"
             }`}
           >
             Lanchas
           </button>
           <button
             onClick={() => setProductType("aircrafts")}
-            className={`px-6 py-2 rounded-md transition ${
+            className={`px-4 py-2 text-sm font-medium border-b-2 transition ${
               productType === "aircrafts"
-                ? "bg-blue-600 text-white"
-                : "bg-gray-200 text-gray-700 hover:bg-gray-300"
+                ? "border-ink text-ink"
+                : "border-transparent text-muted hover:text-ink-soft"
             }`}
           >
             Aeronaves
@@ -173,54 +177,54 @@ export default function ProductsPage() {
 
       {/* Mostra a especialidade do usuário (se tiver) */}
       {userSpeciality && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-          <p className="text-sm text-blue-800">
+        <Alert variant="info" className="mb-4">
+          <p>
             <span className="font-semibold">Sua especialidade:</span>{" "}
             {getProductTypeLabel()}
           </p>
-        </div>
+        </Alert>
       )}
 
       {/* Lista de Produtos */}
-      <div className="bg-white rounded-lg shadow-md p-6">
-        <h2 className="text-xl font-semibold text-text-primary mb-4">{getProductTypeLabel()}</h2>
+      <Card>
+        <h2 className="text-h2 font-semibold text-ink mb-4">{getProductTypeLabel()}</h2>
 
         {loading ? (
-          <p className="text-center text-gray-500 py-8">Carregando...</p>
+          <p className="text-center text-muted py-8">Carregando...</p>
         ) : filteredProducts.length === 0 ? (
-          <p className="text-center text-gray-500 py-8">
+          <p className="text-center text-muted py-8">
             {searchTerm ? "Nenhum produto encontrado com esse termo de pesquisa" : "Nenhum produto cadastrado"}
           </p>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full">
-              <thead className="border-b">
+              <thead className="border-b border-border">
                 <tr className="text-left">
-                  <th className="pb-3 text-sm font-medium text-gray-600">Foto</th>
-                  <th className="pb-3 text-sm font-medium text-gray-600">Marca</th>
-                  <th className="pb-3 text-sm font-medium text-gray-600">Modelo</th>
-                  <th className="pb-3 text-sm font-medium text-gray-600">Ano</th>
-                  <th className="pb-3 text-sm font-medium text-gray-600">Valor</th>
-                  <th className="pb-3 text-sm font-medium text-gray-600">Estado</th>
-                  <th className="pb-3 text-sm font-medium text-gray-600 text-right">Ações</th>
+                  <th className="pb-3 text-sm font-medium text-muted">Foto</th>
+                  <th className="pb-3 text-sm font-medium text-muted">Marca</th>
+                  <th className="pb-3 text-sm font-medium text-muted">Modelo</th>
+                  <th className="pb-3 text-sm font-medium text-muted">Ano</th>
+                  <th className="pb-3 text-sm font-medium text-muted">Valor</th>
+                  <th className="pb-3 text-sm font-medium text-muted">Estado</th>
+                  <th className="pb-3 text-sm font-medium text-muted text-right">Ações</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredProducts.map((product) => (
-                  <tr key={product.id} className="border-b hover:bg-gray-50">
+                  <tr key={product.id} className="border-b border-border-soft hover:bg-border-soft/50">
                     <td className="py-3 pr-3">
                       {product.imageUrl ? (
                         <img
                           src={product.imageUrl}
                           alt={`${product.marca} ${product.modelo}`}
-                          className="w-16 h-16 object-cover rounded-md border border-gray-200"
+                          className="w-16 h-16 object-cover rounded-md border border-border"
                           loading="lazy"
                           onError={(e) => {
                             (e.currentTarget as HTMLImageElement).style.display = "none";
                           }}
                         />
                       ) : (
-                        <div className="w-16 h-16 rounded-md border border-gray-200 bg-gray-100 flex items-center justify-center text-gray-400 text-xs">
+                        <div className="w-16 h-16 rounded-md border border-border bg-border-soft flex items-center justify-center text-subtle text-xs">
                           sem foto
                         </div>
                       )}
@@ -231,44 +235,20 @@ export default function ProductsPage() {
                     <td className="py-3">R$ {product.valor?.toLocaleString("pt-BR") || "0"}</td>
                     <td className="py-3 capitalize">{product.estado || "-"}</td>
                     <td className="py-3">
-                      <div className="flex gap-2 justify-end">
+                      <div className="flex gap-1 justify-end">
                         <button
                           onClick={() => handleEdit(product.id)}
-                          className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition"
+                          className="p-1.5 rounded hover:bg-border-soft text-ink-soft transition"
                           title="Editar"
                         >
-                          <svg
-                            className="w-5 h-5"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                            />
-                          </svg>
+                          <Pencil size={18} />
                         </button>
                         <button
                           onClick={() => handleDelete(product.id)}
-                          className="p-2 text-gray-600 hover:bg-gray-100 rounded-lg transition"
+                          className="p-1.5 rounded hover:bg-status-bad-wash text-status-bad transition"
                           title="Excluir"
                         >
-                          <svg
-                            className="w-5 h-5"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth={2}
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                          </svg>
+                          <Trash2 size={18} />
                         </button>
                       </div>
                     </td>
@@ -278,8 +258,7 @@ export default function ProductsPage() {
             </table>
           </div>
         )}
-      </div>
+      </Card>
     </div>
   );
 }
-

--- a/frontend/src/services/consultant.service.ts
+++ b/frontend/src/services/consultant.service.ts
@@ -161,6 +161,7 @@ export type ConsultantProcess = {
   status: string;
   product_type: string | null;
   created_at: string;
+  updated_at: string;
   client_id: string;
   client: { id: string; name: string; surname: string } | null;
   specialist: { id: string; name: string; surname: string; speciality: string } | null;


### PR DESCRIPTION
## Summary
- Fundação do design system: tokens de cor/sombra (aditivos), utilitário `cn()`, componentes reutilizáveis (Button, Card, Input, Alert, Dialog sobre Radix, StatusBadge, ProposalStatusBadge, EmptyState, BackButton, PageHeader).
- Piloto de rollout aplicado nas telas de Consultor, Especialista, Admin, Escritório e Customer, substituindo classes Tailwind cruas pelos tokens/componentes do design system.
- Fixes de navegação e Calendly encontrados durante o rollout: callback do DocuSign sem saída fora de popup, `/advisor/dashboard` órfão na Sidebar, corrida no `confirmedRef` do `useCalendlyScheduling`, agendamento órfão no ProductPage, convite em lote sem botão durante processamento de CSV.
- Docs: `DESIGN.md`, `PRODUCT.md`, plano de rollout por fatias (Consultor / Especialista / Admin / demais).

## Test plan
- [ ] `cd frontend && npm run lint`
- [ ] `cd frontend && npm run build`
- [ ] QA visual manual: Consultor (Meus Clientes, Processos, Dashboard), Especialista (Processos, Produtos, Contrato), Admin (Dashboard, Empresas, Especialistas, Comissões, Base de dados, Configurações, Minha Empresa), Escritório (Consultores, Dashboard, Clientes, Configurações da Empresa), Customer (Home, Processos, Catálogo com filtro real, Consultoria)
- [ ] Confirmar que os tokens de cor são aditivos (não quebram telas fora do escopo do piloto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)