### PR TITLE
feat(produtos): identificador no formulário manual e modal de import CSV

### DIFF
--- a/.superpowers/sdd/2026-08-03-calculadora-spread-comissoes/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-03-calculadora-spread-comissoes/final-fix-report.md
@@ -27,3 +27,12 @@ Data: 2026-08-03
 ## Commit
 
 As correções e este relatório estão no commit desta alteração.
+
+## Correção residual de overflow
+
+- A venda normalizada agora tem teto de `Number.MAX_VALUE / 100`. Com taxas de
+  até 100% e `round2` multiplicando por 100, esse limite mantém todos os
+  intermediários do split finitos.
+- O teste focado reproduz `Number.MAX_VALUE` com comissão total de 100% e
+  confirma que o split normalizado não contém `Infinity`.
+- Verificação: `npm run test -- src/lib/commission-calculator-input.test.ts --maxWorkers=2 --no-file-parallelism` — 3 testes aprovados.

--- a/.superpowers/sdd/2026-08-03-calculadora-spread-comissoes/final-fix-report.md
+++ b/.superpowers/sdd/2026-08-03-calculadora-spread-comissoes/final-fix-report.md
@@ -1,0 +1,29 @@
+# Final fix report — calculadora de spread de comissões
+
+Data: 2026-08-03
+
+## Correções aplicadas
+
+1. Os dois calculadores convertem os textos dos campos em um objeto de cálculo
+   normalizado: valores não finitos viram `0`, a venda é limitada ao mínimo `0`
+   e todas as taxas são limitadas a `0–100`. O estado continua textual para não
+   interromper a edição de números decimais.
+2. A tabela completa agora mostra `Restante` entre `Especialista` e
+   `Escritório`, calculado como `bolo - specialistValue`; a ordem fica
+   Bolo → Especialista → Restante → Escritório → Plataforma e a taxa efetiva é
+   exibida pela mesma função das demais linhas.
+3. A página completa controla o produto selecionado. Ao trocar categoria,
+   limpa o id, as opções carregadas e o preço associado, evitando reaproveitar
+   visualmente um produto/preço de outra categoria.
+
+## Verificações
+
+- RED: `npm run test -- src/lib/commission-calculator-input.test.ts --maxWorkers=2 --no-file-parallelism` falhou antes da implementação porque o módulo ainda não existia.
+- GREEN focado: o mesmo comando passou com 2 testes.
+- Suite: `npm run test -- --maxWorkers=2 --no-file-parallelism` — 2 arquivos, 9 testes aprovados.
+- Lint: `npm run lint` — exit 0; 122 avisos pré-existentes fora dos arquivos alterados.
+- Build: `npm run build` — exit 0.
+
+## Commit
+
+As correções e este relatório estão no commit desta alteração.

--- a/.superpowers/sdd/2026-08-03-identificador-produto-e-uuid/task-B3-report.md
+++ b/.superpowers/sdd/2026-08-03-identificador-produto-e-uuid/task-B3-report.md
@@ -1,0 +1,26 @@
+# B3 — Frontend: identificador de produto como UUID
+
+## Escopo implementado
+
+- Os contratos `RawCar`, `RawBoat`, `RawAircraft` e `Product` agora usam `id: string`.
+- As operações de produto por identificador (`get`, `update` e `delete`) recebem UUIDs como `string`.
+- As telas de catálogo, formulário e gestão de produtos preservam o identificador da rota sem conversão numérica.
+- Os contratos que propagam o identificador do produto para processos, agendamentos, seleção de produto e criação de processo pelo consultor agora usam `string`.
+
+## Verificação
+
+- `cd frontend && grep -rnE "Number\\((id|product\\.id|productId)" src` não retornou ocorrências.
+- `cd frontend && npm run build` concluiu com sucesso (`tsc -b` e `vite build`).
+- O Vite emitiu apenas o aviso preexistente de chunks acima de 500 kB; não houve erro de compilação.
+
+## Limites respeitados
+
+- Nenhuma alteração em comissões.
+- Nenhum servidor iniciado.
+- Nenhum schema ou reset executado.
+
+## Correção da revisão
+
+- `ConfirmAppointmentModal` e `useCreateAppointment` agora aceitam somente `productId`/`product_id` como `string`.
+- Os contratos de listagem e detalhe em `select-options.service.ts` usam identificadores de produto como `string`.
+- Os objetos `product` aninhados de processos (`processes.service.ts`, `ProcessCard` e `CustomerProcessesPage`) foram alinhados a UUIDs como `string`.

--- a/.superpowers/sdd/2026-08-03-identificador-produto-e-uuid/task-B3-report.md
+++ b/.superpowers/sdd/2026-08-03-identificador-produto-e-uuid/task-B3-report.md
@@ -24,3 +24,4 @@
 - `ConfirmAppointmentModal` e `useCreateAppointment` agora aceitam somente `productId`/`product_id` como `string`.
 - Os contratos de listagem e detalhe em `select-options.service.ts` usam identificadores de produto como `string`.
 - Os objetos `product` aninhados de processos (`processes.service.ts`, `ProcessCard` e `CustomerProcessesPage`) foram alinhados a UUIDs como `string`.
+- `ProductOption` agora substitui o `id: string | number` herdado de `SelectOption` por `id: string`, mantendo o contrato genérico dos demais selects inalterado.

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -60,3 +60,4 @@ pids
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 
 /generated/prisma
+/scripts/out/

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -679,6 +679,7 @@ model Car {
   deactivated_by_sync_job_id String?   @db.Uuid
   marca                      String
   modelo                     String
+  identificador              String
   valor                      Decimal
   estado                     String
   ano                        Int
@@ -697,6 +698,7 @@ model Car {
 
   @@index([specialist_id])
   @@index([specialist_id, is_active])
+  @@unique([specialist_id, identificador])
 }
 
 // Car_image: imagens associadas aos anúncios de Car
@@ -723,6 +725,7 @@ model Boat {
   deactivated_by_sync_job_id String?   @db.Uuid
   marca                      String
   modelo                     String
+  identificador              String
   valor                      Decimal
   ano                        Int
   fabricante                 String?
@@ -744,6 +747,7 @@ model Boat {
 
   @@index([specialist_id])
   @@index([specialist_id, is_active])
+  @@unique([specialist_id, identificador])
 }
 
 // Boat_image: imagens associadas aos anúncios de Boat
@@ -772,6 +776,7 @@ model Aircraft {
   ano                        Int
   marca                      String
   modelo                     String
+  identificador              String
   assentos                   Int?
   estado                     String
   descricao                  String?
@@ -786,6 +791,7 @@ model Aircraft {
 
   @@index([specialist_id])
   @@index([specialist_id, is_active])
+  @@unique([specialist_id, identificador])
 }
 
 // Aircraft_image: imagens associadas aos anúncios de Aircraft

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -666,13 +666,11 @@ model PlatformCompany {
 // ─────────────────────────────────────────────────────────────────────────────
 // Car / Boat / Aircraft: inventário de veículos, embarcações e aeronaves de luxo
 // [Type]_image: imagens específicas por tipo de produto
-// Nota: ids Int com TODO para futura migração a UUID
 
 // === Products & Images ===
 // Car: inventário de automóveis de luxo
-// TODO: converter id Int para UUID em migração futura
 model Car {
-  id                         Int       @id @default(autoincrement())
+  id                         String    @id @default(uuid()) @db.Uuid
   specialist_id              String?   @db.Uuid
   is_active                  Boolean   @default(true)
   deactivated_at             DateTime?
@@ -709,16 +707,15 @@ model Car_image {
   is_primary   Boolean  @default(false)
   created_at   DateTime @default(now())
 
-  car_id Int?
-  car    Car? @relation(fields: [car_id], references: [id])
+  car_id String? @db.Uuid
+  car    Car?    @relation(fields: [car_id], references: [id])
 
   @@index([car_id])
 }
 
 // Boat: inventário de iates/embarcações de luxo
-// TODO: converter id Int para UUID em migração futura
 model Boat {
-  id                         Int       @id @default(autoincrement())
+  id                         String    @id @default(uuid()) @db.Uuid
   specialist_id              String?   @db.Uuid
   is_active                  Boolean   @default(true)
   deactivated_at             DateTime?
@@ -758,16 +755,15 @@ model Boat_image {
   is_primary   Boolean  @default(false)
   created_at   DateTime @default(now())
 
-  boat_id Int?
-  boat    Boat? @relation(fields: [boat_id], references: [id])
+  boat_id String? @db.Uuid
+  boat    Boat?  @relation(fields: [boat_id], references: [id])
 
   @@index([boat_id])
 }
 
 // Aircraft: inventário de aeronaves de luxo
-// TODO: converter id Int para UUID em migração futura
 model Aircraft {
-  id                         Int       @id @default(autoincrement())
+  id                         String    @id @default(uuid()) @db.Uuid
   specialist_id              String?   @db.Uuid
   is_active                  Boolean   @default(true)
   deactivated_at             DateTime?
@@ -802,20 +798,19 @@ model Aircraft_image {
   is_primary   Boolean  @default(false)
   created_at   DateTime @default(now())
 
-  aircraft_id Int?
-  aircraft    Aircraft? @relation(fields: [aircraft_id], references: [id])
+  aircraft_id String? @db.Uuid
+  aircraft    Aircraft?  @relation(fields: [aircraft_id], references: [id])
 
   @@index([aircraft_id])
 }
 
 // Product: camada de abstração para entidades de produto (Car, Boat, Aircraft)
-// TODO: converter car_id, boat_id, aircraft_id para UUID quando IDs de produto migrarem
 model Product {
   id          String      @id @default(uuid()) @db.Uuid
   type        ProductType
-  car_id      Int?
-  boat_id     Int?
-  aircraft_id Int?
+  car_id      String?     @db.Uuid
+  boat_id     String?     @db.Uuid
+  aircraft_id String?     @db.Uuid
 
   process   Process? @relation(fields: [processId], references: [id])
   processId String?  @db.Uuid
@@ -834,14 +829,13 @@ model Product {
 // Process: fluxo de negociação/venda vinculando cliente, especialista e produto
 // Suporta fluxo de consultoria: product_type e car_id/boat_id/aircraft_id opcionais
 // Se product_type for null, é um processo de consultoria sem produto definido
-// TODO: converter car_id, boat_id, aircraft_id para UUID em migração futura
 model Process {
   id            String @id @default(uuid()) @db.Uuid
   client_id     String @db.Uuid
   specialist_id String @db.Uuid
-  car_id        Int?
-  aircraft_id   Int?
-  boat_id       Int?
+  car_id        String? @db.Uuid
+  aircraft_id   String? @db.Uuid
+  boat_id       String? @db.Uuid
 
   product_id         String?       @db.Uuid
   product_type       ProductType? // Opcional para consultoria (null = consultoria sem produto)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1126,7 +1126,7 @@ model Appointment {
   client_id     String       @db.Uuid
   specialist_id String       @db.Uuid
   product_type  ProductType? // Opcional: null para consultoria sem produto específico
-  product_id    Int? // Opcional: null para consultoria sem produto específico
+  product_id    String?       @db.Uuid // Opcional: null para consultoria sem produto específico
 
   // Data e hora do agendamento em UTC (ISO 8601)
   // Exemplo: "2024-10-10T14:00:00Z"
@@ -1320,7 +1320,7 @@ model ProductImportJobItem {
   status        ProductImportItemStatus @default(PENDING)
   payload       Json
   folder_url    String?
-  product_id    Int?
+  product_id    String?                 @db.Uuid
   action        String?
   attempts      Int                     @default(0)
   error_message String?

--- a/backend/prisma/seed-commission-demo.ts
+++ b/backend/prisma/seed-commission-demo.ts
@@ -77,7 +77,7 @@ async function createSale(params: {
   specialist: { id: string; name: string; cpf: string; commission_rate: number };
   company: { name: string; cnpj: string; commission_rate: number } | null;
   productType: 'CAR' | 'BOAT';
-  productId: number;
+  productId: string;
   saleValue: number;
   totalCommissionRate: number;
 }) {

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -191,6 +191,7 @@ async function main() {
       data: {
         marca: carMock.marca,
         modelo: carMock.modelo,
+        identificador: `${carMock.marca}-${carMock.modelo}`,
         valor: carMock.valor,
         estado: carMock.estado,
         ano: carMock.ano,
@@ -234,6 +235,7 @@ async function main() {
       data: {
         marca: boatMock.marca,
         modelo: boatMock.modelo,
+        identificador: `${boatMock.marca}-${boatMock.modelo}`,
         valor: boatMock.valor,
         ano: boatMock.ano,
         fabricante: boatMock.fabricante,
@@ -281,6 +283,7 @@ async function main() {
         ano: aircraftMock.ano,
         marca: aircraftMock.marca,
         modelo: aircraftMock.modelo,
+        identificador: `${aircraftMock.marca}-${aircraftMock.modelo}`,
         assentos: aircraftMock.capacidade_passageiros,
         estado: aircraftMock.estado,
         descricao: aircraftMock.descricao,

--- a/backend/scripts/export-produtos-para-csv.ts
+++ b/backend/scripts/export-produtos-para-csv.ts
@@ -1,0 +1,239 @@
+import { PrismaClient } from '@prisma/client';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+const prisma = new PrismaClient();
+
+type ProductWithIdentifierSource = {
+  specialist_id: string | null;
+  marca: string;
+  modelo: string;
+};
+
+const csvHeaders = {
+  carros: [
+    'marca',
+    'modelo',
+    'identificador',
+    'valor',
+    'estado',
+    'ano',
+    'cor',
+    'km',
+    'cambio',
+    'combustivel',
+    'tipo_categoria',
+    'descricao',
+  ],
+  barcos: [
+    'marca',
+    'modelo',
+    'identificador',
+    'valor',
+    'estado',
+    'ano',
+    'fabricante',
+    'tamanho',
+    'estilo',
+    'combustivel',
+    'motor',
+    'ano_motor',
+    'tipo_embarcacao',
+    'descricao_completa',
+    'acessorios',
+  ],
+  aeronaves: [
+    'marca',
+    'modelo',
+    'identificador',
+    'valor',
+    'estado',
+    'ano',
+    'categoria',
+    'assentos',
+    'tipo_aeronave',
+    'descricao',
+  ],
+} as const;
+
+function escapeCsv(value: unknown): string {
+  const normalized = value == null ? '' : String(value);
+
+  return /[;"\n\r]/.test(normalized)
+    ? `"${normalized.replaceAll('"', '""')}"`
+    : normalized;
+}
+
+function slug(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'SEM-NOME';
+}
+
+function generatedIdentifiers<T extends ProductWithIdentifierSource>(records: T[]) {
+  const sequences = new Map<string, number>();
+
+  return records.map((record) => {
+    const key = [record.specialist_id ?? '', record.marca, record.modelo].join('\u0000');
+    const sequence = (sequences.get(key) ?? 0) + 1;
+    sequences.set(key, sequence);
+
+    return `${slug(record.marca)}-${slug(record.modelo)}-${sequence}`;
+  });
+}
+
+function toCsv(headers: readonly string[], rows: unknown[][]): string {
+  return [headers, ...rows]
+    .map((row) => row.map(escapeCsv).join(';'))
+    .join('\n')
+    .concat('\n');
+}
+
+async function main() {
+  const [cars, boats, aircraft] = await Promise.all([
+    prisma.car.findMany({
+      select: {
+        specialist_id: true,
+        marca: true,
+        modelo: true,
+        valor: true,
+        estado: true,
+        ano: true,
+        cor: true,
+        km: true,
+        cambio: true,
+        combustivel: true,
+        tipo_categoria: true,
+        descricao: true,
+      },
+      orderBy: { id: 'asc' },
+    }),
+    prisma.boat.findMany({
+      select: {
+        specialist_id: true,
+        marca: true,
+        modelo: true,
+        valor: true,
+        estado: true,
+        ano: true,
+        fabricante: true,
+        tamanho: true,
+        estilo: true,
+        combustivel: true,
+        motor: true,
+        ano_motor: true,
+        tipo_embarcacao: true,
+        descricao_completa: true,
+        acessorios: true,
+      },
+      orderBy: { id: 'asc' },
+    }),
+    prisma.aircraft.findMany({
+      select: {
+        specialist_id: true,
+        marca: true,
+        modelo: true,
+        valor: true,
+        estado: true,
+        ano: true,
+        categoria: true,
+        assentos: true,
+        tipo_aeronave: true,
+        descricao: true,
+      },
+      orderBy: { id: 'asc' },
+    }),
+  ]);
+
+  const outputDirectory = resolve(__dirname, 'out');
+  await mkdir(outputDirectory, { recursive: true });
+
+  const carIdentifiers = generatedIdentifiers(cars);
+  const boatIdentifiers = generatedIdentifiers(boats);
+  const aircraftIdentifiers = generatedIdentifiers(aircraft);
+
+  const files = [
+    {
+      name: 'carros.csv',
+      content: toCsv(
+        csvHeaders.carros,
+        cars.map((car, index) => [
+          car.marca,
+          car.modelo,
+          carIdentifiers[index],
+          car.valor,
+          car.estado,
+          car.ano,
+          car.cor,
+          car.km,
+          car.cambio,
+          car.combustivel,
+          car.tipo_categoria,
+          car.descricao,
+        ]),
+      ),
+    },
+    {
+      name: 'barcos.csv',
+      content: toCsv(
+        csvHeaders.barcos,
+        boats.map((boat, index) => [
+          boat.marca,
+          boat.modelo,
+          boatIdentifiers[index],
+          boat.valor,
+          boat.estado,
+          boat.ano,
+          boat.fabricante,
+          boat.tamanho,
+          boat.estilo,
+          boat.combustivel,
+          boat.motor,
+          boat.ano_motor,
+          boat.tipo_embarcacao,
+          boat.descricao_completa,
+          boat.acessorios,
+        ]),
+      ),
+    },
+    {
+      name: 'aeronaves.csv',
+      content: toCsv(
+        csvHeaders.aeronaves,
+        aircraft.map((item, index) => [
+          item.marca,
+          item.modelo,
+          aircraftIdentifiers[index],
+          item.valor,
+          item.estado,
+          item.ano,
+          item.categoria,
+          item.assentos,
+          item.tipo_aeronave,
+          item.descricao,
+        ]),
+      ),
+    },
+  ];
+
+  await Promise.all(
+    files.map(async ({ name, content }) => {
+      const outputPath = resolve(outputDirectory, name);
+      await writeFile(outputPath, content, 'utf8');
+      console.log(`${outputPath}: ${content.split('\n').length - 2} registros exportados`);
+    }),
+  );
+}
+
+main()
+  .catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/features/aircrafts/aircrafts.controller.ts
+++ b/backend/src/features/aircrafts/aircrafts.controller.ts
@@ -141,7 +141,7 @@ export class AircraftsController {
   @Get(':id')
   @Public()
   findOne(@Param('id') id: string) {
-    return this.aircraftsService.findOne(+id);
+    return this.aircraftsService.findOne(id);
   }
 
   @Patch(':id')
@@ -152,17 +152,17 @@ export class AircraftsController {
     @CurrentUser() user: UserEntity,
   ) {
     assertSpecialistCanModify('AIRCRAFT', user);
-    const existing = await this.aircraftsService.findOne(+id);
+    const existing = await this.aircraftsService.findOne(id);
     assertSpecialistOwnsProduct(user, existing?.specialist_id);
-    return this.aircraftsService.update(+id, updateAircraftDto);
+    return this.aircraftsService.update(id, updateAircraftDto);
   }
 
   @Delete(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
   async remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
     assertSpecialistCanModify('AIRCRAFT', user);
-    const existing = await this.aircraftsService.findOne(+id);
+    const existing = await this.aircraftsService.findOne(id);
     assertSpecialistOwnsProduct(user, existing?.specialist_id);
-    return this.aircraftsService.remove(+id);
+    return this.aircraftsService.remove(id);
   }
 }

--- a/backend/src/features/aircrafts/aircrafts.service.ts
+++ b/backend/src/features/aircrafts/aircrafts.service.ts
@@ -63,6 +63,7 @@ export class AircraftsService {
       ano: aircraftData.ano,
       marca: aircraftData.marca,
       modelo: aircraftData.modelo,
+      identificador: aircraftData.identificador,
       assentos: aircraftData.assentos,
       estado: aircraftData.estado,
       descricao: aircraftData.descricao,
@@ -303,6 +304,9 @@ export class AircraftsService {
     if (aircraftData.modelo !== undefined) {
       payload.modelo = aircraftData.modelo;
     }
+    if (aircraftData.identificador !== undefined) {
+      payload.identificador = aircraftData.identificador;
+    }
     if (aircraftData.assentos !== undefined) {
       payload.assentos = aircraftData.assentos;
     }
@@ -484,6 +488,7 @@ export class AircraftsService {
         const aircraftData: any = {
           marca: row.marca,
           modelo: row.modelo,
+          identificador: row.identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),
@@ -530,6 +535,7 @@ export class AircraftsService {
               ano: aircraftData.ano,
               marca: aircraftData.marca,
               modelo: aircraftData.modelo,
+              identificador: aircraftData.identificador,
               assentos: aircraftData.assentos,
               estado: aircraftData.estado,
               descricao: aircraftData.descricao,
@@ -545,6 +551,7 @@ export class AircraftsService {
               ano: aircraftData.ano,
               marca: aircraftData.marca,
               modelo: aircraftData.modelo,
+              identificador: aircraftData.identificador,
               assentos: aircraftData.assentos,
               estado: aircraftData.estado,
               descricao: aircraftData.descricao,
@@ -613,6 +620,7 @@ export class AircraftsService {
         const aircraftData: any = {
           marca: row.marca,
           modelo: row.modelo,
+          identificador: row.identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),
@@ -666,6 +674,7 @@ export class AircraftsService {
               ano: aircraftData.ano,
               marca: aircraftData.marca,
               modelo: aircraftData.modelo,
+              identificador: aircraftData.identificador,
               assentos: aircraftData.assentos,
               estado: aircraftData.estado,
               descricao: aircraftData.descricao,
@@ -682,6 +691,7 @@ export class AircraftsService {
               ano: aircraftData.ano,
               marca: aircraftData.marca,
               modelo: aircraftData.modelo,
+              identificador: aircraftData.identificador,
               assentos: aircraftData.assentos,
               estado: aircraftData.estado,
               descricao: aircraftData.descricao,

--- a/backend/src/features/aircrafts/aircrafts.service.ts
+++ b/backend/src/features/aircrafts/aircrafts.service.ts
@@ -37,6 +37,7 @@ export class AircraftsService {
   private readonly xlsxColumns: XlsxColumnDefinition[] = [
     { name: 'marca', required: true, type: 'string' },
     { name: 'modelo', required: true, type: 'string' },
+    { name: 'identificador', required: true, type: 'string' },
     { name: 'valor', required: true, type: 'number' },
     { name: 'estado', required: true, type: 'string' },
     { name: 'ano', required: true, type: 'number' },
@@ -393,6 +394,7 @@ export class AircraftsService {
     const instructions: Record<string, string> = {
       marca: 'Nome da marca da aeronave (texto)',
       modelo: 'Nome do modelo (texto)',
+      identificador: 'Identificador único do produto (texto)',
       valor: 'Preço em reais (número inteiro, sem pontos ou vírgulas)',
       estado: 'Estado onde a aeronave está localizada (texto)',
       ano: 'Ano de fabricação (número)',
@@ -408,6 +410,7 @@ export class AircraftsService {
     const example: Record<string, any> = {
       marca: 'Embraer',
       modelo: 'Phenom 300',
+      identificador: 'Embraer-Phenom 300-1',
       valor: 15000000,
       estado: 'São Paulo',
       ano: 2021,
@@ -430,6 +433,7 @@ export class AircraftsService {
     const exampleValues = [
       'Embraer',
       'Phenom 300',
+      'Embraer-Phenom 300-1',
       '15000000',
       'São Paulo',
       '2021',

--- a/backend/src/features/aircrafts/aircrafts.service.ts
+++ b/backend/src/features/aircrafts/aircrafts.service.ts
@@ -521,9 +521,8 @@ export class AircraftsService {
 
         const existingAircraft = await this.prismaService.aircraft.findFirst({
           where: {
-            marca: row.marca?.trim(),
-            modelo: row.modelo?.trim(),
             specialist_id: user.id,
+            identificador: row.identificador?.trim(),
           },
         });
 
@@ -656,9 +655,8 @@ export class AircraftsService {
         // Verificar se já existe um produto com mesma marca + modelo para este especialista
         const existingAircraft = await this.prismaService.aircraft.findFirst({
           where: {
-            marca: row.marca?.trim(),
-            modelo: row.modelo?.trim(),
             specialist_id: user.id,
+            identificador: row.identificador?.trim(),
           },
         });
 

--- a/backend/src/features/aircrafts/aircrafts.service.ts
+++ b/backend/src/features/aircrafts/aircrafts.service.ts
@@ -131,6 +131,9 @@ export class AircraftsService {
       );
       return aircraftWithImages;
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw error;
+      }
       this.logger.error(
         `[create] Erro ao criar aeronave: ${error.message}`,
         error.stack,
@@ -369,6 +372,9 @@ export class AircraftsService {
         include: { images: true },
       });
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw error;
+      }
       throw new Error(`Erro ao atualizar aeronave: ${error.message}`);
     }
   }

--- a/backend/src/features/aircrafts/aircrafts.service.ts
+++ b/backend/src/features/aircrafts/aircrafts.service.ts
@@ -256,7 +256,7 @@ export class AircraftsService {
     };
   }
 
-  async findOne(id: number) {
+  async findOne(id: string) {
     this.logger.log(`[findOne] Buscando aeronave - ID: ${id}`);
     const aircraft = await this.prismaService.aircraft.findUnique({
       where: { id },
@@ -282,11 +282,11 @@ export class AircraftsService {
     return { ...aircraft };
   }
 
-  // update(id: number, updateAircraftDto: UpdateAircraftDto) {
+  // update(id: string, updateAircraftDto: UpdateAircraftDto) {
   //   return `This action updates a #${id} aircraft`;
   // }
 
-  async update(id: number, updateAircraftDto: UpdateAircraftDto) {
+  async update(id: string, updateAircraftDto: UpdateAircraftDto) {
     await this.findOne(id);
 
     const { specialist_id, images, ...aircraftData } = updateAircraftDto;
@@ -373,7 +373,7 @@ export class AircraftsService {
     }
   }
 
-  async remove(id: number) {
+  async remove(id: string) {
     await this.findOne(id);
 
     try {
@@ -476,8 +476,8 @@ export class AircraftsService {
       });
     }
 
-    const insertedIds: number[] = [];
-    const updatedIds: number[] = [];
+    const insertedIds: string[] = [];
+    const updatedIds: string[] = [];
     const errorRows: ImportErrorRow[] = [];
 
     for (let i = 0; i < rows.length; i++) {
@@ -604,8 +604,8 @@ export class AircraftsService {
       });
     }
 
-    const insertedIds: number[] = [];
-    const updatedIds: number[] = [];
+    const insertedIds: string[] = [];
+    const updatedIds: string[] = [];
     const errorRows: ImportErrorRow[] = [];
     const warningRows: ImportErrorRow[] = [];
 

--- a/backend/src/features/aircrafts/aircrafts.service.ts
+++ b/backend/src/features/aircrafts/aircrafts.service.ts
@@ -613,13 +613,14 @@ export class AircraftsService {
     for (let i = 0; i < rows.length; i++) {
       const rowNumber = i + 2; // +2 porque linha 1 é header e arrays começam em 0
       const row = rows[i];
+      const identificador = row.identificador?.trim();
 
       try {
         // Preparar DTO
         const aircraftData: any = {
           marca: row.marca,
           modelo: row.modelo,
-          identificador: row.identificador,
+          identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),
@@ -652,11 +653,11 @@ export class AircraftsService {
           continue;
         }
 
-        // Verificar se já existe um produto com mesma marca + modelo para este especialista
+        // Verificar se já existe um produto com mesmo identificador para este especialista
         const existingAircraft = await this.prismaService.aircraft.findFirst({
           where: {
             specialist_id: user.id,
-            identificador: row.identificador?.trim(),
+            identificador,
           },
         });
 

--- a/backend/src/features/aircrafts/dto/create-aircraft.dto.ts
+++ b/backend/src/features/aircrafts/dto/create-aircraft.dto.ts
@@ -24,6 +24,9 @@ export class CreateAircraftDto {
   @IsString()
   modelo: string;
 
+  @IsString()
+  identificador: string;
+
   @IsNumber()
   valor: number;
 

--- a/backend/src/features/aircrafts/entity/aircraft-image.entity.ts
+++ b/backend/src/features/aircrafts/entity/aircraft-image.entity.ts
@@ -5,7 +5,7 @@ export class AircraftImage {
   product_type: string;
   image_url: string;
   is_primary: boolean;
-  aircraft_id?: number | null;
+  aircraft_id?: string | null;
   created_at: Date;
 
   aircraft?: Aircraft;

--- a/backend/src/features/aircrafts/entity/aircraft.entity.ts
+++ b/backend/src/features/aircrafts/entity/aircraft.entity.ts
@@ -2,7 +2,7 @@ import { AircraftImage } from './aircraft-image.entity';
 import { UserEntity } from 'src/auth/entities/user.entity';
 
 export class Aircraft {
-  id: number;
+  id: string;
   is_active: boolean;
   deactivated_at: Date | null;
   deactivated_by_sync_job_id: string | null;

--- a/backend/src/features/appointments/appointments.service.ts
+++ b/backend/src/features/appointments/appointments.service.ts
@@ -831,7 +831,7 @@ export class AppointmentsService {
    */
   private async getProductByType(
     productType: ProductType | null,
-    productId: number | null,
+    productId: string | null,
   ): Promise<Car | Boat | Aircraft | null> {
     // Para consultoria, não há produto ainda
     if (!productType || !productId) {
@@ -928,28 +928,17 @@ export class AppointmentsService {
    * @param clientId ID do cliente (UUID)
    * @param specialistId ID do especialista (UUID)
    * @param productType Tipo de produto (CAR, BOAT, AIRCRAFT)
-   * @param productId ID do produto (convertido para number)
+   * @param productId UUID do produto
    * @returns Appointment se encontrado e status = SCHEDULED, caso contrário null
    */
   async findScheduledAppointment(
     clientId: string,
     specialistId: string,
     productType: ProductType,
-    productId: number | string,
+    productId: string,
   ): Promise<AppointmentResponseEntity | null> {
-    // Converter productId para number (pode vir como string da query param)
-    const productIdNum =
-      typeof productId === 'string' ? parseInt(productId, 10) : productId;
-
-    if (isNaN(productIdNum)) {
-      this.logger.warn(
-        `[findScheduledAppointment] productId inválido: ${productId}`,
-      );
-      return null;
-    }
-
     this.logger.log(
-      `[findScheduledAppointment] Buscando agendamento existente: cliente=${clientId}, especialista=${specialistId}, produto=${productType}/${productIdNum}`,
+      `[findScheduledAppointment] Buscando agendamento existente: cliente=${clientId}, especialista=${specialistId}, produto=${productType}/${productId}`,
     );
 
     const appointment = await this.prisma.appointment.findFirst({
@@ -957,7 +946,7 @@ export class AppointmentsService {
         client_id: clientId,
         specialist_id: specialistId,
         product_type: productType,
-        product_id: productIdNum,
+        product_id: productId,
         status: 'SCHEDULED',
       },
       include: {
@@ -1649,28 +1638,21 @@ export class AppointmentsService {
    * @param clientId ID do cliente (UUID)
    * @param specialistId ID do especialista (UUID)
    * @param productType Tipo de produto (CAR, BOAT, AIRCRAFT)
-   * @param productId ID do produto (convertido para number)
+   * @param productId UUID do produto
    * @returns Appointment se encontrado, caso contrário null
    */
   async findExistingAppointment(
     clientId: string,
     specialistId: string,
     productType: ProductType,
-    productId: number | string,
+    productId: string,
   ): Promise<AppointmentResponseEntity | null> {
-    const productIdNum =
-      typeof productId === 'string' ? parseInt(productId, 10) : productId;
-
-    if (isNaN(productIdNum)) {
-      return null;
-    }
-
     const appointment = await this.prisma.appointment.findFirst({
       where: {
         client_id: clientId,
         specialist_id: specialistId,
         product_type: productType,
-        product_id: productIdNum,
+        product_id: productId,
         status: {
           in: [StatusAgendamento.PENDING, StatusAgendamento.SCHEDULED],
         },

--- a/backend/src/features/appointments/dto/create-appointment.dto.ts
+++ b/backend/src/features/appointments/dto/create-appointment.dto.ts
@@ -3,8 +3,6 @@ import {
   IsEnum,
   IsOptional,
   MaxLength,
-  IsInt,
-  Min,
   ValidateIf,
 } from 'class-validator';
 import { ProductType } from '@prisma/client';
@@ -63,16 +61,12 @@ export class CreateAppointmentDto {
    * Opcional para consultoria (sem produto inicial)
    * Se fornecido, product_type também deve ser fornecido
    *
-   * Exemplo:
-   * - Se product_type = CAR: product_id = 1 (referencia Car com id=1)
-   * - Se product_type = BOAT: product_id = 5 (referencia Boat com id=5)
-   * - Se product_type = AIRCRAFT: product_id = 3 (referencia Aircraft com id=3)
+   * Deve ser um UUID v4 do produto correspondente.
    */
   @IsOptional()
   @ValidateIf((o) => o.product_type !== undefined)
-  @IsInt({ message: 'product_id deve ser um número inteiro' })
-  @Min(1, { message: 'product_id deve ser no mínimo 1' })
-  product_id?: number;
+  @IsUUID('4', { message: 'product_id deve ser um UUID válido' })
+  product_id?: string;
 
   /**
    * Data e hora do agendamento em ISO 8601 UTC

--- a/backend/src/features/appointments/entities/appointment.response.ts
+++ b/backend/src/features/appointments/entities/appointment.response.ts
@@ -81,7 +81,7 @@ export class ProductResponseDto {
    * Usado junto com product_type para identificar único
    */
   @Expose()
-  id: number;
+  id: string;
 
   /**
    * Tipo de produto

--- a/backend/src/features/boats/boats.controller.ts
+++ b/backend/src/features/boats/boats.controller.ts
@@ -141,7 +141,7 @@ export class BoatsController {
   @Get(':id')
   @Public()
   findOne(@Param('id') id: string) {
-    return this.boatsService.findOne(+id);
+    return this.boatsService.findOne(id);
   }
 
   @Patch(':id')
@@ -152,17 +152,17 @@ export class BoatsController {
     @CurrentUser() user: UserEntity,
   ) {
     assertSpecialistCanModify('BOAT', user);
-    const existing = await this.boatsService.findOne(+id);
+    const existing = await this.boatsService.findOne(id);
     assertSpecialistOwnsProduct(user, existing?.specialist_id);
-    return this.boatsService.update(+id, updateBoatDto);
+    return this.boatsService.update(id, updateBoatDto);
   }
 
   @Delete(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
   async remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
     assertSpecialistCanModify('BOAT', user);
-    const existing = await this.boatsService.findOne(+id);
+    const existing = await this.boatsService.findOne(id);
     assertSpecialistOwnsProduct(user, existing?.specialist_id);
-    return this.boatsService.remove(+id);
+    return this.boatsService.remove(id);
   }
 }

--- a/backend/src/features/boats/boats.service.ts
+++ b/backend/src/features/boats/boats.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { CreateBoatDto } from './dto/create-boat.dto';
 import { UpdateBoatDto } from './dto/update-boat.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -117,6 +118,9 @@ export class BoatsService {
       );
       return boatWithImages;
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw error;
+      }
       this.logger.error(
         `[create] Erro ao criar barco: ${error.message}`,
         error.stack,
@@ -309,6 +313,9 @@ export class BoatsService {
         include: { images: true },
       });
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw error;
+      }
       throw new Error(`Erro ao atualizar lancha: ${error.message}`);
     }
   }

--- a/backend/src/features/boats/boats.service.ts
+++ b/backend/src/features/boats/boats.service.ts
@@ -238,7 +238,7 @@ export class BoatsService {
     };
   }
 
-  async findOne(id: number) {
+  async findOne(id: string) {
     this.logger.log(`[findOne] Buscando barco - ID: ${id}`);
     const boat = await this.prismaService.boat.findUnique({
       where: { id },
@@ -264,7 +264,7 @@ export class BoatsService {
     return { ...boat };
   }
 
-  async update(id: number, updateBoatDto: UpdateBoatDto) {
+  async update(id: string, updateBoatDto: UpdateBoatDto) {
     await this.findOne(id);
 
     const { images, ...boatData } = updateBoatDto;
@@ -313,7 +313,7 @@ export class BoatsService {
     }
   }
 
-  async remove(id: number) {
+  async remove(id: string) {
     await this.findOne(id);
 
     try {
@@ -431,8 +431,8 @@ export class BoatsService {
       });
     }
 
-    const insertedIds: number[] = [];
-    const updatedIds: number[] = [];
+    const insertedIds: string[] = [];
+    const updatedIds: string[] = [];
     const errorRows: ImportErrorRow[] = [];
 
     for (let i = 0; i < rows.length; i++) {
@@ -543,8 +543,8 @@ export class BoatsService {
       });
     }
 
-    const insertedIds: number[] = [];
-    const updatedIds: number[] = [];
+    const insertedIds: string[] = [];
+    const updatedIds: string[] = [];
     const errorRows: ImportErrorRow[] = [];
     const warningRows: ImportErrorRow[] = [];
 

--- a/backend/src/features/boats/boats.service.ts
+++ b/backend/src/features/boats/boats.service.ts
@@ -443,6 +443,7 @@ export class BoatsService {
         const boatData: any = {
           marca: row.marca,
           modelo: row.modelo,
+          identificador: row.identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),
@@ -558,6 +559,7 @@ export class BoatsService {
         const boatData: any = {
           marca: row.marca,
           modelo: row.modelo,
+          identificador: row.identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),

--- a/backend/src/features/boats/boats.service.ts
+++ b/backend/src/features/boats/boats.service.ts
@@ -552,13 +552,14 @@ export class BoatsService {
     for (let i = 0; i < rows.length; i++) {
       const rowNumber = i + 2; // +2 porque linha 1 é header e arrays começam em 0
       const row = rows[i];
+      const identificador = row.identificador?.trim();
 
       try {
         // Preparar DTO
         const boatData: any = {
           marca: row.marca,
           modelo: row.modelo,
-          identificador: row.identificador,
+          identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),
@@ -597,11 +598,11 @@ export class BoatsService {
           continue;
         }
 
-        // Verificar se já existe um produto com mesma marca + modelo para este especialista
+        // Verificar se já existe um produto com mesmo identificador para este especialista
         const existingBoat = await this.prismaService.boat.findFirst({
           where: {
             specialist_id: user.id,
-            identificador: row.identificador?.trim(),
+            identificador,
           },
         });
 

--- a/backend/src/features/boats/boats.service.ts
+++ b/backend/src/features/boats/boats.service.ts
@@ -482,9 +482,8 @@ export class BoatsService {
 
         const existingBoat = await this.prismaService.boat.findFirst({
           where: {
-            marca: row.marca?.trim(),
-            modelo: row.modelo?.trim(),
             specialist_id: user.id,
+            identificador: row.identificador?.trim(),
           },
         });
 
@@ -601,9 +600,8 @@ export class BoatsService {
         // Verificar se já existe um produto com mesma marca + modelo para este especialista
         const existingBoat = await this.prismaService.boat.findFirst({
           where: {
-            marca: row.marca?.trim(),
-            modelo: row.modelo?.trim(),
             specialist_id: user.id,
+            identificador: row.identificador?.trim(),
           },
         });
 

--- a/backend/src/features/boats/boats.service.ts
+++ b/backend/src/features/boats/boats.service.ts
@@ -36,6 +36,7 @@ export class BoatsService {
   private readonly xlsxColumns: XlsxColumnDefinition[] = [
     { name: 'marca', required: true, type: 'string' },
     { name: 'modelo', required: true, type: 'string' },
+    { name: 'identificador', required: true, type: 'string' },
     { name: 'valor', required: true, type: 'number' },
     { name: 'estado', required: true, type: 'string' },
     { name: 'ano', required: true, type: 'number' },
@@ -337,6 +338,7 @@ export class BoatsService {
     const instructions: Record<string, string> = {
       marca: 'Nome da marca da embarcação (texto)',
       modelo: 'Nome do modelo (texto)',
+      identificador: 'Identificador único do produto (texto)',
       valor: 'Preço em reais (número inteiro, sem pontos ou vírgulas)',
       estado: 'Estado onde a embarcação está localizada (texto)',
       ano: 'Ano de fabricação (número)',
@@ -356,6 +358,7 @@ export class BoatsService {
     const example: Record<string, any> = {
       marca: 'Azimut',
       modelo: '55 Fly',
+      identificador: 'Azimut-55 Fly-1',
       valor: 3500000,
       estado: 'São Paulo',
       ano: 2022,
@@ -384,6 +387,7 @@ export class BoatsService {
     const exampleValues = [
       'Azimut',
       '55 Fly',
+      'Azimut-55 Fly-1',
       '3500000',
       'São Paulo',
       '2022',

--- a/backend/src/features/boats/dto/create-boat.dto.ts
+++ b/backend/src/features/boats/dto/create-boat.dto.ts
@@ -24,6 +24,9 @@ export class CreateBoatDto {
   @IsString()
   modelo: string;
 
+  @IsString()
+  identificador: string;
+
   @IsNumber()
   valor: number;
 

--- a/backend/src/features/boats/entity/boat-image.entity.ts
+++ b/backend/src/features/boats/entity/boat-image.entity.ts
@@ -7,6 +7,6 @@ export class BoatImage {
   is_primary: boolean;
   created_at: Date;
 
-  boat_id?: number | null;
+  boat_id?: string | null;
   boat?: Boat;
 }

--- a/backend/src/features/boats/entity/boat.entity.ts
+++ b/backend/src/features/boats/entity/boat.entity.ts
@@ -2,7 +2,7 @@ import { BoatImage } from './boat-image.entity';
 import { UserEntity } from 'src/auth/entities/user.entity';
 
 export class Boat {
-  id: number;
+  id: string;
   is_active: boolean;
   deactivated_at: Date | null;
   deactivated_by_sync_job_id: string | null;

--- a/backend/src/features/cars/cars.controller.ts
+++ b/backend/src/features/cars/cars.controller.ts
@@ -137,14 +137,14 @@ export class CarsController {
 
   @Get(':id')
   @Public()
-  findOne(@Param('id') id: number) {
-    return this.carsService.findOne(+id);
+  findOne(@Param('id') id: string) {
+    return this.carsService.findOne(id);
   }
 
   @Patch(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
   async update(
-    @Param('id') id: number,
+    @Param('id') id: string,
     @Body() updateCarDto: UpdateCarDto,
     @CurrentUser() user: UserEntity,
   ) {
@@ -153,17 +153,17 @@ export class CarsController {
     }
 
     assertSpecialistCanModify('CAR', user);
-    const existing = await this.carsService.findOne(+id);
+    const existing = await this.carsService.findOne(id);
     assertSpecialistOwnsProduct(user, existing?.specialist_id);
-    return this.carsService.update(+id, updateCarDto);
+    return this.carsService.update(id, updateCarDto);
   }
 
   @Delete(':id')
   @Roles(UserRole.ADMIN, UserRole.SPECIALIST)
   async remove(@Param('id') id: string, @CurrentUser() user: UserEntity) {
     assertSpecialistCanModify('CAR', user);
-    const existing = await this.carsService.findOne(+id);
+    const existing = await this.carsService.findOne(id);
     assertSpecialistOwnsProduct(user, existing?.specialist_id);
-    return this.carsService.remove(+id);
+    return this.carsService.remove(id);
   }
 }

--- a/backend/src/features/cars/cars.service.spec.ts
+++ b/backend/src/features/cars/cars.service.spec.ts
@@ -1,0 +1,23 @@
+import { CarsService } from './cars.service';
+
+describe('CarsService — UUID do produto', () => {
+  it('consulta o carro pelo UUID recebido', async () => {
+    const carId = '11111111-1111-4111-8111-111111111111';
+    const findUnique = jest.fn().mockResolvedValue({
+      id: carId,
+      images: [],
+    });
+    const service = new CarsService(
+      { car: { findUnique } } as any,
+      {} as any,
+      {} as any,
+    );
+
+    await service.findOne(carId);
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: carId },
+      include: { images: true },
+    });
+  });
+});

--- a/backend/src/features/cars/cars.service.ts
+++ b/backend/src/features/cars/cars.service.ts
@@ -516,13 +516,14 @@ export class CarsService {
     for (let i = 0; i < rows.length; i++) {
       const rowNumber = i + 2; // +2 porque linha 1 é header e arrays começam em 0
       const row = rows[i];
+      const identificador = row.identificador?.trim();
 
       try {
         // Preparar DTO
         const carData: any = {
           marca: row.marca,
           modelo: row.modelo,
-          identificador: row.identificador,
+          identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),
@@ -557,11 +558,11 @@ export class CarsService {
           continue;
         }
 
-        // Verificar se já existe um produto com mesma marca + modelo para este especialista
+        // Verificar se já existe um produto com mesmo identificador para este especialista
         const existingCar = await this.prismaService.car.findFirst({
           where: {
             specialist_id: user.id,
-            identificador: row.identificador?.trim(),
+            identificador,
           },
         });
 

--- a/backend/src/features/cars/cars.service.ts
+++ b/backend/src/features/cars/cars.service.ts
@@ -411,6 +411,7 @@ export class CarsService {
         const carData: any = {
           marca: row.marca,
           modelo: row.modelo,
+          identificador: row.identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),
@@ -522,6 +523,7 @@ export class CarsService {
         const carData: any = {
           marca: row.marca,
           modelo: row.modelo,
+          identificador: row.identificador,
           valor: Number(row.valor),
           estado: row.estado,
           ano: Number(row.ano),

--- a/backend/src/features/cars/cars.service.ts
+++ b/backend/src/features/cars/cars.service.ts
@@ -36,6 +36,7 @@ export class CarsService {
   private readonly xlsxColumns: XlsxColumnDefinition[] = [
     { name: 'marca', required: true, type: 'string' },
     { name: 'modelo', required: true, type: 'string' },
+    { name: 'identificador', required: true, type: 'string' },
     { name: 'valor', required: true, type: 'number' },
     { name: 'estado', required: true, type: 'string' },
     { name: 'ano', required: true, type: 'number' },
@@ -314,6 +315,7 @@ export class CarsService {
     const instructions: Record<string, string> = {
       marca: 'Nome da marca do carro (texto)',
       modelo: 'Nome do modelo (texto)',
+      identificador: 'Identificador único do produto (texto)',
       valor: 'Preço em reais (número inteiro, sem pontos ou vírgulas)',
       estado: 'Estado onde o carro está localizado (texto)',
       ano: 'Ano de fabricação (número)',
@@ -331,6 +333,7 @@ export class CarsService {
     const example: Record<string, any> = {
       marca: 'BMW',
       modelo: 'X5',
+      identificador: 'BMW-X5-1',
       valor: 450000,
       estado: 'São Paulo',
       ano: 2023,
@@ -355,6 +358,7 @@ export class CarsService {
     const exampleValues = [
       'BMW',
       'X5',
+      'BMW-X5-1',
       '450000',
       'São Paulo',
       '2023',

--- a/backend/src/features/cars/cars.service.ts
+++ b/backend/src/features/cars/cars.service.ts
@@ -215,7 +215,7 @@ export class CarsService {
     };
   }
 
-  async findOne(id: number) {
+  async findOne(id: string) {
     this.logger.log(`[findOne] Buscando carro - ID: ${id}`);
     const car = await this.prismaService.car.findUnique({
       where: { id },
@@ -241,7 +241,7 @@ export class CarsService {
     return { ...car };
   }
 
-  async update(id: number, updateCarDto: UpdateCarDto) {
+  async update(id: string, updateCarDto: UpdateCarDto) {
     await this.findOne(id);
 
     const { images, ...carData } = updateCarDto;
@@ -290,7 +290,7 @@ export class CarsService {
     }
   }
 
-  async remove(id: number) {
+  async remove(id: string) {
     await this.findOne(id);
 
     try {
@@ -399,8 +399,8 @@ export class CarsService {
       });
     }
 
-    const insertedIds: number[] = [];
-    const updatedIds: number[] = [];
+    const insertedIds: string[] = [];
+    const updatedIds: string[] = [];
     const errorRows: ImportErrorRow[] = [];
 
     for (let i = 0; i < rows.length; i++) {
@@ -507,8 +507,8 @@ export class CarsService {
       });
     }
 
-    const insertedIds: number[] = [];
-    const updatedIds: number[] = [];
+    const insertedIds: string[] = [];
+    const updatedIds: string[] = [];
     const errorRows: ImportErrorRow[] = [];
     const warningRows: ImportErrorRow[] = [];
 

--- a/backend/src/features/cars/cars.service.ts
+++ b/backend/src/features/cars/cars.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   Logger,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { CreateCarDto } from './dto/create-car.dto';
 import { UpdateCarDto } from './dto/update-car.dto';
 import { PrismaService } from 'src/prisma/prisma.service';
@@ -95,6 +96,9 @@ export class CarsService {
         include: { images: true },
       });
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw error;
+      }
       throw new Error(`Erro ao criar carro: ${error.message}`);
     }
   }
@@ -286,6 +290,9 @@ export class CarsService {
         include: { images: true },
       });
     } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw error;
+      }
       throw new Error(`Erro ao atualizar carro: ${error.message}`);
     }
   }

--- a/backend/src/features/cars/cars.service.ts
+++ b/backend/src/features/cars/cars.service.ts
@@ -446,9 +446,8 @@ export class CarsService {
 
         const existingCar = await this.prismaService.car.findFirst({
           where: {
-            marca: row.marca?.trim(),
-            modelo: row.modelo?.trim(),
             specialist_id: user.id,
+            identificador: row.identificador?.trim(),
           },
         });
 
@@ -561,9 +560,8 @@ export class CarsService {
         // Verificar se já existe um produto com mesma marca + modelo para este especialista
         const existingCar = await this.prismaService.car.findFirst({
           where: {
-            marca: row.marca?.trim(),
-            modelo: row.modelo?.trim(),
             specialist_id: user.id,
+            identificador: row.identificador?.trim(),
           },
         });
 

--- a/backend/src/features/cars/dto/create-car.dto.ts
+++ b/backend/src/features/cars/dto/create-car.dto.ts
@@ -24,6 +24,9 @@ export class CreateCarDto {
   @IsString()
   modelo: string;
 
+  @IsString()
+  identificador: string;
+
   @IsNumber()
   valor: number;
 

--- a/backend/src/features/cars/entity/car-image.entity.ts
+++ b/backend/src/features/cars/entity/car-image.entity.ts
@@ -5,7 +5,7 @@ export class CarImage {
   product_type: string;
   image_url: string;
   is_primary: boolean;
-  car_id?: number | null;
+  car_id?: string | null;
   created_at: Date;
 
   car?: Car;

--- a/backend/src/features/cars/entity/car.entity.ts
+++ b/backend/src/features/cars/entity/car.entity.ts
@@ -1,7 +1,7 @@
 import { CarImage } from './car-image.entity';
 import { UserEntity } from 'src/auth/entities/user.entity';
 export class Car {
-  id: number;
+  id: string;
   specialist_id: string | null;
   is_active: boolean;
   deactivated_at: Date | null;

--- a/backend/src/features/consultant/dto/create-consultant-process.dto.spec.ts
+++ b/backend/src/features/consultant/dto/create-consultant-process.dto.spec.ts
@@ -1,0 +1,22 @@
+import { validate } from 'class-validator';
+import {
+  CreateConsultantProcessDto,
+  ProductTypeEnum,
+} from './create-consultant-process.dto';
+
+const clientId = '11111111-1111-4111-8111-111111111111';
+const specialistId = '22222222-2222-4222-8222-222222222222';
+const productId = '33333333-3333-4333-8333-333333333333';
+
+describe('CreateConsultantProcessDto', () => {
+  it('aceita product_id UUID v4 para criar processo em nome do cliente', async () => {
+    const dto = Object.assign(new CreateConsultantProcessDto(), {
+      client_id: clientId,
+      specialist_id: specialistId,
+      product_type: ProductTypeEnum.CAR,
+      product_id: productId,
+    });
+
+    expect(await validate(dto)).toHaveLength(0);
+  });
+});

--- a/backend/src/features/consultant/dto/create-consultant-process.dto.ts
+++ b/backend/src/features/consultant/dto/create-consultant-process.dto.ts
@@ -1,4 +1,4 @@
-import { IsUUID, IsEnum, IsOptional, IsNumber } from 'class-validator';
+import { IsUUID, IsEnum, IsOptional } from 'class-validator';
 
 export enum ProductTypeEnum {
   CAR = 'CAR',
@@ -18,7 +18,7 @@ export class CreateConsultantProcessDto {
   })
   product_type: ProductTypeEnum;
 
-  @IsNumber({}, { message: 'product_id deve ser um número inteiro' })
+  @IsUUID('4', { message: 'product_id deve ser um UUID válido' })
   @IsOptional()
-  product_id?: number; // ID do produto (car_id, boat_id ou aircraft_id — Int PKs)
+  product_id?: string; // ID do produto (car_id, boat_id ou aircraft_id — UUID)
 }

--- a/backend/src/features/contracts/contracts.service.ts
+++ b/backend/src/features/contracts/contracts.service.ts
@@ -133,7 +133,7 @@ export class ContractsService {
 
     // Determinar produto baseado no tipo
     let product: {
-      id: number;
+      id: string;
       brand: string;
       model: string;
       year: number;

--- a/backend/src/features/contracts/dto/prefill-contract-response.dto.ts
+++ b/backend/src/features/contracts/dto/prefill-contract-response.dto.ts
@@ -34,7 +34,7 @@ export class PrefillContractResponseDto {
 
   // Dados do produto
   product: {
-    id: number;
+    id: string;
     brand: string;
     model: string;
     year: number;

--- a/backend/src/features/drive-import/drive-import.service.ts
+++ b/backend/src/features/drive-import/drive-import.service.ts
@@ -20,7 +20,7 @@ type DriveFile = {
 };
 
 type ProductRef = {
-  id: number;
+  id: string;
   marca: string;
   modelo: string;
 };
@@ -29,7 +29,7 @@ type ImportItemResult = {
   file_name: string;
   status: 'uploaded' | 'skipped' | 'failed';
   reason?: string;
-  product_id?: number;
+  product_id?: string;
   product_key?: string;
   s3_key?: string;
 };
@@ -56,7 +56,7 @@ export class DriveImportService {
   async importImagesForProductFromFolder(params: {
     folder_url: string;
     product_type: ProductType;
-    product_id: number;
+    product_id: string;
     max_files?: number;
   }): Promise<DirectProductFolderImportResult> {
     const apiKey = this.configService.get<string>('GOOGLE_DRIVE_API_KEY');
@@ -476,8 +476,8 @@ export class DriveImportService {
   private async buildExistingImageNameIndex(
     type: ProductType,
     products: ProductRef[],
-  ): Promise<Map<number, Set<string>>> {
-    const index = new Map<number, Set<string>>();
+  ): Promise<Map<string, Set<string>>> {
+    const index = new Map<string, Set<string>>();
     const ids = products.map((p) => p.id);
 
     if (ids.length === 0) {
@@ -531,7 +531,7 @@ export class DriveImportService {
 
   private async getExistingImageFileNamesByProduct(
     type: ProductType,
-    productId: number,
+    productId: string,
   ): Promise<Set<string>> {
     const names = new Set<string>();
 
@@ -579,7 +579,7 @@ export class DriveImportService {
 
   private async hasPrimaryImage(
     type: ProductType,
-    productId: number,
+    productId: string,
   ): Promise<boolean> {
     if (type === ProductType.CAR) {
       const record = await this.prisma.car_image.findFirst({
@@ -606,7 +606,7 @@ export class DriveImportService {
 
   private async deleteAllProductImages(
     type: ProductType,
-    productId: number,
+    productId: string,
   ): Promise<void> {
     let keys: string[] = [];
 
@@ -694,7 +694,7 @@ export class DriveImportService {
 
   private buildS3ObjectKey(
     type: ProductType,
-    productId: number,
+    productId: string,
     originalName: string,
   ): string {
     const safeFileName = this.sanitizeS3FileName(originalName);
@@ -787,7 +787,7 @@ export class DriveImportService {
 
   private async createImageRecord(params: {
     productType: ProductType;
-    productId: number;
+    productId: string;
     imageKey: string;
     isPrimary: boolean;
   }): Promise<void> {

--- a/backend/src/features/processes/dto/assign-product.dto.ts
+++ b/backend/src/features/processes/dto/assign-product.dto.ts
@@ -1,5 +1,5 @@
 import { $Enums } from '@prisma/client';
-import { IsNotEmpty, IsInt, Min, IsEnum } from 'class-validator';
+import { IsNotEmpty, IsUUID, IsEnum } from 'class-validator';
 
 /**
  * DTO para associar um produto a um processo de consultoria
@@ -28,7 +28,6 @@ export class AssignProductToProcessDto {
    * Deve existir na tabela correspondente e pertencer ao especialista
    */
   @IsNotEmpty({ message: 'product_id é obrigatório' })
-  @IsInt({ message: 'product_id deve ser um número inteiro' })
-  @Min(1, { message: 'product_id deve ser no mínimo 1' })
-  product_id: number;
+  @IsUUID('4', { message: 'product_id deve ser um UUID válido' })
+  product_id: string;
 }

--- a/backend/src/features/processes/dto/create-process.dto.ts
+++ b/backend/src/features/processes/dto/create-process.dto.ts
@@ -3,8 +3,6 @@ import {
   IsNotEmpty,
   IsOptional,
   IsUUID,
-  IsInt,
-  Min,
   ValidateIf,
   IsEnum,
 } from 'class-validator';
@@ -29,9 +27,8 @@ export class CreateProcessDTO {
    */
   @IsOptional()
   @ValidateIf((o) => o.product_type !== undefined)
-  @IsInt({ message: 'product_id deve ser um número inteiro' })
-  @Min(1, { message: 'product_id deve ser no mínimo 1' })
-  product_id?: number;
+  @IsUUID('4', { message: 'product_id deve ser um UUID válido' })
+  product_id?: string;
 
   /**
    * Tipo do produto: CAR, BOAT ou AIRCRAFT

--- a/backend/src/features/processes/entity/process.response.entity.ts
+++ b/backend/src/features/processes/entity/process.response.entity.ts
@@ -6,7 +6,7 @@ export class ProcessResponse {
   appointment_status?: $Enums.StatusAgendamento | null;
   appointment_datetime?: Date | null;
   product_type: $Enums.ProductType | null; // Null para processos de consultoria
-  product_id?: number | null; // ID do produto (car_id, boat_id, ou aircraft_id)
+  product_id?: string | null; // ID do produto (car_id, boat_id, ou aircraft_id)
   client: {
     id: string;
     name: string;
@@ -27,9 +27,8 @@ export class ProcessResponse {
   updated_at?: Date;
 }
 
-// TODO: trocar para string quando for trocado para UUID
 export class Product {
-  id: number;
+  id: string;
   marca: string;
   modelo: string;
 }

--- a/backend/src/features/processes/processes.service.spec.ts
+++ b/backend/src/features/processes/processes.service.spec.ts
@@ -1,0 +1,81 @@
+import { validate } from 'class-validator';
+import { CreateProcessDTO } from './dto/create-process.dto';
+import { AssignProductToProcessDto } from './dto/assign-product.dto';
+import { ProcessesService } from './processes.service';
+
+const productId = '11111111-1111-4111-8111-111111111111';
+const clientId = '22222222-2222-4222-8222-222222222222';
+const specialistId = '33333333-3333-4333-8333-333333333333';
+
+describe('ProcessesService — produto UUID', () => {
+  it('persiste e consulta o produto pelo UUID sem conversão numérica', async () => {
+    const findFirst = jest.fn().mockResolvedValue(null);
+    const create = jest.fn().mockImplementation(({ data }) =>
+      Promise.resolve({
+        id: '44444444-4444-4444-8444-444444444444',
+        status: 'SCHEDULING',
+        product_type: data.product_type,
+        ...data,
+        client: { id: clientId, email: 'client@example.com', name: 'Client' },
+        specialist: {
+          id: specialistId,
+          name: 'Specialist',
+          speciality: 'CAR',
+        },
+        car: { id: productId, marca: 'Porsche', modelo: '911' },
+        aircraft: null,
+        boat: null,
+        created_at: new Date(),
+        notes: null,
+      }),
+    );
+    const prisma = {
+      process: { findFirst },
+      $transaction: jest.fn(async (callback) =>
+        callback({
+          process: { create },
+          processStatusHistory: { create: jest.fn().mockResolvedValue({}) },
+        }),
+      ),
+    } as any;
+    const service = new ProcessesService(prisma, {} as any);
+
+    await service.create({
+      client_id: clientId,
+      specialist_id: specialistId,
+      product_type: 'CAR',
+      product_id: productId,
+    } as unknown as CreateProcessDTO);
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({ car_id: productId }),
+    });
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ car_id: productId }),
+      }),
+    );
+  });
+
+  it('aceita UUID v4 e rejeita identificador numérico nos DTOs de processo', async () => {
+    const createDto = Object.assign(new CreateProcessDTO(), {
+      client_id: clientId,
+      specialist_id: specialistId,
+      product_type: 'CAR',
+      product_id: productId,
+    });
+    const assignDto = Object.assign(new AssignProductToProcessDto(), {
+      product_type: 'CAR',
+      product_id: productId,
+    });
+
+    expect(await validate(createDto)).toHaveLength(0);
+    expect(await validate(assignDto)).toHaveLength(0);
+
+    createDto.product_id = 1 as never;
+    assignDto.product_id = 1 as never;
+
+    expect((await validate(createDto)).some((error) => error.property === 'product_id')).toBe(true);
+    expect((await validate(assignDto)).some((error) => error.property === 'product_id')).toBe(true);
+  });
+});

--- a/backend/src/features/processes/processes.service.ts
+++ b/backend/src/features/processes/processes.service.ts
@@ -67,9 +67,9 @@ export class ProcessesService {
    * Helper: Retorna o product_id (car_id, boat_id ou aircraft_id) do processo
    *
    * @param {ProcessWithProducts} process - processo com os produtos includos
-   * @returns {number | null} - ID do produto ou null se for consultoria
+   * @returns {string | null} - ID do produto ou null se for consultoria
    */
-  private getProductId(process: ProcessWithProducts | any): number | null {
+  private getProductId(process: ProcessWithProducts | any): string | null {
     if (!process.product_type) return null;
 
     // Retorna o ID específico baseado no tipo de produto
@@ -204,14 +204,14 @@ export class ProcessesService {
       const whereClause: {
         client_id: string;
         specialist_id: string;
-        aircraft_id?: number;
-        boat_id?: number;
-        car_id?: number;
+        aircraft_id?: string;
+        boat_id?: string;
+        car_id?: string;
         status?: { in: ProcessStatus[] };
       } = {
         client_id,
         specialist_id,
-        [`${fieldName}_id`]: Number(createProcessDto.product_id),
+        [`${fieldName}_id`]: createProcessDto.product_id,
         // Só bloqueia se houver processo ATIVO; processos encerrados
         // (COMPLETED/REJECTED) permitem novo processo para o mesmo produto.
         status: { in: activeStatuses },
@@ -257,11 +257,10 @@ export class ProcessesService {
       car: false,
       boat: false,
     };
-    // TODO: trocar para string quando for trocado para UUID
     const finalProduct: {
-      aircraft_id: number | null;
-      boat_id: number | null;
-      car_id: number | null;
+      aircraft_id: string | null;
+      boat_id: string | null;
+      car_id: string | null;
     } = {
       aircraft_id: null,
       boat_id: null,
@@ -271,15 +270,15 @@ export class ProcessesService {
     // Preenchimento do id e o include do produto de acordo com o tipo dele
     switch (createProcessDto.product_type) {
       case 'AIRCRAFT':
-        finalProduct.aircraft_id = Number(createProcessDto.product_id);
+        finalProduct.aircraft_id = createProcessDto.product_id ?? null;
         include.aircraft = true;
         break;
       case 'CAR':
-        finalProduct.car_id = Number(createProcessDto.product_id);
+        finalProduct.car_id = createProcessDto.product_id ?? null;
         include.car = true;
         break;
       case 'BOAT':
-        finalProduct.boat_id = Number(createProcessDto.product_id);
+        finalProduct.boat_id = createProcessDto.product_id ?? null;
         include.boat = true;
         break;
     }
@@ -880,7 +879,7 @@ export class ProcessesService {
    */
   async assignProduct(
     processId: string,
-    dto: { product_type: string; product_id: number },
+    dto: { product_type: string; product_id: string },
     userId: string,
     userRole: string,
   ): Promise<ProcessResponse> {

--- a/backend/src/features/product-identificador-normalization.spec.ts
+++ b/backend/src/features/product-identificador-normalization.spec.ts
@@ -1,0 +1,47 @@
+import { AircraftsService } from './aircrafts/aircrafts.service';
+import { BoatsService } from './boats/boats.service';
+import { CarsService } from './cars/cars.service';
+
+const specialistId = '00000000-0000-4000-8000-000000000001';
+
+describe('importação XLSX por identificador', () => {
+  it.each([
+    ['carro', CarsService, 'car'],
+    ['barco', BoatsService, 'boat'],
+    ['aeronave', AircraftsService, 'aircraft'],
+  ])(
+    'normaliza o identificador antes de buscar e criar %s',
+    async (_productType, Service, delegateName) => {
+      const findFirst = jest.fn().mockResolvedValue(null);
+      const create = jest.fn().mockResolvedValue({ id: 1 });
+      const prisma = { [delegateName]: { findFirst, create } } as any;
+      const xlsxImportService = {
+        parseWorkbook: jest.fn().mockResolvedValue({
+          rows: [
+            {
+              marca: 'Marca',
+              modelo: 'Modelo',
+              identificador: '  PRODUTO-001  ',
+              valor: '100',
+              estado: 'SP',
+              ano: '2020',
+            },
+          ],
+          imageMap: new Map(),
+        }),
+        validateStructure: jest.fn().mockReturnValue({ valid: true }),
+        createResponse: jest.fn().mockReturnValue({}),
+      } as any;
+      const service = new Service(prisma, {} as any, xlsxImportService);
+
+      await service.importFromXlsx(Buffer.alloc(0), { id: specialistId } as any);
+
+      expect(findFirst).toHaveBeenCalledWith({
+        where: { specialist_id: specialistId, identificador: 'PRODUTO-001' },
+      });
+      expect(create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ identificador: 'PRODUTO-001' }),
+      });
+    },
+  );
+});

--- a/backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts
+++ b/backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts
@@ -1,0 +1,33 @@
+import { ProductImportJobsService } from './product-import-jobs.service';
+
+describe('ProductImportJobsService', () => {
+  it('busca produto existente por (specialist_id, identificador), nao por modelo', async () => {
+    const findFirst = jest.fn().mockResolvedValue(null);
+    const create = jest.fn().mockResolvedValue({ id: 'uuid-1' });
+    const prisma = { car: { findFirst, create } } as any;
+    const service = new ProductImportJobsService(prisma, {} as any, {} as any);
+
+    await (service as any).upsertProductFromRow(
+      'CAR',
+      {
+        marca: 'Ferrari',
+        modelo: 'X',
+        identificador: 'FERRARI-X-2',
+        valor: '100',
+        estado: 'SP',
+        ano: '2020',
+      },
+      '00000000-0000-4000-8000-000000000001',
+    );
+
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        specialist_id: '00000000-0000-4000-8000-000000000001',
+        identificador: 'FERRARI-X-2',
+      },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ identificador: 'FERRARI-X-2' }),
+    });
+  });
+});

--- a/backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts
+++ b/backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts
@@ -1,6 +1,27 @@
 import { ProductImportJobsService } from './product-import-jobs.service';
 
 describe('ProductImportJobsService', () => {
+  it('lanca erro quando identificador vem vazio', async () => {
+    const prisma = { car: { findFirst: jest.fn(), create: jest.fn() } } as any;
+    const service = new ProductImportJobsService(prisma, {} as any, {} as any);
+
+    await expect(
+      (service as any).upsertProductFromRow(
+        'CAR',
+        {
+          marca: 'Ferrari',
+          modelo: 'X',
+          identificador: '  ',
+          valor: '100',
+          estado: 'SP',
+          ano: '2020',
+        },
+        'spec-1',
+      ),
+    ).rejects.toThrow(/identificador/i);
+    expect(prisma.car.create).not.toHaveBeenCalled();
+  });
+
   it('busca produto existente por (specialist_id, identificador), nao por modelo', async () => {
     const findFirst = jest.fn().mockResolvedValue(null);
     const create = jest.fn().mockResolvedValue({ id: 'uuid-1' });

--- a/backend/src/features/product-import-jobs/product-import-jobs.service.ts
+++ b/backend/src/features/product-import-jobs/product-import-jobs.service.ts
@@ -33,7 +33,7 @@ import { CreateAircraftDto } from '../aircrafts/dto/create-aircraft.dto';
 import { DriveImportService } from '../drive-import/drive-import.service';
 
 type UpsertResult = {
-  productId: number;
+  productId: string;
   action: 'CREATED' | 'UPDATED';
   reactivated?: boolean;
 };
@@ -233,7 +233,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
 
     const response = this.buildImportResponse(job.items, {
       deactivatedIds: Array.isArray(job.deactivated_product_ids)
-        ? (job.deactivated_product_ids as number[])
+      ? (job.deactivated_product_ids as string[])
         : [],
       reactivatedCount: job.reactivated_items,
     });
@@ -341,7 +341,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
     });
 
     try {
-      const seenProductIds = new Set<number>();
+    const seenProductIds = new Set<string>();
       let reactivatedCount = 0;
 
       for (const item of job.items) {
@@ -450,7 +450,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
 
   private async refreshJobCounters(
     jobId: string,
-    syncSummary?: { deactivatedIds: number[]; reactivatedCount: number },
+    syncSummary?: { deactivatedIds: string[]; reactivatedCount: number },
   ) {
     const items = await this.prisma.productImportJobItem.findMany({
       where: { job_id: jobId },
@@ -510,9 +510,9 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
   private async deactivateMissingProducts(
     productType: ProductType,
     specialistId: string,
-    seenProductIds: Set<number>,
+    seenProductIds: Set<string>,
     jobId: string,
-  ): Promise<number[]> {
+  ): Promise<string[]> {
     const activeProductIds = await this.getActiveProductIdsByType(
       productType,
       specialistId,
@@ -553,7 +553,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
   private async getActiveProductIdsByType(
     productType: ProductType,
     specialistId: string,
-  ): Promise<number[]> {
+  ): Promise<string[]> {
     if (productType === ProductType.CAR) {
       const cars = await this.prisma.car.findMany({
         where: { specialist_id: specialistId, is_active: true },
@@ -755,14 +755,14 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
       status: ProductImportItemStatus;
       payload: unknown;
       action: string | null;
-      product_id: number | null;
+      product_id: string | null;
       error_message: string | null;
       warnings: unknown;
     }>,
-    syncSummary?: { deactivatedIds: number[]; reactivatedCount: number },
+    syncSummary?: { deactivatedIds: string[]; reactivatedCount: number },
   ): ImportResponseDto {
-    const insertedIds: number[] = [];
-    const updatedIds: number[] = [];
+    const insertedIds: string[] = [];
+    const updatedIds: string[] = [];
     const errorRows: ImportErrorRow[] = [];
     const warningRows: ImportErrorRow[] = [];
 

--- a/backend/src/features/product-import-jobs/product-import-jobs.service.ts
+++ b/backend/src/features/product-import-jobs/product-import-jobs.service.ts
@@ -47,6 +47,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
   private readonly carColumns: XlsxColumnDefinition[] = [
     { name: 'marca', required: true, type: 'string' },
     { name: 'modelo', required: true, type: 'string' },
+    { name: 'identificador', required: true, type: 'string' },
     { name: 'valor', required: true, type: 'number' },
     { name: 'estado', required: true, type: 'string' },
     { name: 'ano', required: true, type: 'number' },
@@ -62,6 +63,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
   private readonly boatColumns: XlsxColumnDefinition[] = [
     { name: 'marca', required: true, type: 'string' },
     { name: 'modelo', required: true, type: 'string' },
+    { name: 'identificador', required: true, type: 'string' },
     { name: 'valor', required: true, type: 'number' },
     { name: 'estado', required: true, type: 'string' },
     { name: 'ano', required: true, type: 'number' },
@@ -80,6 +82,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
   private readonly aircraftColumns: XlsxColumnDefinition[] = [
     { name: 'marca', required: true, type: 'string' },
     { name: 'modelo', required: true, type: 'string' },
+    { name: 'identificador', required: true, type: 'string' },
     { name: 'valor', required: true, type: 'number' },
     { name: 'estado', required: true, type: 'string' },
     { name: 'ano', required: true, type: 'number' },

--- a/backend/src/features/product-import-jobs/product-import-jobs.service.ts
+++ b/backend/src/features/product-import-jobs/product-import-jobs.service.ts
@@ -582,6 +582,12 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
     row: ImportParsedRow,
     specialistId: string,
   ): Promise<UpsertResult> {
+    if (!row.identificador || !row.identificador.trim()) {
+      throw new BadRequestException(
+        'identificador é obrigatório e não pode ser vazio',
+      );
+    }
+
     if (productType === ProductType.CAR) {
       const data = {
         marca: row.marca,

--- a/backend/src/features/product-import-jobs/product-import-jobs.service.ts
+++ b/backend/src/features/product-import-jobs/product-import-jobs.service.ts
@@ -586,6 +586,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
       const data = {
         marca: row.marca,
         modelo: row.modelo,
+        identificador: row.identificador,
         valor: Number(row.valor),
         estado: row.estado,
         ano: Number(row.ano),
@@ -632,6 +633,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
       const data = {
         marca: row.marca,
         modelo: row.modelo,
+        identificador: row.identificador,
         valor: Number(row.valor),
         estado: row.estado,
         ano: Number(row.ano),
@@ -680,6 +682,7 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
     const data = {
       marca: row.marca,
       modelo: row.modelo,
+      identificador: row.identificador,
       valor: Number(row.valor),
       estado: row.estado,
       ano: Number(row.ano),

--- a/backend/src/features/product-import-jobs/product-import-jobs.service.ts
+++ b/backend/src/features/product-import-jobs/product-import-jobs.service.ts
@@ -603,9 +603,8 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
 
       const existing = await this.prisma.car.findFirst({
         where: {
-          marca: row.marca?.trim(),
-          modelo: row.modelo?.trim(),
           specialist_id: specialistId,
+          identificador: row.identificador?.trim(),
         },
       });
 
@@ -653,9 +652,8 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
 
       const existing = await this.prisma.boat.findFirst({
         where: {
-          marca: row.marca?.trim(),
-          modelo: row.modelo?.trim(),
           specialist_id: specialistId,
+          identificador: row.identificador?.trim(),
         },
       });
 
@@ -697,9 +695,8 @@ export class ProductImportJobsService implements OnModuleInit, OnModuleDestroy {
 
     const existing = await this.prisma.aircraft.findFirst({
       where: {
-        marca: row.marca?.trim(),
-        modelo: row.modelo?.trim(),
         specialist_id: specialistId,
+        identificador: row.identificador?.trim(),
       },
     });
 

--- a/backend/src/shared/dto/import-response.dto.ts
+++ b/backend/src/shared/dto/import-response.dto.ts
@@ -33,13 +33,13 @@ export interface ImportResponseDto {
   /** Produtos criados com falhas parciais de imagem */
   warningRows: ImportErrorRow[];
   /** IDs dos produtos inseridos (opcional) */
-  insertedIds?: number[];
+  insertedIds?: string[];
   /** IDs dos produtos atualizados (opcional) */
-  updatedIds?: number[];
+  updatedIds?: string[];
   /** Quantidade de produtos inativados por ausência na planilha */
   deactivatedCount: number;
   /** IDs dos produtos inativados por ausência na planilha */
-  deactivatedIds: number[];
+  deactivatedIds: string[];
   /** Quantidade de produtos reativados (voltaram na planilha) */
   reactivatedCount: number;
 }

--- a/backend/src/shared/services/xlsx-import.service.ts
+++ b/backend/src/shared/services/xlsx-import.service.ts
@@ -407,10 +407,10 @@ export class XlsxImportService {
    * Cria resposta de importação
    */
   createResponse(
-    insertedIds: number[],
+    insertedIds: string[],
     errorRows: ImportErrorRow[],
     warningRows: ImportErrorRow[] = [],
-    updatedIds: number[] = [],
+    updatedIds: string[] = [],
   ): ImportResponseDto {
     const insertedCount = insertedIds.length;
     const updatedCount = updatedIds.length;

--- a/docs/superpowers/plans/2026-08-03-calculadora-spread-comissoes.md
+++ b/docs/superpowers/plans/2026-08-03-calculadora-spread-comissoes.md
@@ -1,0 +1,891 @@
+# Calculadora de spread de comissões (admin) + remoção de "Meus Assessorados" — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Dar ao admin uma calculadora de spread de comissões (venda → especialista/escritório/plataforma, todos os campos editáveis) com versão completa e versão reduzida no dashboard; remover o item de menu "Meus Assessorados" de todos os papéis.
+
+**Architecture:** Frontend-only. A função pura de split já existe no backend (`backend/src/features/contracts/commission-split.ts`) — é portada (não reescrita) para `frontend/src/lib/commission-split.ts`. Todos os dados (especialistas, escritórios, produtos) vêm de serviços que já existem; nenhum endpoint novo. Um componente de resultado presentacional (`CommissionSplitResult`) é reusado pela página completa e pela versão reduzida do dashboard.
+
+**Tech Stack:** React 19 + TypeScript + Vite + Tailwind v4 (tokens custom em `src/index.css`: `ink`, `ink-soft`, `surface`, `border`, `border-soft`, `muted`, `subtle`). Vitest é adicionado como dependência de dev só para testar a função pura de split (projeto não tem test runner de frontend hoje).
+
+## Global Constraints
+
+- **Zero mudanças no backend.** Nenhum endpoint novo, nenhuma alteração em `commission-split.ts`/`contracts.service.ts` do backend.
+- **Plataforma = resíduo.** A calculadora não expõe campo de taxa de plataforma — o valor da plataforma é sempre `restante − escritório`, fiel a `resolveCommissionFromTotal`.
+- **Todos os campos numéricos são sempre editáveis** (o "modo livre"). Selecionar produto/especialista/escritório só pré-preenche; nunca trava o campo.
+- **Reusar tokens Tailwind existentes** (`text-ink`, `bg-surface`, `border-border`, `bg-border-soft`, `text-muted`, `focus:ring-focus-ring`) — não introduzir cores hex novas nem HeroUI (o locpay é referência de UX, não de stack).
+- **Paleta de cores das 3 fatias**, para consistência com `DashboardPage.tsx` (`CommissionSplitBar`): Especialista = `emerald-500`, Escritório = `sky-500`, Plataforma = `violet-500`.
+- Verificação final obrigatória: `cd frontend && npm run lint && npm run build` (e `npm run test` para o Task 1) devem passar sem erros novos antes de considerar o plano concluído.
+
+---
+
+### Task 1: Portar a função pura de split + setup de teste (Vitest)
+
+**Files:**
+- Create: `frontend/src/lib/commission-split.ts`
+- Create: `frontend/src/lib/commission-split.test.ts`
+- Modify: `frontend/package.json` (script `test`, devDependency `vitest`)
+- Modify: `frontend/vite.config.ts` (config do Vitest)
+
+**Interfaces:**
+- Produces: `computeNestedCommissionSplit(input: NestedCommissionInput): NestedCommissionSplit`, `effectiveRate(value: number, saleValue: number): number`, tipos `NestedCommissionInput` e `NestedCommissionSplit` — consumidos pelas Tasks 2, 3 e 4.
+
+- [ ] **Step 1: Instalar o Vitest**
+
+Run: `cd frontend && npm install -D vitest`
+
+- [ ] **Step 2: Apontar o Vite config para o Vitest**
+
+Editar `frontend/vite.config.ts` (arquivo atual, 21 linhas) — trocar o import de `defineConfig` e adicionar o bloco `test`:
+
+```ts
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss()
+  ],
+  server: {
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+})
+```
+
+- [ ] **Step 3: Adicionar o script `test` no `package.json`**
+
+No bloco `"scripts"` de `frontend/package.json`, adicionar `"test": "vitest run"` (mantendo `dev`, `build`, `lint`, `preview` como estão).
+
+- [ ] **Step 4: Escrever o teste (falha esperada — módulo ainda não existe)**
+
+Criar `frontend/src/lib/commission-split.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { computeNestedCommissionSplit, effectiveRate } from "./commission-split";
+
+describe("computeNestedCommissionSplit", () => {
+  it("divide bolo em especialista / escritório / plataforma (aninhado)", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 100_000,
+      totalCommissionRate: 10, // bolo = 10.000
+      specialistShareRate: 70, // 70% do bolo
+      officeShareRate: 40, // 40% do restante
+    });
+    expect(r.bolo).toBe(10_000);
+    expect(r.specialistValue).toBe(7_000);
+    expect(r.officeValue).toBe(1_200); // 40% de 3.000
+    expect(r.platformValue).toBe(1_800); // resto do restante
+  });
+
+  it("sem escritório: restante inteiro vai pra plataforma", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 100_000,
+      totalCommissionRate: 10,
+      specialistShareRate: 70,
+      officeShareRate: 0,
+    });
+    expect(r.officeValue).toBe(0);
+    expect(r.platformValue).toBe(3_000);
+  });
+
+  it("as três fatias somam exatamente o bolo (sem drift de centavos)", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 99_999.99,
+      totalCommissionRate: 7.33,
+      specialistShareRate: 63.5,
+      officeShareRate: 41.7,
+    });
+    expect(r.specialistValue + r.officeValue + r.platformValue).toBe(r.bolo);
+  });
+
+  it("especialista com 100% do bolo zera escritório e plataforma", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 50_000,
+      totalCommissionRate: 8,
+      specialistShareRate: 100,
+      officeShareRate: 50,
+    });
+    expect(r.specialistValue).toBe(r.bolo);
+    expect(r.officeValue).toBe(0);
+    expect(r.platformValue).toBe(0);
+  });
+});
+
+describe("effectiveRate", () => {
+  it("calcula a taxa efetiva sobre a venda", () => {
+    expect(effectiveRate(7_000, 100_000)).toBe(7);
+    expect(effectiveRate(1_200, 100_000)).toBe(1.2);
+  });
+
+  it("retorna 0 quando a venda é 0", () => {
+    expect(effectiveRate(100, 0)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 5: Rodar o teste e confirmar que falha**
+
+Run: `cd frontend && npx vitest run src/lib/commission-split.test.ts`
+Expected: FAIL — `Cannot find module './commission-split'` (o arquivo ainda não existe).
+
+- [ ] **Step 6: Implementar a função pura**
+
+Criar `frontend/src/lib/commission-split.ts`:
+
+```ts
+// ponytail: cópia da lógica pura de backend/src/features/contracts/commission-split.ts
+// (fonte de verdade do split real do contrato) — manter em sync manualmente se aquele
+// arquivo mudar; sem endpoint novo, calculadora roda 100% no client.
+
+export interface NestedCommissionInput {
+  /** Valor de referência da venda (produto ou manual). */
+  proposalValue: number;
+  /** % da venda que vira o "bolo" (comissão total), 0–100. */
+  totalCommissionRate: number;
+  /** Fatia do especialista SOBRE O BOLO, 0–100. */
+  specialistShareRate: number;
+  /** Fatia do escritório SOBRE O RESTANTE, 0–100; 0 quando não há escritório. */
+  officeShareRate: number;
+}
+
+export interface NestedCommissionSplit {
+  bolo: number;
+  specialistValue: number;
+  officeValue: number;
+  platformValue: number;
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/**
+ * Split aninhado da comissão:
+ *   bolo         = venda × total%
+ *   especialista = bolo × fatiaEspecialista%
+ *   restante     = bolo − especialista
+ *   escritório   = restante × fatiaEscritório%
+ *   plataforma   = restante − escritório   (resíduo)
+ */
+export function computeNestedCommissionSplit(
+  input: NestedCommissionInput,
+): NestedCommissionSplit {
+  const bolo = round2((input.proposalValue * input.totalCommissionRate) / 100);
+  const specialistValue = round2((bolo * input.specialistShareRate) / 100);
+  const restante = round2(bolo - specialistValue);
+  const officeValue = round2((restante * input.officeShareRate) / 100);
+  const platformValue = round2(restante - officeValue);
+  return { bolo, specialistValue, officeValue, platformValue };
+}
+
+/** Taxa efetiva de um valor sobre a venda, em %. */
+export function effectiveRate(value: number, saleValue: number): number {
+  return saleValue > 0 ? round2((value / saleValue) * 100) : 0;
+}
+```
+
+- [ ] **Step 7: Rodar o teste e confirmar que passa**
+
+Run: `cd frontend && npx vitest run src/lib/commission-split.test.ts`
+Expected: PASS (6 testes).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/vite.config.ts frontend/src/lib/commission-split.ts frontend/src/lib/commission-split.test.ts
+git commit -m "feat(admin): função pura de split de comissão + vitest"
+```
+
+---
+
+### Task 2: Componente de resultado (`CommissionSplitResult`)
+
+**Files:**
+- Create: `frontend/src/components/commission/CommissionSplitResult.tsx`
+
+**Interfaces:**
+- Consumes: `NestedCommissionSplit`, `effectiveRate` de `frontend/src/lib/commission-split.ts` (Task 1).
+- Produces: `CommissionSplitResult({ saleValue, split, compact? }: CommissionSplitResultProps)` — consumido pelas Tasks 3 e 4.
+
+- [ ] **Step 1: Criar o componente**
+
+Criar `frontend/src/components/commission/CommissionSplitResult.tsx`:
+
+```tsx
+import type { NestedCommissionSplit } from "../../lib/commission-split";
+import { effectiveRate } from "../../lib/commission-split";
+
+export interface CommissionSplitResultProps {
+  saleValue: number;
+  split: NestedCommissionSplit;
+  /** Versão reduzida (card do dashboard): sem tabela, sem linha de bolo. */
+  compact?: boolean;
+}
+
+const brl = (n: number) =>
+  n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+
+const DOT = {
+  specialist: "bg-emerald-500",
+  office: "bg-sky-500",
+  platform: "bg-violet-500",
+} as const;
+
+export function CommissionSplitResult({
+  saleValue,
+  split,
+  compact = false,
+}: CommissionSplitResultProps) {
+  if (compact) {
+    const rows = [
+      { label: "Especialista", value: split.specialistValue, dot: DOT.specialist },
+      { label: "Escritório", value: split.officeValue, dot: DOT.office },
+      { label: "Plataforma", value: split.platformValue, dot: DOT.platform },
+    ];
+    return (
+      <div className="flex flex-col gap-2">
+        {rows.map((row) => (
+          <div key={row.label} className="flex items-center justify-between text-sm">
+            <span className="inline-flex items-center gap-1.5 text-ink-soft">
+              <span className={`w-2 h-2 rounded-full shrink-0 ${row.dot}`} />
+              {row.label}
+            </span>
+            <span className="font-semibold text-ink">{brl(row.value)}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const bodyRows = [
+    { label: "Comissão total (bolo)", value: split.bolo, dot: null as string | null },
+    { label: "Especialista", value: split.specialistValue, dot: DOT.specialist },
+    { label: "Escritório", value: split.officeValue, dot: DOT.office },
+  ];
+
+  return (
+    <table className="w-full text-sm border border-border rounded-lg overflow-hidden">
+      <thead>
+        <tr className="bg-border-soft text-ink-soft">
+          <th className="text-left px-3 py-2 font-medium">Indicador</th>
+          <th className="text-right px-3 py-2 font-medium">Valor</th>
+          <th className="text-right px-3 py-2 font-medium">% da venda</th>
+        </tr>
+      </thead>
+      <tbody>
+        {bodyRows.map((row) => (
+          <tr key={row.label} className="border-t border-border">
+            <td className="px-3 py-2 text-ink-soft">
+              <span className="inline-flex items-center gap-1.5">
+                {row.dot && (
+                  <span className={`w-2 h-2 rounded-full shrink-0 ${row.dot}`} />
+                )}
+                {row.label}
+              </span>
+            </td>
+            <td className="px-3 py-2 text-right font-medium text-ink">
+              {brl(row.value)}
+            </td>
+            <td className="px-3 py-2 text-right text-ink-soft">
+              {effectiveRate(row.value, saleValue)}%
+            </td>
+          </tr>
+        ))}
+      </tbody>
+      <tfoot>
+        <tr className="bg-ink text-surface font-bold">
+          <td className="px-3 py-2">
+            <span className="inline-flex items-center gap-1.5">
+              <span className={`w-2 h-2 rounded-full shrink-0 ${DOT.platform}`} />
+              Plataforma
+            </span>
+          </td>
+          <td className="px-3 py-2 text-right">{brl(split.platformValue)}</td>
+          <td className="px-3 py-2 text-right">
+            {effectiveRate(split.platformValue, saleValue)}%
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  );
+}
+```
+
+- [ ] **Step 2: Verificar tipos**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros novos relacionados a este arquivo.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/components/commission/CommissionSplitResult.tsx
+git commit -m "feat(admin): componente de resultado do split de comissão"
+```
+
+---
+
+### Task 3: Página completa da calculadora + rota + item de menu
+
+**Files:**
+- Create: `frontend/src/pages/admin/CommissionCalculatorPage.tsx`
+- Modify: `frontend/src/routes/routes.tsx` (import + rota `/admin/calculator`)
+- Modify: `frontend/src/layouts/Sidebar.tsx` (item "Calculadora" no bloco ADMIN)
+
+**Interfaces:**
+- Consumes: `computeNestedCommissionSplit` (Task 1), `CommissionSplitResult` (Task 2), `getSpecialists` (`Specialist` tem `id: string`, `name`, `surname`, `commission_rate?: number | null`), `getCompanies` (`Company` tem `id: string`, `name`, `commission_rate?: number | null`), `getCars`/`getBoats`/`getAircrafts(1, 100)` (retornam `{ cars/boats/aircrafts: Product[] }`, `Product` tem `id: number`, `marca`, `modelo`, `valor: number`).
+
+- [ ] **Step 1: Criar a página**
+
+Criar `frontend/src/pages/admin/CommissionCalculatorPage.tsx`:
+
+```tsx
+import { useEffect, useMemo, useState } from "react";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { Card } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { CommissionSplitResult } from "../../components/commission/CommissionSplitResult";
+import { computeNestedCommissionSplit } from "../../lib/commission-split";
+import {
+  getSpecialists,
+  type Specialist,
+} from "../../services/specialists.service";
+import { getCompanies, type Company } from "../../services/companies.service";
+import { getCars } from "../../services/cars.service";
+import { getBoats } from "../../services/boats.service";
+import { getAircrafts } from "../../services/aircrafts.service";
+import type { Product } from "../../types/types";
+
+type ProductCategory = "CAR" | "BOAT" | "AIRCRAFT";
+
+const CATEGORY_LABEL: Record<ProductCategory, string> = {
+  CAR: "Carro",
+  BOAT: "Embarcação",
+  AIRCRAFT: "Aeronave",
+};
+
+const brl = (n: number) =>
+  n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+
+async function fetchProductsByCategory(
+  category: ProductCategory,
+): Promise<Product[]> {
+  if (category === "CAR") return (await getCars(1, 100)).cars;
+  if (category === "BOAT") return (await getBoats(1, 100)).boats;
+  return (await getAircrafts(1, 100)).aircrafts;
+}
+
+const selectClass =
+  "w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-focus-ring";
+const labelClass = "block text-sm font-medium text-ink-soft mb-1";
+
+export default function CommissionCalculatorPage() {
+  const [saleValue, setSaleValue] = useState(0);
+  const [totalCommissionRate, setTotalCommissionRate] = useState(10);
+  const [specialistShareRate, setSpecialistShareRate] = useState(0);
+  const [officeShareRate, setOfficeShareRate] = useState(0);
+
+  const [specialists, setSpecialists] = useState<Specialist[]>([]);
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [category, setCategory] = useState<ProductCategory | "">("");
+  const [products, setProducts] = useState<Product[]>([]);
+  const [isLoadingProducts, setIsLoadingProducts] = useState(false);
+
+  useEffect(() => {
+    getSpecialists().then(setSpecialists).catch(() => setSpecialists([]));
+    getCompanies().then(setCompanies).catch(() => setCompanies([]));
+  }, []);
+
+  useEffect(() => {
+    if (!category) {
+      setProducts([]);
+      return;
+    }
+    setIsLoadingProducts(true);
+    fetchProductsByCategory(category)
+      .then(setProducts)
+      .catch(() => setProducts([]))
+      .finally(() => setIsLoadingProducts(false));
+  }, [category]);
+
+  const split = useMemo(
+    () =>
+      computeNestedCommissionSplit({
+        proposalValue: saleValue,
+        totalCommissionRate,
+        specialistShareRate,
+        officeShareRate,
+      }),
+    [saleValue, totalCommissionRate, specialistShareRate, officeShareRate],
+  );
+
+  return (
+    <div className="w-full">
+      <PageHeader title="Calculadora de comissões" />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 flex flex-col gap-6">
+          <Card className="flex flex-col gap-4">
+            <h2 className="text-lg font-semibold text-ink">Venda</h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className={labelClass}>Categoria do produto (opcional)</label>
+                <select
+                  value={category}
+                  onChange={(e) =>
+                    setCategory(e.target.value as ProductCategory | "")
+                  }
+                  className={selectClass}
+                >
+                  <option value="">Nenhuma — valor manual</option>
+                  <option value="CAR">Carro</option>
+                  <option value="BOAT">Embarcação</option>
+                  <option value="AIRCRAFT">Aeronave</option>
+                </select>
+              </div>
+
+              <div>
+                <label className={labelClass}>
+                  Produto {category && `(${CATEGORY_LABEL[category]})`}
+                </label>
+                <select
+                  disabled={!category || isLoadingProducts}
+                  onChange={(e) => {
+                    const product = products.find(
+                      (p) => String(p.id) === e.target.value,
+                    );
+                    if (product) setSaleValue(product.valor);
+                  }}
+                  className={selectClass}
+                >
+                  <option value="">
+                    {isLoadingProducts ? "Carregando..." : "Selecionar produto"}
+                  </option>
+                  {products.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.marca} {p.modelo} — {brl(p.valor)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className={labelClass}>Valor de venda (R$)</label>
+              <Input
+                type="number"
+                min={0}
+                step="0.01"
+                value={saleValue}
+                onChange={(e) => setSaleValue(Number(e.target.value) || 0)}
+              />
+            </div>
+
+            <div>
+              <label className={labelClass}>Comissão total da venda (%)</label>
+              <Input
+                type="number"
+                min={0}
+                max={100}
+                step="0.01"
+                value={totalCommissionRate}
+                onChange={(e) =>
+                  setTotalCommissionRate(Number(e.target.value) || 0)
+                }
+              />
+            </div>
+          </Card>
+
+          <Card className="flex flex-col gap-4">
+            <h2 className="text-lg font-semibold text-ink">
+              Especialista e escritório
+            </h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className={labelClass}>Especialista (opcional)</label>
+                <select
+                  onChange={(e) => {
+                    const specialist = specialists.find(
+                      (s) => s.id === e.target.value,
+                    );
+                    setSpecialistShareRate(specialist?.commission_rate ?? 0);
+                  }}
+                  className={selectClass}
+                >
+                  <option value="">Nenhum — fatia manual</option>
+                  {specialists.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name} {s.surname}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className={labelClass}>
+                  Fatia do especialista sobre o bolo (%)
+                </label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  value={specialistShareRate}
+                  onChange={(e) =>
+                    setSpecialistShareRate(Number(e.target.value) || 0)
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className={labelClass}>Escritório (opcional)</label>
+                <select
+                  onChange={(e) => {
+                    const company = companies.find((c) => c.id === e.target.value);
+                    setOfficeShareRate(company?.commission_rate ?? 0);
+                  }}
+                  className={selectClass}
+                >
+                  <option value="">Nenhum</option>
+                  {companies.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className={labelClass}>
+                  Fatia do escritório sobre o restante (%)
+                </label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  value={officeShareRate}
+                  onChange={(e) =>
+                    setOfficeShareRate(Number(e.target.value) || 0)
+                  }
+                />
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <div className="lg:sticky lg:top-6 h-fit">
+          <Card>
+            <h2 className="text-lg font-semibold text-ink mb-4">Resultado</h2>
+            <CommissionSplitResult saleValue={saleValue} split={split} />
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Registrar a rota**
+
+Em `frontend/src/routes/routes.tsx`, adicionar o import junto aos outros de `pages/admin/` (perto da linha 21, após `import DatabasePage from "../pages/admin/DatabasePage";`):
+
+```tsx
+import CommissionCalculatorPage from "../pages/admin/CommissionCalculatorPage";
+```
+
+E adicionar a rota logo após o bloco `/admin/commissions` (linhas 257-266), seguindo exatamente o mesmo padrão:
+
+```tsx
+    {
+      path: "/admin/calculator",
+      element: (
+        <MainLayout>
+          <ProtectedRoute allowedRoles={["ADMIN"]}>
+            <CommissionCalculatorPage />
+          </ProtectedRoute>
+        </MainLayout>
+      ),
+    },
+```
+
+- [ ] **Step 3: Adicionar o item de menu**
+
+Em `frontend/src/layouts/Sidebar.tsx`, adicionar `Calculator` ao import de `lucide-react` (linha 1-17, junto com `Percent`):
+
+```tsx
+import {
+  TextAlignJustifyIcon,
+  LayoutDashboard,
+  Building2,
+  Users,
+  UserCog,
+  Car,
+  Ship,
+  Plane,
+  Package,
+  Home,
+  FilePen,
+  Settings,
+  Percent,
+  Database,
+  UserCheck,
+  Calculator,
+} from "lucide-react";
+```
+
+E inserir o item logo após o bloco `/admin/commissions` no `case "ADMIN":` (linhas 148-152):
+
+```tsx
+          {
+            to: "/admin/commissions",
+            label: "Comissões",
+            icon: <Percent size={20} />,
+          },
+          {
+            to: "/admin/calculator",
+            label: "Calculadora",
+            icon: <Calculator size={20} />,
+          },
+```
+
+- [ ] **Step 4: Rodar lint e build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: sem erros.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/admin/CommissionCalculatorPage.tsx frontend/src/routes/routes.tsx frontend/src/layouts/Sidebar.tsx
+git commit -m "feat(admin): página completa da calculadora de comissões em /admin/calculator"
+```
+
+---
+
+### Task 4: Versão reduzida no dashboard
+
+**Files:**
+- Create: `frontend/src/components/commission/CommissionMiniCalculator.tsx`
+- Modify: `frontend/src/pages/admin/DashboardPage.tsx`
+
+**Interfaces:**
+- Consumes: `computeNestedCommissionSplit` (Task 1), `CommissionSplitResult` com `compact` (Task 2), `getSpecialists` (Task 3 já validou o tipo).
+- Produces: `CommissionMiniCalculator()` — sem props, self-contained; renderizado dentro de `DashboardPage`.
+
+- [ ] **Step 1: Criar o mini componente**
+
+Criar `frontend/src/components/commission/CommissionMiniCalculator.tsx`:
+
+```tsx
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { ArrowRight, Calculator } from "lucide-react";
+import { Card } from "../ui/card";
+import { Input } from "../ui/input";
+import { CommissionSplitResult } from "./CommissionSplitResult";
+import { computeNestedCommissionSplit } from "../../lib/commission-split";
+import {
+  getSpecialists,
+  type Specialist,
+} from "../../services/specialists.service";
+
+export function CommissionMiniCalculator() {
+  const [saleValue, setSaleValue] = useState(0);
+  const [totalCommissionRate, setTotalCommissionRate] = useState(10);
+  const [specialistShareRate, setSpecialistShareRate] = useState(0);
+  const [specialists, setSpecialists] = useState<Specialist[]>([]);
+
+  useEffect(() => {
+    getSpecialists().then(setSpecialists).catch(() => setSpecialists([]));
+  }, []);
+
+  const split = useMemo(
+    () =>
+      computeNestedCommissionSplit({
+        proposalValue: saleValue,
+        totalCommissionRate,
+        specialistShareRate,
+        officeShareRate: 0,
+      }),
+    [saleValue, totalCommissionRate, specialistShareRate],
+  );
+
+  return (
+    <Card className="h-full flex flex-col">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+        <div className="flex items-center gap-2">
+          <Calculator className="w-5 h-5 text-ink-soft" />
+          <h2 className="text-lg font-semibold text-ink">Calculadora rápida</h2>
+        </div>
+        <Link
+          to="/admin/calculator"
+          className="flex items-center gap-1 text-sm text-ink-soft hover:text-ink shrink-0 whitespace-nowrap"
+        >
+          calculadora completa <ArrowRight className="w-4 h-4" />
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
+        <div>
+          <label className="block text-xs text-muted mb-1">
+            Valor de venda (R$)
+          </label>
+          <Input
+            type="number"
+            min={0}
+            step="0.01"
+            value={saleValue}
+            onChange={(e) => setSaleValue(Number(e.target.value) || 0)}
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-muted mb-1">
+            Comissão total (%)
+          </label>
+          <Input
+            type="number"
+            min={0}
+            max={100}
+            step="0.01"
+            value={totalCommissionRate}
+            onChange={(e) =>
+              setTotalCommissionRate(Number(e.target.value) || 0)
+            }
+          />
+        </div>
+        <div>
+          <label className="block text-xs text-muted mb-1">Especialista</label>
+          <select
+            onChange={(e) => {
+              const specialist = specialists.find((s) => s.id === e.target.value);
+              setSpecialistShareRate(specialist?.commission_rate ?? 0);
+            }}
+            className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-focus-ring"
+          >
+            <option value="">Nenhum</option>
+            {specialists.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name} {s.surname}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="border-t border-border pt-4">
+        <CommissionSplitResult saleValue={saleValue} split={split} compact />
+      </div>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 2: Encaixar no dashboard**
+
+Em `frontend/src/pages/admin/DashboardPage.tsx`:
+
+Adicionar o import (junto aos outros, perto da linha 34, após `import { PageHeader } ...`):
+
+```tsx
+import { CommissionMiniCalculator } from "../../components/commission/CommissionMiniCalculator";
+```
+
+Inserir uma nova seção full-width logo depois do grid `lg:grid-cols-2` existente (fecha na linha 338 com `</div>`) e antes do comentário `{/* Gráficos */}` (linha 340):
+
+```tsx
+      {/* Calculadora rápida de comissões */}
+      <div className="mb-8">
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: cardDuration, delay: 0.19 }}
+        >
+          <CommissionMiniCalculator />
+        </motion.div>
+      </div>
+
+```
+
+- [ ] **Step 3: Rodar lint e build**
+
+Run: `cd frontend && npm run lint && npm run build`
+Expected: sem erros.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/commission/CommissionMiniCalculator.tsx frontend/src/pages/admin/DashboardPage.tsx
+git commit -m "feat(admin-dashboard): card de calculadora rápida de comissões"
+```
+
+---
+
+### Task 5: Remover "Meus Assessorados" da navegação (todos os papéis)
+
+**Files:**
+- Modify: `frontend/src/layouts/Sidebar.tsx`
+
+**Interfaces:**
+- Nenhuma — remoção pura de UI. `AdvisorDashboardPage.tsx`, a rota `/advisor/dashboard`, `/advisor/accept` e `advisor.service.ts` permanecem intactos (fluxo de convite/aceite continua funcionando; só o item de menu some).
+
+- [ ] **Step 1: Remover o bloco que injeta o item de menu**
+
+Em `frontend/src/layouts/Sidebar.tsx`, remover o bloco (linhas 196-202, logo após o `switch`):
+
+```tsx
+    if (user.role !== "OFFICE") {
+      links.push({
+        to: "/advisor/dashboard",
+        label: "Meus Assessorados",
+        icon: <UserCheck size={20} />,
+      });
+    }
+```
+
+Remover também o import agora não usado `UserCheck` do bloco de `lucide-react` (linha 16) — **atenção:** confirmar antes que `UserCheck` não é usado em nenhum outro lugar do arquivo (`grep -n "UserCheck" frontend/src/layouts/Sidebar.tsx` deve retornar só a linha do import após a remoção; se sim, apagar a linha do import).
+
+- [ ] **Step 2: Rodar lint**
+
+Run: `cd frontend && npm run lint`
+Expected: sem erros (nenhum import não usado sobrando).
+
+- [ ] **Step 3: Verificação manual**
+
+Rodar `cd frontend && npm run dev`, logar como cada papel (CUSTOMER, CONSULTANT, SPECIALIST, ADMIN) e confirmar que "Meus Assessorados" não aparece mais em nenhum menu. Confirmar que "Meus Clientes" (consultor, `/consultant/clients`) continua aparecendo normalmente — é uma feature diferente e não deve ser tocada.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/layouts/Sidebar.tsx
+git commit -m "fix(nav): remove item 'Meus Assessorados' de todos os papéis"
+```
+
+---
+
+## Verificação final (rodar após a Task 5)
+
+```bash
+cd frontend
+npm run lint
+npm run build
+npm run test
+```
+
+Todos devem passar sem erros novos antes de considerar o plano concluído.

--- a/docs/superpowers/plans/2026-08-03-identificador-produto-e-uuid.md
+++ b/docs/superpowers/plans/2026-08-03-identificador-produto-e-uuid.md
@@ -1,0 +1,586 @@
+# Identificador de produto + PK de produtos em UUID — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir que um especialista cadastre vários produtos do mesmo marca/modelo via import, distinguindo-os por um `identificador` obrigatório, e migrar a PK dos produtos de `Int` para `UUID`.
+
+**Architecture:** Fase A adiciona um campo `identificador` (chave natural por especialista) aos 3 produtos e troca a chave de deduplicação do import de `(marca, modelo)` para `(specialist_id, identificador)` em todos os pontos de upsert. Fase B troca a PK `Int autoincrement` → `String @db.Uuid` nos 3 produtos e propaga nas FKs, DTOs e front. Fase C exporta os produtos atuais para CSV (antes do wipe) e apaga a base via `prisma db push --accept-data-loss`.
+
+**Tech Stack:** NestJS + Prisma (PostgreSQL/Supabase dev), React + Vite + TypeScript, Jest (`*.spec.ts`, prisma mockado).
+
+## Global Constraints
+
+- **RAM da máquina:** nunca rodar a suite inteira sem cap. Todo comando de teste usa `--maxWorkers=2` e alvo focado (arquivo único). Nunca `npm test` puro.
+- **Banco é dev/demo (Supabase com drift):** mudanças de schema vão por `npx prisma db push` (nunca `migrate deploy`). A troca de PK exige `--accept-data-loss`.
+- **Consultor não recebe comissão** — nada nesta feature toca comissão.
+- **Ordem entre fases é obrigatória:** A → B → C. O export da Fase C roda **antes** do `db push` que reseta a base.
+- Mensagens de commit em português, seguindo o padrão do repo (`feat:`, `fix:`, `refactor:`, `test:`).
+
+---
+
+## File Structure
+
+**Fase A**
+- `backend/prisma/schema.prisma` — campo `identificador` + `@@unique` em Car/Boat/Aircraft.
+- `backend/src/features/product-import-jobs/product-import-jobs.service.ts` — colunas + chave de dedup (3 ramos) + validação de valor vazio.
+- `backend/src/features/cars/cars.service.ts` — `xlsxColumns`, `getCsvTemplate`, dedup em `importFromCsv`/`importFromXlsx`.
+- `backend/src/features/boats/boats.service.ts` — idem.
+- `backend/src/features/aircrafts/aircrafts.service.ts` — idem.
+- `backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts` — teste da chave de dedup (criar se não existir).
+
+**Fase B**
+- `backend/prisma/schema.prisma` — `id` UUID em Car/Boat/Aircraft; FKs em Car_image/Boat_image/Aircraft_image, Process, Product.
+- `backend/src/features/processes/dto/create-process.dto.ts`, `assign-product.dto.ts` — `@IsInt` → `@IsUUID`.
+- `backend/src/features/processes/processes.service.ts` — remover `Number(product_id)`.
+- Controllers car/boat/aircraft — remover `ParseIntPipe` de params de id.
+- `frontend/src/services/{cars,boats,aircrafts}.service.ts` — `getXById(id: string)` + `RawCar/RawBoat/RawAircraft.id: string`.
+- `frontend/src/pages/catalog/ProductPage.tsx`, `frontend/src/pages/specialist/ProductFormPage.tsx` — remover `Number(id)`.
+
+**Fase C**
+- `backend/scripts/export-produtos-para-csv.ts` — export (novo).
+
+---
+
+## FASE A — Identificador de produto
+
+### Task A1: Schema — campo `identificador`
+
+**Files:**
+- Modify: `backend/prisma/schema.prisma` (models `Car`, `Boat`, `Aircraft`)
+
+**Interfaces:**
+- Produces: coluna `identificador String` e constraint `@@unique([specialist_id, identificador])` nas 3 tabelas.
+
+- [ ] **Step 1: Adicionar campo e unique em Car**
+
+Em `model Car`, logo abaixo de `modelo String`, adicionar:
+
+```prisma
+  identificador              String
+```
+
+E junto dos índices existentes, adicionar:
+
+```prisma
+  @@unique([specialist_id, identificador])
+```
+
+- [ ] **Step 2: Repetir em Boat e Aircraft**
+
+Mesma linha `identificador String` após `modelo` e mesmo `@@unique([specialist_id, identificador])` em `model Boat` e `model Aircraft`.
+
+- [ ] **Step 3: Aplicar no banco dev**
+
+Run: `cd backend && npx prisma db push`
+Expected: falha pedindo default para coluna obrigatória em tabela com linhas existentes.
+
+> Se a base tiver produtos, o push vai reclamar da coluna `NOT NULL` sem default. **Não** adicionar default permanente. Para dev, resolver assim: rodar o export da Fase C **antes**, ou aceitar o reset agora com `npx prisma db push --accept-data-loss` (a base será recriada; produtos atuais são recuperados na Fase C). Para esta task isolada, se a base estiver vazia o push passa direto.
+
+- [ ] **Step 4: Regenerar client**
+
+Run: `cd backend && npx prisma generate`
+Expected: client regenerado, tipo `Car`/`Boat`/`Aircraft` com `identificador: string`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/prisma/schema.prisma
+git commit -m "feat(produtos): campo identificador + unique por especialista no schema"
+```
+
+---
+
+### Task A2: Colunas de import + templates
+
+**Files:**
+- Modify: `backend/src/features/product-import-jobs/product-import-jobs.service.ts` (arrays `carColumns`, `boatColumns`, `aircraftColumns`)
+- Modify: `backend/src/features/cars/cars.service.ts` (`xlsxColumns`, `getCsvTemplate`)
+- Modify: `backend/src/features/boats/boats.service.ts` (idem)
+- Modify: `backend/src/features/aircrafts/aircrafts.service.ts` (idem)
+
+**Interfaces:**
+- Consumes: schema da Task A1.
+- Produces: templates com coluna `identificador` (obrigatória) nos 3 tipos, em ambos os caminhos (job e service).
+
+- [ ] **Step 1: Adicionar coluna nos arrays do job service**
+
+Em `product-import-jobs.service.ts`, em `carColumns`, `boatColumns` e `aircraftColumns`, adicionar como **primeira** coluna após as required de identidade (logo depois de `modelo`):
+
+```ts
+    { name: 'identificador', required: true, type: 'string' },
+```
+
+- [ ] **Step 2: Adicionar coluna no `xlsxColumns` de cada service**
+
+Em `cars.service.ts`, `boats.service.ts`, `aircrafts.service.ts`, no array `xlsxColumns`, adicionar a mesma definição após `modelo`:
+
+```ts
+    { name: 'identificador', required: true, type: 'string' },
+```
+
+- [ ] **Step 3: Atualizar `getCsvTemplate` (headers + exemplo)**
+
+Em cada service, `getCsvTemplate` monta `headers` a partir de `xlsxColumns` (já cobre a nova coluna automaticamente) mas tem um array `exampleValues` posicional. Adicionar o valor de exemplo do `identificador` na **mesma posição** da coluna (após o valor de `modelo`). Ex. em `cars.service.ts`:
+
+```ts
+    const exampleValues = [
+      'BMW',
+      'X5',
+      'BMW-X5-1',
+      // ...restante inalterado
+    ];
+```
+
+Fazer o equivalente em boats/aircrafts (valor exemplo `MARCA-MODELO-1`).
+
+- [ ] **Step 4: Atualizar o exemplo do `generateTemplate` (XLSX)**
+
+Em cada service, o objeto `example` passado para `xlsxImportService.generateTemplate` precisa da chave nova:
+
+```ts
+      identificador: 'BMW-X5-1',
+```
+
+- [ ] **Step 5: Verificar que compila**
+
+Run: `cd backend && npx tsc --noEmit`
+Expected: sem erros.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/features/product-import-jobs/product-import-jobs.service.ts backend/src/features/cars/cars.service.ts backend/src/features/boats/boats.service.ts backend/src/features/aircrafts/aircrafts.service.ts
+git commit -m "feat(import): coluna identificador obrigatoria nos templates de produto"
+```
+
+---
+
+### Task A3: Chave de dedup por identificador (todos os pontos)
+
+**Files:**
+- Modify: `backend/src/features/product-import-jobs/product-import-jobs.service.ts` (`upsertProductFromRow`, 3 ramos)
+- Modify: `backend/src/features/cars/cars.service.ts` (`importFromCsv` ~442, `importFromXlsx` ~556)
+- Modify: `backend/src/features/boats/boats.service.ts` (`importFromCsv` ~478, `importFromXlsx` ~596)
+- Modify: `backend/src/features/aircrafts/aircrafts.service.ts` (`importFromCsv` ~513, `importFromXlsx` ~645)
+- Test: `backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts`
+
+**Interfaces:**
+- Consumes: campo `identificador` (A1), coluna no payload (A2).
+- Produces: dedup determinístico por `(specialist_id, identificador)`; `identificador` gravado no `data` de create/update.
+
+- [ ] **Step 1: Escrever teste que falha (dedup por identificador)**
+
+Se o arquivo `product-import-jobs.service.spec.ts` não existir, criar com um `PrismaService` mockado. O teste verifica que `upsertProductFromRow` para CAR busca por `identificador` e não por `modelo`:
+
+```ts
+it('busca produto existente por (specialist_id, identificador), nao por modelo', async () => {
+  const findFirst = jest.fn().mockResolvedValue(null);
+  const create = jest.fn().mockResolvedValue({ id: 'uuid-1' });
+  const prisma = { car: { findFirst, create } } as any;
+  const service = new ProductImportJobsService(prisma, {} as any, {} as any);
+
+  await (service as any).upsertProductFromRow(
+    'CAR',
+    { marca: 'Ferrari', modelo: 'X', identificador: 'FERRARI-X-2', valor: '100', estado: 'SP', ano: '2020' },
+    'spec-1',
+  );
+
+  expect(findFirst).toHaveBeenCalledWith({
+    where: { specialist_id: 'spec-1', identificador: 'FERRARI-X-2' },
+  });
+  expect(create).toHaveBeenCalledWith({
+    data: expect.objectContaining({ identificador: 'FERRARI-X-2' }),
+  });
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `cd backend && npm test -- product-import-jobs.service --maxWorkers=2`
+Expected: FAIL (findFirst chamado com marca/modelo, sem identificador no data).
+
+- [ ] **Step 3: Trocar a chave nos 3 ramos do job service**
+
+Em `upsertProductFromRow`, para cada ramo (car/boat/aircraft):
+1. Adicionar `identificador: row.identificador` ao objeto `data`.
+2. Trocar o `where` do `findFirst`:
+
+```ts
+const existing = await this.prisma.car.findFirst({
+  where: {
+    specialist_id: specialistId,
+    identificador: row.identificador?.trim(),
+  },
+});
+```
+
+(idem `this.prisma.boat` / `this.prisma.aircraft`). Manter o resto do fluxo update/create igual. No update, `identificador` já entra via `updateData`.
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cd backend && npm test -- product-import-jobs.service --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 5: Trocar a chave nos 6 pontos síncronos**
+
+Em cars/boats/aircrafts service, `importFromCsv` e `importFromXlsx`, cada `findFirst` que hoje busca por `{ marca, modelo, specialist_id }` passa a `{ specialist_id, identificador: row.identificador?.trim() }`, e o objeto de dados do create/update ganha `identificador: row.identificador`.
+
+- [ ] **Step 6: Confirmar compilação e teste**
+
+Run: `cd backend && npx tsc --noEmit && npm test -- product-import-jobs.service --maxWorkers=2`
+Expected: sem erro de tipo; teste PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/features
+git commit -m "feat(import): dedup de produto por (specialist_id, identificador)"
+```
+
+---
+
+### Task A4: Validação de identificador vazio → erro de linha
+
+**Files:**
+- Modify: `backend/src/features/product-import-jobs/product-import-jobs.service.ts` (`upsertProductFromRow`, início)
+- Test: `backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts`
+
+**Interfaces:**
+- Consumes: A3.
+- Produces: linha com `identificador` ausente/vazio lança erro (vira `FAILED` / `errorRows`), não cria produto.
+
+- [ ] **Step 1: Escrever teste que falha**
+
+```ts
+it('lanca erro quando identificador vem vazio', async () => {
+  const prisma = { car: { findFirst: jest.fn(), create: jest.fn() } } as any;
+  const service = new ProductImportJobsService(prisma, {} as any, {} as any);
+
+  await expect(
+    (service as any).upsertProductFromRow(
+      'CAR',
+      { marca: 'Ferrari', modelo: 'X', identificador: '  ', valor: '100', estado: 'SP', ano: '2020' },
+      'spec-1',
+    ),
+  ).rejects.toThrow(/identificador/i);
+  expect(prisma.car.create).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Rodar e confirmar que falha**
+
+Run: `cd backend && npm test -- product-import-jobs.service --maxWorkers=2`
+Expected: FAIL (hoje não valida vazio).
+
+- [ ] **Step 3: Guard no início de `upsertProductFromRow`**
+
+Logo no começo do método, antes do `if (productType === ProductType.CAR)`:
+
+```ts
+if (!row.identificador || !row.identificador.trim()) {
+  throw new BadRequestException('identificador é obrigatório e não pode ser vazio');
+}
+```
+
+`BadRequestException` já é importado no arquivo. O erro é capturado pelo `try/catch` do loop de `processJob` e vira `FAILED` na linha.
+
+- [ ] **Step 4: Rodar e confirmar que passa**
+
+Run: `cd backend && npm test -- product-import-jobs.service --maxWorkers=2`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/features/product-import-jobs/product-import-jobs.service.ts backend/src/features/product-import-jobs/product-import-jobs.service.spec.ts
+git commit -m "feat(import): rejeita linha com identificador vazio"
+```
+
+---
+
+## FASE B — PK de produtos em UUID
+
+> A partir daqui a base **será resetada**. Se houver dados a preservar, executar a Fase C (export) **antes** do Step de `db push` da Task B1.
+
+### Task B1: Schema — PK UUID e FKs
+
+**Files:**
+- Modify: `backend/prisma/schema.prisma`
+
+**Interfaces:**
+- Produces: `Car/Boat/Aircraft.id: String @db.Uuid`; FKs correspondentes como `String? @db.Uuid`.
+
+- [ ] **Step 1: Trocar a PK dos 3 produtos**
+
+Em `model Car`, `model Boat`, `model Aircraft`:
+
+```prisma
+  id  String  @id @default(uuid()) @db.Uuid
+```
+
+(era `Int @default(autoincrement())`).
+
+- [ ] **Step 2: Trocar as FKs**
+
+- `Car_image.car_id`, `Boat_image.boat_id`, `Aircraft_image.aircraft_id`: `Int?` → `String? @db.Uuid`.
+- `Process.car_id`, `Process.boat_id`, `Process.aircraft_id`: `Int?` → `String? @db.Uuid`.
+- `Product.car_id`, `Product.boat_id`, `Product.aircraft_id`: `Int?` → `String? @db.Uuid`. Remover o comentário `// TODO: converter ... para UUID`.
+
+- [ ] **Step 3: (SE for preservar dados) rodar o export da Fase C agora**
+
+Ver Task C1. Só então continuar.
+
+- [ ] **Step 4: Aplicar reset no banco dev**
+
+Run: `cd backend && npx prisma db push --accept-data-loss`
+Expected: tabelas de produto recriadas com `id` UUID. Aviso de perda de dados é esperado e autorizado.
+
+- [ ] **Step 5: Regenerar client**
+
+Run: `cd backend && npx prisma generate`
+Expected: `Car.id` etc. tipados como `string`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/prisma/schema.prisma
+git commit -m "feat(produtos): PK de Car/Boat/Aircraft migrada para UUID"
+```
+
+---
+
+### Task B2: Backend — DTOs, service e pipes
+
+**Files:**
+- Modify: `backend/src/features/processes/dto/create-process.dto.ts`
+- Modify: `backend/src/features/processes/dto/assign-product.dto.ts`
+- Modify: `backend/src/features/processes/processes.service.ts`
+- Modify: controllers `cars.controller.ts`, `boats.controller.ts`, `aircrafts.controller.ts`
+
+**Interfaces:**
+- Consumes: schema UUID (B1).
+- Produces: `product_id` como string/UUID ponta a ponta no backend.
+
+- [ ] **Step 1: DTOs — `@IsInt` → `@IsUUID`**
+
+Em `create-process.dto.ts` e `assign-product.dto.ts`, no campo `product_id`, trocar:
+
+```ts
+  @IsUUID('4', { message: 'product_id deve ser um UUID válido' })
+  product_id: string;
+```
+
+Remover o import de `IsInt` se ficar sem uso; adicionar `IsUUID` ao import de `class-validator`. Remover `Min` se só era usado no id.
+
+- [ ] **Step 2: `processes.service.ts` — remover `Number()`**
+
+Nas linhas que fazem `Number(createProcessDto.product_id)` (~214, 274, 278, 282), usar `createProcessDto.product_id` direto (já é string). Os campos `car_id`/`boat_id`/`aircraft_id` agora recebem string.
+
+- [ ] **Step 3: Controllers — remover `ParseIntPipe` de params de id de produto**
+
+Em `cars.controller.ts`, `boats.controller.ts`, `aircrafts.controller.ts`, trocar `@Param('id', ParseIntPipe) id: number` por `@Param('id') id: string`. Remover import de `ParseIntPipe` se ficar sem uso. Ajustar as assinaturas dos métodos de service chamados (id: string).
+
+- [ ] **Step 4: Ajustar services que recebem id numérico**
+
+Em cars/boats/aircrafts service, métodos `findOne`/`update`/`remove` que tipavam `id: number` passam a `id: string`; remover qualquer `Number(id)` interno. `where: { id }` continua válido (agora string).
+
+- [ ] **Step 5: Compilar**
+
+Run: `cd backend && npx tsc --noEmit`
+Expected: sem erros. Corrigir cada `id: number` remanescente que o compilador apontar em produto.
+
+- [ ] **Step 6: Rodar testes de produto/processo focados**
+
+Run: `cd backend && npm test -- cars.service --maxWorkers=2 && npm test -- processes.service --maxWorkers=2`
+Expected: PASS (ou apenas as falhas pré-existentes de comissão já conhecidas — não relacionadas a id).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/features
+git commit -m "refactor(backend): product_id como UUID em DTOs, services e controllers"
+```
+
+---
+
+### Task B3: Frontend — id de produto como string
+
+**Files:**
+- Modify: `frontend/src/services/cars.service.ts`, `boats.service.ts`, `aircrafts.service.ts`
+- Modify: `frontend/src/pages/catalog/ProductPage.tsx`
+- Modify: `frontend/src/pages/specialist/ProductFormPage.tsx`
+
+**Interfaces:**
+- Consumes: API com id UUID (B2).
+- Produces: front tratando id de produto como string.
+
+- [ ] **Step 1: Tipos e assinaturas nos services**
+
+Em cada service, `getXById(id: number)` → `getXById(id: string)`. No tipo `RawCar`/`RawBoat`/`RawAircraft`, `id: number` → `id: string`.
+
+- [ ] **Step 2: `ProductPage.tsx` — remover `Number(id)`**
+
+Trocar `getCarById(Number(id))` → `getCarById(id)` (idem boat/aircraft, linhas ~150/153/156). Nos usos `Number(product.id)` (~298, 368) e `productId={Number(id)}` (~670), passar a string direto. Ajustar props que tipavam `productId: number` para `string`.
+
+- [ ] **Step 3: `specialist/ProductFormPage.tsx` — remover `Number(id)`**
+
+Linha ~31 `const productId = Number(id)` → `const productId = id`. Linha ~87 `productId={id ? Number(id) : undefined}` → `productId={id}`. Ajustar tipos de prop para string.
+
+- [ ] **Step 4: Grep de verificação — nenhum `Number(` sobre id de produto**
+
+Run: `cd frontend && grep -rnE "Number\((id|product\.id|productId)" src`
+Expected: **sem resultados**. (Os `Number()` de filtros de ano/preço em `CatalogPage.tsx` não casam este padrão e devem permanecer.)
+
+- [ ] **Step 5: Build do front**
+
+Run: `cd frontend && npm run build`
+Expected: `tsc -b` sem erros e build conclui. Corrigir qualquer `id: number` de produto que o TS apontar.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src
+git commit -m "refactor(front): id de produto como string (UUID)"
+```
+
+---
+
+## FASE C — Export dos produtos + wipe
+
+### Task C1: Script de export para CSV
+
+**Files:**
+- Create: `backend/scripts/export-produtos-para-csv.ts`
+
+**Interfaces:**
+- Consumes: base **atual** (antes do reset da Task B1 Step 4).
+- Produces: `backend/scripts/out/carros.csv`, `barcos.csv`, `aeronaves.csv` no formato dos templates (com coluna `identificador` preenchida `MARCA-MODELO-seq`).
+
+> **Importante:** este script lê os produtos **antigos** (PK Int, sem coluna `identificador`). Ele gera o `identificador` em memória; não depende do schema novo. Rodar **antes** do `db push --accept-data-loss`.
+
+- [ ] **Step 1: Escrever o script**
+
+```ts
+// backend/scripts/export-produtos-para-csv.ts
+import { PrismaClient } from '@prisma/client';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const prisma = new PrismaClient();
+const OUT = join(__dirname, 'out');
+
+function slug(s: string) {
+  return (s || '')
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+// gera MARCA-MODELO-seq por (specialist, marca, modelo)
+function withIdentificadores<T extends { specialist_id: string | null; marca: string; modelo: string }>(
+  rows: T[],
+): (T & { identificador: string })[] {
+  const counters = new Map<string, number>();
+  return rows.map((r) => {
+    const base = `${slug(r.marca)}-${slug(r.modelo)}`;
+    const key = `${r.specialist_id ?? 'none'}|${base}`;
+    const n = (counters.get(key) ?? 0) + 1;
+    counters.set(key, n);
+    return { ...r, identificador: `${base}-${n}` };
+  });
+}
+
+function toCsv(headers: string[], rows: Record<string, unknown>[]): string {
+  const esc = (v: unknown) => {
+    const s = v == null ? '' : String(v);
+    return /[";\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+  };
+  const lines = [headers.join(';')];
+  for (const row of rows) lines.push(headers.map((h) => esc(row[h])).join(';'));
+  return lines.join('\n');
+}
+
+async function main() {
+  mkdirSync(OUT, { recursive: true });
+
+  const carros = withIdentificadores(await prisma.car.findMany());
+  writeFileSync(
+    join(OUT, 'carros.csv'),
+    toCsv(
+      ['marca', 'modelo', 'identificador', 'valor', 'estado', 'ano', 'cor', 'km', 'cambio', 'combustivel', 'tipo_categoria', 'descricao'],
+      carros,
+    ),
+  );
+
+  const barcos = withIdentificadores(await prisma.boat.findMany());
+  writeFileSync(
+    join(OUT, 'barcos.csv'),
+    toCsv(
+      ['marca', 'modelo', 'identificador', 'valor', 'estado', 'ano', 'fabricante', 'tamanho', 'estilo', 'combustivel', 'motor', 'ano_motor', 'tipo_embarcacao', 'descricao_completa', 'acessorios'],
+      barcos,
+    ),
+  );
+
+  const aeronaves = withIdentificadores(await prisma.aircraft.findMany());
+  writeFileSync(
+    join(OUT, 'aeronaves.csv'),
+    toCsv(
+      ['marca', 'modelo', 'identificador', 'valor', 'estado', 'ano', 'categoria', 'assentos', 'tipo_aeronave', 'descricao'],
+      aeronaves,
+    ),
+  );
+
+  console.log(`Exportado: ${carros.length} carros, ${barcos.length} barcos, ${aeronaves.length} aeronaves em ${OUT}`);
+}
+
+main().finally(() => prisma.$disconnect());
+```
+
+- [ ] **Step 2: Rodar o export (base ANTIGA, antes do reset)**
+
+Run: `cd backend && npx ts-node scripts/export-produtos-para-csv.ts`
+Expected: imprime as contagens e cria `backend/scripts/out/*.csv`. Abrir um CSV e conferir que a coluna `identificador` está preenchida e única por especialista.
+
+- [ ] **Step 3: Commit (só o script; NÃO versionar os CSVs de dados)**
+
+```bash
+echo "scripts/out/" >> backend/.gitignore
+git add backend/scripts/export-produtos-para-csv.ts backend/.gitignore
+git commit -m "chore(scripts): export de produtos para CSV com identificador gerado"
+```
+
+---
+
+### Task C2: Verificação ponta a ponta
+
+**Files:** nenhum (validação manual).
+
+- [ ] **Step 1: Confirmar reset aplicado**
+
+A base já foi resetada na Task B1 Step 4. Confirmar via `npx prisma studio` que `Car` está vazia e `id` é UUID.
+
+- [ ] **Step 2: Re-importar pela plataforma**
+
+Subir `backend` + `frontend` (o usuário roda; não iniciar `nest start --watch` em background nesta máquina). Logado como especialista, importar `carros.csv` / `barcos.csv` / `aeronaves.csv` pela tela de import.
+Expected: import conclui; N produtos criados; nenhum erro de estrutura.
+
+- [ ] **Step 3: Validar o critério das Ferraris**
+
+Num CSV de teste com 2 linhas mesma marca/modelo e `identificador` diferente (`FERRARI-X-1`, `FERRARI-X-2`), importar.
+Expected: 2 produtos ativos distintos. Re-importar o mesmo arquivo → 0 criados, 2 atualizados, 0 duplicados. Remover uma linha e re-importar → o ausente fica inativo.
+
+- [ ] **Step 4: Validar catálogo com UUID**
+
+Abrir a página de um produto no catálogo (`/catalog/...`) e o fluxo de criar processo para esse produto.
+Expected: página carrega com id UUID na URL; processo criado sem erro de `product_id`.
+
+---
+
+## Self-Review (feito na redação)
+
+- **Cobertura do spec:** Fase A (identificador + dedup + validação) → A1–A4. Fase B (UUID back+front) → B1–B3. Fase C (export+wipe+reimport) → C1–C2. Full-sync preservado (não é tocado). ✔
+- **Placeholders:** sem TODO/TBD; todos os steps têm código ou comando concreto. Os pontos "corrigir o que o TS apontar" vêm acompanhados de `tsc --noEmit`/`npm run build` como verificação determinística. ✔
+- **Consistência de tipos:** `identificador: string` (A1) usado igual em colunas (A2) e dedup (A3); `product_id: string`/`@IsUUID` (B2) casa com `getXById(id: string)` (B3). ✔
+- **Ordem crítica:** export (C1) explicitamente antes do `db push --accept-data-loss` (B1 Step 4), com nota cruzada nos dois pontos. ✔

--- a/docs/superpowers/plans/2026-08-04-identificador-manual-e-modal-csv.md
+++ b/docs/superpowers/plans/2026-08-04-identificador-manual-e-modal-csv.md
@@ -1,0 +1,283 @@
+# Identificador no Formulário Manual e no Modal de CSV — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir que um especialista crie um produto (carro/barco/aeronave) pelo formulário manual preenchendo `identificador` (hoje impossível — 400 sempre), e corrigir o modal de import CSV para mostrar `identificador` como coluna obrigatória com uma dica de dedup correta.
+
+**Architecture:** Três mudanças isoladas no frontend, sem tocar backend (o contrato — `identificador` obrigatório + `@@unique([specialist_id, identificador])` — já existe e já está em produção via o fluxo de CSV). Task 1 adiciona o input no componente de campos compartilhados. Task 2 propaga o valor do form pro payload da API e atualiza os tipos TS que descrevem a resposta da API. Task 3 corrige as strings estáticas do modal de CSV.
+
+**Tech Stack:** React + Vite + TypeScript, react-hook-form, axios (via `services/*.service.ts`).
+
+## Global Constraints
+
+- **Sem infraestrutura de teste de componente nova.** Este frontend não tem testes de componente React hoje (só testes de função pura em `lib/*.test.ts` via vitest). Verificação de cada task é manual, com passos exatos — não criar `*.test.tsx` novos.
+- **Sem mudança de backend.** `CreateCarDto`/`CreateBoatDto`/`CreateAircraftDto`, `PrismaExceptionFilter`, e a constraint `@@unique` já existem e não devem ser tocados.
+- **`identificador` é digitado pelo especialista, sem geração automática nem checagem de unicidade em tempo real** (decisão do spec — ver `docs/superpowers/specs/2026-08-04-identificador-manual-e-modal-csv-design.md`).
+- Mensagens de commit em português, seguindo o padrão do repo (`feat:`, `fix:`).
+
+---
+
+## File Structure
+
+- `frontend/src/components/specialist/CommonProductFields.tsx` — adiciona o input `identificador`, compartilhado pelos 3 tipos de produto.
+- `frontend/src/services/cars.service.ts`, `boats.service.ts`, `aircrafts.service.ts` — adiciona `identificador: string` em `RawCar`/`RawBoat`/`RawAircraft`.
+- `frontend/src/components/specialist/ProductForm.tsx` — inclui `identificador` no payload (`formattedData`) enviado pra API.
+- `frontend/src/components/shared/XlsxImporter.tsx` — adiciona `identificador` às colunas obrigatórias exibidas e corrige o texto de dica sobre dedup.
+
+---
+
+## Task 1: Campo `identificador` no formulário manual
+
+**Files:**
+- Modify: `frontend/src/components/specialist/CommonProductFields.tsx`
+
+**Interfaces:**
+- Consumes: nada de outra task (primeira task do plano).
+- Produces: input HTML com `name="identificador"` registrado via `register("identificador", { required: ... })` — Task 2 depende do form emitir esse campo em `data.identificador` no submit.
+
+- [ ] **Step 1: Adicionar `identificador` ao objeto `placeholders`**
+
+Em `CommonProductFields.tsx`, dentro do objeto `placeholders` (começa na linha 11), adicionar uma nova entrada logo após `modelo` (que termina na linha 21):
+
+```tsx
+    modelo: {
+      CAR: "Ex: 488 GTB, 911 Turbo S, Aventador",
+      BOAT: "Ex: S6, Flybridge 68, Manhattan 55",
+      AIRCRAFT: "Ex: Phenom 300, G650, Citation X",
+    },
+    identificador: {
+      CAR: "Ex: BMW-X5-1",
+      BOAT: "Ex: AZIMUT-S6-1",
+      AIRCRAFT: "Ex: EMBRAER-PHENOM300-1",
+    },
+    ano: {
+```
+
+- [ ] **Step 2: Adicionar o campo `identificador` no JSX, entre Modelo e Ano**
+
+O bloco de "Modelo" termina no `</div>` da linha 67, e "Ano" começa no comentário `{/* Ano */}` da linha 69. Inserir entre os dois:
+
+```tsx
+      {/* Identificador */}
+      <div className="flex flex-col gap-2">
+        <label htmlFor="identificador" className="text-sm font-medium text-text-primary">
+          Identificador *
+        </label>
+        <input
+          id="identificador"
+          type="text"
+          {...register("identificador", { required: "Identificador é obrigatório" })}
+          className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder={productType ? placeholders.identificador[productType] : "Ex: BMW-X5-1"}
+        />
+        {errors.identificador && (
+          <span className="text-sm text-red-500">{errors.identificador.message as string}</span>
+        )}
+      </div>
+```
+
+- [ ] **Step 3: Verificar visualmente**
+
+Rodar o frontend: `cd frontend && npm run dev`. Logar como um usuário `SPECIALIST` (ou `ADMIN`) e navegar até `/specialist/products/new`. Confirmar:
+1. Um campo "Identificador *" aparece entre "Modelo" e "Ano", para os 3 tipos de produto (trocar o seletor "Tipo de Produto" se logado como ADMIN).
+2. Clicar em "Criar Produto" sem preencher o campo mostra o erro "Identificador é obrigatório" abaixo do input, sem enviar a requisição (checar aba Network do devtools — nenhuma chamada a `POST /cars`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/specialist/CommonProductFields.tsx
+git commit -m "feat(produtos): adiciona campo identificador no formulario manual"
+```
+
+---
+
+## Task 2: Propagar `identificador` pro payload da API e pros tipos
+
+**Files:**
+- Modify: `frontend/src/services/cars.service.ts:15-42` (interface `RawCar`)
+- Modify: `frontend/src/services/boats.service.ts` (interface `RawBoat`, mesmo padrão de `RawCar`)
+- Modify: `frontend/src/services/aircrafts.service.ts` (interface `RawAircraft`, mesmo padrão de `RawCar`)
+- Modify: `frontend/src/components/specialist/ProductForm.tsx:205-211`
+
+**Interfaces:**
+- Consumes: `data.identificador` do form (produzido pela Task 1 via `register("identificador", ...)`).
+- Produces: `formattedData.identificador` no payload enviado a `createCar`/`updateCar`/`createBoat`/`updateBoat`/`createAircraft`/`updateAircraft`. Nenhuma task depende disso depois — é o fim da cadeia (a API já aceita e persiste esse campo).
+
+- [ ] **Step 1: Adicionar `identificador` na interface `RawCar`**
+
+Em `frontend/src/services/cars.service.ts`, na interface `RawCar` (linha 15), adicionar o campo logo após `modelo`:
+
+```ts
+export interface RawCar {
+  id: string;
+  marca: string;
+  modelo: string;
+  identificador: string;
+  valor: number;
+```
+
+- [ ] **Step 2: Repetir o Step 1 para `RawBoat` e `RawAircraft`**
+
+Abrir `frontend/src/services/boats.service.ts` e `frontend/src/services/aircrafts.service.ts`. Em cada um, achar a interface (`RawBoat`, `RawAircraft`) e adicionar `identificador: string;` logo após o campo `modelo`, mesmo padrão do Step 1.
+
+- [ ] **Step 3: Rodar o type-check pra confirmar que os 3 arquivos compilam**
+
+```bash
+cd frontend && npx tsc -b --noEmit
+```
+
+Expected: sem erros novos relacionados a `RawCar`/`RawBoat`/`RawAircraft` ou `identificador`. (Se já havia erros pré-existentes no repo antes desta mudança, ignore-os — não são escopo desta task.)
+
+- [ ] **Step 4: Incluir `identificador` no payload montado em `ProductForm.tsx`**
+
+Em `frontend/src/components/specialist/ProductForm.tsx`, dentro de `onSubmit` (a partir da linha 205), o objeto `formattedData` hoje é:
+
+```ts
+      const formattedData: any = {
+        marca: data.marca,
+        modelo: data.modelo,
+        ano: Number(data.ano),
+        valor: Number(data.valor),
+        estado: data.estado,
+      };
+```
+
+Adicionar `identificador` (campo comum aos 3 tipos, igual `marca`/`modelo` — não entra nos blocos `if (productType === ...)`):
+
+```ts
+      const formattedData: any = {
+        marca: data.marca,
+        modelo: data.modelo,
+        identificador: data.identificador,
+        ano: Number(data.ano),
+        valor: Number(data.valor),
+        estado: data.estado,
+      };
+```
+
+- [ ] **Step 5: Verificar criação de produto de ponta a ponta**
+
+Com `npm run dev` rodando (frontend) e o backend no ar, logado como `SPECIALIST`:
+
+1. Preencher o formulário em `/specialist/products/new` com um `identificador` novo (ex.: `TESTE-1`) e ao menos uma imagem. Submeter.
+   Expected: alerta "Produto criado com sucesso!", sem erro 400.
+2. Repetir o cadastro com o **mesmo** `identificador` (`TESTE-1`) pro mesmo especialista.
+   Expected: alerta de erro contendo "Já existe um registro" (não um erro técnico cru, não crash da tela) — vem do `PrismaExceptionFilter` (409).
+3. Abrir o produto criado no passo 1 em modo edição (`/specialist/products/:id/edit` ou equivalente na navegação da tela de lista).
+   Expected: o campo "Identificador" já vem preenchido com `TESTE-1` (herdado de `reset(productData as any)` em `ProductForm.tsx:161`, que já espalha todos os campos de `productData` no form — nenhum código adicional necessário pra isso funcionar).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/services/cars.service.ts frontend/src/services/boats.service.ts frontend/src/services/aircrafts.service.ts frontend/src/components/specialist/ProductForm.tsx
+git commit -m "feat(produtos): envia identificador no payload de criacao/edicao"
+```
+
+---
+
+## Task 3: Corrigir modal de import CSV
+
+**Files:**
+- Modify: `frontend/src/components/shared/XlsxImporter.tsx:53-95` (`COLUMN_DEFINITIONS`)
+- Modify: `frontend/src/components/shared/XlsxImporter.tsx:337-342` (texto de dica)
+
+**Interfaces:**
+- Consumes: nada das tasks anteriores — mudança isolada de strings estáticas de UI.
+- Produces: nada consumido por outra task — última task do plano.
+
+- [ ] **Step 1: Adicionar `identificador` às colunas obrigatórias dos 3 tipos**
+
+Em `XlsxImporter.tsx`, `COLUMN_DEFINITIONS` (linha 54), trocar `required: ["marca", "modelo", "valor", "estado", "ano"]` por `required: ["marca", "modelo", "identificador", "valor", "estado", "ano"]` nos 3 blocos (`CAR`, `BOAT`, `AIRCRAFT`):
+
+```tsx
+const COLUMN_DEFINITIONS: Record<
+  ProductType,
+  { required: string[]; optional: string[] }
+> = {
+  CAR: {
+    required: ["marca", "modelo", "identificador", "valor", "estado", "ano"],
+    optional: [
+      "cor",
+      "km",
+      "cambio",
+      "combustivel",
+      "tipo_categoria",
+      "descricao",
+      "folder_url",
+    ],
+  },
+  BOAT: {
+    required: ["marca", "modelo", "identificador", "valor", "estado", "ano"],
+    optional: [
+      "fabricante",
+      "tamanho",
+      "estilo",
+      "combustivel",
+      "motor",
+      "ano_motor",
+      "tipo_embarcacao",
+      "descricao_completa",
+      "acessorios",
+      "folder_url",
+    ],
+  },
+  AIRCRAFT: {
+    required: ["marca", "modelo", "identificador", "valor", "estado", "ano"],
+    optional: [
+      "categoria",
+      "assentos",
+      "tipo_aeronave",
+      "descricao",
+      "folder_url",
+    ],
+  },
+};
+```
+
+- [ ] **Step 2: Corrigir o texto de dica sobre dedup**
+
+Em `XlsxImporter.tsx`, o último item da lista "Dicas" (linhas 337-342) hoje diz:
+
+```tsx
+              <li className="flex items-start gap-2">
+                <span className="w-1 h-1 mt-2 bg-gray-400 rounded-full shrink-0"></span>
+                Produtos com mesma{" "}
+                <strong className="text-gray-900">marca + modelo</strong> serao
+                atualizados ao inves de duplicados.
+              </li>
+```
+
+Substituir por:
+
+```tsx
+              <li className="flex items-start gap-2">
+                <span className="w-1 h-1 mt-2 bg-gray-400 rounded-full shrink-0"></span>
+                Produtos com mesmo{" "}
+                <strong className="text-gray-900">identificador</strong> serao
+                atualizados ao inves de duplicados (marca e modelo podem se
+                repetir entre produtos diferentes).
+              </li>
+```
+
+- [ ] **Step 3: Verificar visualmente**
+
+Com `npm run dev` rodando, abrir `/specialist/products/new`, clicar em "Upload Planilha" e expandir "Ver estrutura da planilha". Confirmar:
+1. `identificador` aparece no grupo "Colunas Obrigatorias" (chip vermelho), pros 3 tipos de produto (trocar o seletor de tipo se aplicável).
+2. O último item de "Dicas" menciona `identificador` como chave de dedup, não mais "marca + modelo".
+3. Clicar em "Baixar Template" ainda funciona (não foi tocado nesta task — o template já inclui `identificador`, gerado pelo backend).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/shared/XlsxImporter.tsx
+git commit -m "fix(produtos): modal de import CSV mostra identificador como obrigatorio e corrige dica de dedup"
+```
+
+---
+
+## Critérios de aceitação (do spec)
+
+1. Criar um carro/barco/aeronave pelo formulário manual, preenchendo `identificador`, salva com sucesso (sem 400). → coberto pela verificação da Task 2.
+2. Tentar criar um segundo produto do mesmo especialista com o mesmo `identificador` mostra mensagem de erro amigável na tela. → coberto pela verificação da Task 2.
+3. Modal de import CSV mostra `identificador` na lista de colunas obrigatórias, para os 3 tipos de produto. → coberto pela verificação da Task 3.
+4. Texto de dica do modal não afirma mais que dedup é por marca+modelo; descreve corretamente o dedup por `identificador`. → coberto pela verificação da Task 3.

--- a/docs/superpowers/plans/2026-08-04-mascara-documentos-telefone.md
+++ b/docs/superpowers/plans/2026-08-04-mascara-documentos-telefone.md
@@ -1,0 +1,1208 @@
+# Máscara de CPF/CNPJ/RG/Telefone — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidar e aplicar máscara de exibição (pontuação) em todos os campos de CPF/CNPJ/RG/telefone da plataforma — sempre pontuado na tela, sempre sem pontuação no banco, nunca com dígitos ocultos — e corrigir o bug do `CreateContractPage` que hoje envia documentos pontuados para o backend.
+
+**Architecture:** Um único módulo `frontend/src/utils/mask.ts` concentra as funções puras de máscara (mesma função serve para "enquanto digita" e para "exibir valor salvo", pois ambas são apenas formatação de uma string de dígitos). Cada tela consumidora aplica a máscara no `onChange` e faz `stripFormatting()` antes de enviar ao backend. No backend, o RG passa a aceitar 11 dígitos (CPF, por causa da unificação RG/CPF) e o `ContractsService` ganha uma função pura `stripContractDocumentFields` para higienizar documentos antes de gravar no banco — defesa em profundidade complementar à correção no frontend.
+
+**Tech Stack:** React + TypeScript (frontend, Vitest), NestJS + class-validator (backend, Jest), Prisma/PostgreSQL.
+
+## Global Constraints
+
+- Documentos e telefone são **sempre salvos no banco sem pontuação** (apenas dígitos).
+- Documentos e telefone são **sempre exibidos ao usuário com pontuação completa** — nunca com dígitos ocultos/mascarados por segurança (não é esse tipo de "máscara").
+- RG aceita um CPF completo (11 dígitos) como valor válido, devido à unificação RG/CPF — quando tiver 10-11 dígitos, formata como CPF; com 7-9 dígitos, usa o agrupamento de RG.
+- Rodar testes com paralelismo limitado nesta máquina: backend `npm test -- --maxWorkers=2 <arquivo>`, frontend `npx vitest run <arquivo>` (Vitest não sobe múltiplos processos pesados por padrão, mas evite rodar a suíte inteira junto com outro processo pesado).
+- Fora de escopo: `frontend/src/pages/admin/DatabasePage.tsx` (viewer genérico de debug), `formatBRL` e demais formatadores não relacionados a documento/telefone.
+
+---
+
+### Task 1: Criar `frontend/src/utils/mask.ts`
+
+**Files:**
+- Create: `frontend/src/utils/mask.ts`
+- Test: `frontend/src/utils/mask.test.ts`
+
+**Interfaces:**
+- Produces: `stripFormatting(value: string): string`, `applyCpfMask(value: string): string`, `applyCnpjMask(value: string): string`, `applyCepMask(value: string): string`, `applyRgMask(value: string): string`, `applyPhoneMask(value: string): string` — todas puras, aceitam qualquer string (com ou sem pontuação) e devolvem a string formatada.
+
+- [ ] **Step 1: Escrever o teste**
+
+```typescript
+// frontend/src/utils/mask.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  stripFormatting,
+  applyCpfMask,
+  applyCnpjMask,
+  applyCepMask,
+  applyRgMask,
+  applyPhoneMask,
+} from "./mask";
+
+describe("stripFormatting", () => {
+  it("remove tudo que não é dígito", () => {
+    expect(stripFormatting("123.456.789-00")).toBe("12345678900");
+    expect(stripFormatting("(11) 99999-9999")).toBe("11999999999");
+    expect(stripFormatting("")).toBe("");
+  });
+});
+
+describe("applyCpfMask", () => {
+  it("aplica pontuação progressivamente enquanto digita", () => {
+    expect(applyCpfMask("123")).toBe("123");
+    expect(applyCpfMask("123456")).toBe("123.456");
+    expect(applyCpfMask("123456789")).toBe("123.456.789");
+    expect(applyCpfMask("12345678900")).toBe("123.456.789-00");
+  });
+
+  it("ignora pontuação já existente e trunca em 11 dígitos", () => {
+    expect(applyCpfMask("123.456.789-00")).toBe("123.456.789-00");
+    expect(applyCpfMask("1234567890099999")).toBe("123.456.789-00");
+  });
+});
+
+describe("applyCnpjMask", () => {
+  it("aplica pontuação progressivamente enquanto digita", () => {
+    expect(applyCnpjMask("12")).toBe("12");
+    expect(applyCnpjMask("12345678000199")).toBe("12.345.678/0001-99");
+  });
+
+  it("trunca em 14 dígitos", () => {
+    expect(applyCnpjMask("123456780001999999")).toBe("12.345.678/0001-99");
+  });
+});
+
+describe("applyCepMask", () => {
+  it("formata CEP de 8 dígitos", () => {
+    expect(applyCepMask("01234567")).toBe("01234-567");
+    expect(applyCepMask("01234")).toBe("01234");
+  });
+});
+
+describe("applyRgMask", () => {
+  it("agrupa RG de 7, 8 ou 9 dígitos", () => {
+    expect(applyRgMask("1234567")).toBe("1.234.567");
+    expect(applyRgMask("12345678")).toBe("12.345.678");
+    expect(applyRgMask("123456789")).toBe("12.345.678-9");
+  });
+
+  it("delega para máscara de CPF a partir de 10 dígitos (unificação RG/CPF)", () => {
+    expect(applyRgMask("1234567890")).toBe("123.456.789-0");
+    expect(applyRgMask("12345678900")).toBe("123.456.789-00");
+  });
+
+  it("trunca em 11 dígitos", () => {
+    expect(applyRgMask("123456789001234")).toBe("123.456.789-00");
+  });
+});
+
+describe("applyPhoneMask", () => {
+  it("formata celular de 9 dígitos locais (DDD + 9)", () => {
+    expect(applyPhoneMask("11987654321")).toBe("(11) 98765-4321");
+  });
+
+  it("formata fixo de 8 dígitos locais (DDD + 8)", () => {
+    expect(applyPhoneMask("1132654321")).toBe("(11) 3265-4321");
+  });
+
+  it("formata progressivamente enquanto digita", () => {
+    expect(applyPhoneMask("11")).toBe("(11");
+    expect(applyPhoneMask("1198765")).toBe("(11) 98765");
+  });
+
+  it("trunca em 11 dígitos", () => {
+    expect(applyPhoneMask("119876543219999")).toBe("(11) 98765-4321");
+  });
+});
+```
+
+- [ ] **Step 2: Rodar o teste e confirmar que falha**
+
+Run: `cd frontend && npx vitest run src/utils/mask.test.ts`
+Expected: FAIL — `Cannot find module './mask'`
+
+- [ ] **Step 3: Implementar `frontend/src/utils/mask.ts`**
+
+```typescript
+/**
+ * Utilitários de máscara para documentos (CPF/CNPJ/RG/CEP) e telefone.
+ *
+ * Documentos e telefone são sempre salvos no banco sem pontuação
+ * (stripFormatting antes do submit) e sempre exibidos ao usuário
+ * pontuados. Estas funções nunca ocultam dígitos — apenas formatam.
+ */
+
+/** Remove tudo que não é dígito. */
+export function stripFormatting(value: string): string {
+  if (!value) return "";
+  return value.replace(/\D/g, "");
+}
+
+/** Aplica máscara de CPF (###.###.###-##) enquanto o usuário digita. */
+export function applyCpfMask(value: string): string {
+  const digits = stripFormatting(value).slice(0, 11);
+  let formatted = digits;
+  if (digits.length > 3) formatted = digits.slice(0, 3) + "." + digits.slice(3);
+  if (digits.length > 6)
+    formatted = formatted.slice(0, 7) + "." + digits.slice(6);
+  if (digits.length > 9)
+    formatted = formatted.slice(0, 11) + "-" + digits.slice(9);
+  return formatted;
+}
+
+/** Aplica máscara de CNPJ (##.###.###/####-##) enquanto o usuário digita. */
+export function applyCnpjMask(value: string): string {
+  const digits = stripFormatting(value).slice(0, 14);
+  let formatted = digits;
+  if (digits.length > 2) formatted = digits.slice(0, 2) + "." + digits.slice(2);
+  if (digits.length > 5)
+    formatted = formatted.slice(0, 6) + "." + digits.slice(5);
+  if (digits.length > 8)
+    formatted = formatted.slice(0, 10) + "/" + digits.slice(8);
+  if (digits.length > 12)
+    formatted = formatted.slice(0, 15) + "-" + digits.slice(12);
+  return formatted;
+}
+
+/** Aplica máscara de CEP (#####-###) enquanto o usuário digita. */
+export function applyCepMask(value: string): string {
+  const digits = stripFormatting(value).slice(0, 8);
+  if (digits.length > 5) {
+    return digits.slice(0, 5) + "-" + digits.slice(5);
+  }
+  return digits;
+}
+
+/**
+ * Aplica máscara de RG (#.###.###-#, variável de 7 a 9 dígitos).
+ * A partir de 10 dígitos, o valor é tratado como CPF (unificação RG/CPF)
+ * e formatado como tal.
+ */
+export function applyRgMask(value: string): string {
+  const digits = stripFormatting(value);
+  if (digits.length >= 10) {
+    return applyCpfMask(digits);
+  }
+  const truncated = digits.slice(0, 9);
+  if (truncated.length === 9) {
+    return truncated.replace(/(\d{2})(\d{3})(\d{3})(\d{1})/, "$1.$2.$3-$4");
+  }
+  if (truncated.length === 8) {
+    return truncated.replace(/(\d{2})(\d{3})(\d{3})/, "$1.$2.$3");
+  }
+  if (truncated.length === 7) {
+    return truncated.replace(/(\d{1})(\d{3})(\d{3})/, "$1.$2.$3");
+  }
+  return truncated;
+}
+
+/**
+ * Aplica máscara de telefone local: (##) ####-#### (8 dígitos) ou
+ * (##) #####-#### (9 dígitos), enquanto o usuário digita.
+ */
+export function applyPhoneMask(value: string): string {
+  const digits = stripFormatting(value).slice(0, 11);
+  if (digits.length <= 2) return digits.length ? `(${digits}` : digits;
+  const local = digits.slice(2);
+  if (local.length <= 4) return `(${digits.slice(0, 2)}) ${local}`;
+  const dashAt = local.length >= 9 ? 5 : 4;
+  return `(${digits.slice(0, 2)}) ${local.slice(0, dashAt)}-${local.slice(dashAt)}`;
+}
+```
+
+- [ ] **Step 4: Rodar o teste e confirmar que passa**
+
+Run: `cd frontend && npx vitest run src/utils/mask.test.ts`
+Expected: PASS (todos os casos)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/utils/mask.ts frontend/src/utils/mask.test.ts
+git commit -m "feat(frontend): utilitário compartilhado de máscara de documento/telefone"
+```
+
+---
+
+### Task 2: Migrar `contracts.service.ts` e `CreateContractPage.tsx` para o util compartilhado
+
+**Files:**
+- Modify: `frontend/src/services/contracts.service.ts`
+- Modify: `frontend/src/pages/specialist/CreateContractPage.tsx`
+
+**Interfaces:**
+- Consumes: `stripFormatting`, `applyCpfMask`, `applyCnpjMask`, `applyCepMask`, `applyRgMask` de `frontend/src/utils/mask.ts` (Task 1).
+
+- [ ] **Step 1: Remover as funções de máscara duplicadas de `contracts.service.ts`**
+
+Em `frontend/src/services/contracts.service.ts`:
+- Adicionar no topo do arquivo: `import { stripFormatting, applyCpfMask, applyCnpjMask, applyCepMask } from "../utils/mask";`
+- Remover as declarações locais de `stripFormatting`, `applyCpfMask`, `applyCnpjMask`, `applyCepMask` (linhas ~390-486, mantendo `formatBRL` que fica no arquivo).
+- Remover também `formatCpf`, `formatCnpj`, `formatCep`, `formatRg` (linhas ~398-434) — são código morto (nenhum import externo os usa, confirmado via grep no repo).
+- Todas as 41 chamadas internas a `stripFormatting(...)` no restante do arquivo continuam funcionando normalmente, agora resolvendo para a versão importada.
+
+- [ ] **Step 2: Atualizar o import em `CreateContractPage.tsx`**
+
+Em `frontend/src/pages/specialist/CreateContractPage.tsx`, trocar:
+
+```typescript
+import {
+  prefillContract,
+  previewContract,
+  sendContractAfterPreview,
+  cancelContractPreview,
+  listContractTemplates,
+  type GenerateContractData,
+  type PrefillContractResponse,
+  type PreviewContractData,
+  type PreviewContractResponse,
+  type ContractTemplate,
+  applyCpfMask,
+  applyCnpjMask,
+  applyCepMask,
+  formatBRL,
+} from "../../services/contracts.service";
+```
+
+por:
+
+```typescript
+import {
+  prefillContract,
+  previewContract,
+  sendContractAfterPreview,
+  cancelContractPreview,
+  listContractTemplates,
+  type GenerateContractData,
+  type PrefillContractResponse,
+  type PreviewContractData,
+  type PreviewContractResponse,
+  type ContractTemplate,
+  formatBRL,
+} from "../../services/contracts.service";
+import {
+  applyCpfMask,
+  applyCnpjMask,
+  applyCepMask,
+  applyRgMask,
+  stripFormatting,
+} from "../../utils/mask";
+```
+
+(`applyRgMask` e `stripFormatting` são usados nas Tasks 3 e 4 abaixo — importar já agora evita um segundo diff no mesmo bloco de import.)
+
+- [ ] **Step 3: Verificar que o build de tipos passa**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros novos relacionados a `mask.ts`/`contracts.service.ts`/`CreateContractPage.tsx`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/services/contracts.service.ts frontend/src/pages/specialist/CreateContractPage.tsx
+git commit -m "refactor(frontend): mover máscara de documento p/ utils/mask.ts, remover código morto"
+```
+
+---
+
+### Task 3: Corrigir `CreateContractPage.tsx` — máscara faltante e strip antes do submit
+
+**Files:**
+- Modify: `frontend/src/pages/specialist/CreateContractPage.tsx`
+
+**Interfaces:**
+- Consumes: `applyCpfMask`, `applyCnpjMask`, `applyCepMask`, `applyRgMask`, `stripFormatting` de `frontend/src/utils/mask.ts` (import já feito na Task 2).
+
+- [ ] **Step 1: Adicionar máscara em `buyer_cpf` (hoje só `seller_cpf` tem)**
+
+Localizar o `register("buyer_cpf", {...})` (por volta da linha 1066-1069) e trocar pelo mesmo padrão de `Controller` + `applyCpfMask` já usado em `seller_cpf` (linhas ~873-882):
+
+```typescript
+<Controller
+  name="buyer_cpf"
+  control={control}
+  render={({ field }) => (
+    <input
+      {...field}
+      type="text"
+      onChange={(e) => field.onChange(applyCpfMask(e.target.value))}
+      // ...manter demais props (className, placeholder etc.) já existentes no input atual
+    />
+  )}
+/>
+```
+
+Manter todas as props visuais/validação já existentes no input atual — só a fonte do valor (`register` puro → `Controller` com `applyCpfMask`) muda, espelhando exatamente o bloco de `seller_cpf`.
+
+- [ ] **Step 2: Adicionar máscara em `seller_rg` e `buyer_rg`**
+
+Nos dois pontos onde `seller_rg`/`buyer_rg` são registrados via `register(...)` puro (linhas ~903 e ~1084), trocar para `Controller` + `applyRgMask`, mesmo padrão do Step 1:
+
+```typescript
+<Controller
+  name="seller_rg"
+  control={control}
+  render={({ field }) => (
+    <input
+      {...field}
+      type="text"
+      onChange={(e) => field.onChange(applyRgMask(e.target.value))}
+      // manter demais props existentes
+    />
+  )}
+/>
+```
+
+Repetir de forma análoga para `buyer_rg`.
+
+- [ ] **Step 3: Formatar o prefill de RG**
+
+Nos pontos onde `data.seller.rg`/`data.buyer.rg` populam o form (linhas ~240 e ~254, junto dos já existentes `applyCpfMask(data.seller.cpf)`), envolver com `applyRgMask`:
+
+```typescript
+seller_rg: data.seller.rg ? applyRgMask(data.seller.rg) : "",
+// ...
+buyer_rg: data.buyer.rg ? applyRgMask(data.buyer.rg) : "",
+```
+
+- [ ] **Step 4: Corrigir `buildContractData` para enviar documentos sem pontuação**
+
+Em `buildContractData` (linhas ~403-462), envolver todos os campos de documento/CEP com `stripFormatting`, preservando os `|| undefined` já existentes:
+
+```typescript
+const buildContractData = (
+  formData: ContractFormData,
+): GenerateContractData => ({
+  process_id: processId!,
+  template_id: selectedTemplateId || undefined,
+  seller_name: formData.seller_name,
+  seller_email: formData.seller_email,
+  seller_cpf: stripFormatting(formData.seller_cpf),
+  seller_rg: formData.seller_rg ? stripFormatting(formData.seller_rg) : undefined,
+  seller_address: formData.seller_address,
+  seller_cep: stripFormatting(formData.seller_cep),
+  seller_bank: formData.seller_bank,
+  seller_agency: formData.seller_agency,
+  seller_checking_account: formData.seller_checking_account,
+  buyer_name: formData.buyer_name,
+  buyer_email: formData.buyer_email,
+  buyer_cpf: stripFormatting(formData.buyer_cpf),
+  buyer_rg: formData.buyer_rg ? stripFormatting(formData.buyer_rg) : undefined,
+  buyer_address: formData.buyer_address,
+  buyer_cep: stripFormatting(formData.buyer_cep),
+  vehicle_model: formData.vehicle_model,
+  vehicle_year: formData.vehicle_year,
+  vehicle_registration_id: formData.vehicle_registration_id,
+  vehicle_serial_number: formData.vehicle_serial_number,
+  vehicle_technical_info: formData.vehicle_technical_info || undefined,
+  vehicle_price: formData.vehicle_price,
+  payment_seller_value: formData.payment_seller_value,
+  total_commission_rate: formData.total_commission_rate,
+  platform_name: formData.platform_name || undefined,
+  platform_cnpj: formData.platform_cnpj
+    ? stripFormatting(formData.platform_cnpj)
+    : undefined,
+  platform_bank: formData.platform_bank || undefined,
+  platform_agency: formData.platform_agency || undefined,
+  platform_checking_account:
+    formData.platform_checking_account || undefined,
+  office_name: formData.office_name || undefined,
+  office_cnpj: formData.office_cnpj
+    ? stripFormatting(formData.office_cnpj)
+    : undefined,
+  office_bank: formData.office_bank || undefined,
+  office_agency: formData.office_agency || undefined,
+  office_checking_account: formData.office_checking_account || undefined,
+  specialist_name: formData.specialist_name || undefined,
+  specialist_email: formData.specialist_email || undefined,
+  specialist_document: formData.specialist_document
+    ? stripFormatting(formData.specialist_document)
+    : undefined,
+  specialist_bank: formData.specialist_bank || undefined,
+  specialist_agency: formData.specialist_agency || undefined,
+  specialist_checking_account:
+    formData.specialist_checking_account || undefined,
+  testimonial1_name: formData.testimonial1_name || undefined,
+  testimonial1_cpf: formData.testimonial1_cpf
+    ? stripFormatting(formData.testimonial1_cpf)
+    : undefined,
+  testimonial1_email: formData.testimonial1_email || undefined,
+  testimonial2_name: formData.testimonial2_name || undefined,
+  testimonial2_cpf: formData.testimonial2_cpf
+    ? stripFormatting(formData.testimonial2_cpf)
+    : undefined,
+  testimonial2_email: formData.testimonial2_email || undefined,
+  city: formData.city,
+  description: formData.description || undefined,
+});
+```
+
+- [ ] **Step 5: Verificar build de tipos**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/specialist/CreateContractPage.tsx
+git commit -m "fix(frontend): mascarar buyer_cpf/rg e enviar documentos sem pontuação no contrato"
+```
+
+---
+
+### Task 4: Backend — RG aceita CPF (unificação) e defesa contra documento pontuado
+
+**Files:**
+- Modify: `backend/src/auth/dto/auth.ts`
+- Modify: `backend/src/features/consultants/dto/create-consultant.dto.ts`
+- Modify: `backend/src/features/specialists/dto/create-specialist.dto.ts`
+- Modify: `backend/src/features/specialists/dto/update-specialist.dto.ts`
+- Modify: `backend/src/features/users/dto/update-user.dto.ts`
+- Modify: `backend/src/shared/utils/format.utils.ts`
+- Create: `backend/src/shared/utils/format.utils.spec.ts`
+- Modify: `backend/src/features/contracts/contracts.service.ts`
+- Modify: `backend/src/features/contracts/contracts.service.spec.ts`
+
+**Interfaces:**
+- Produces: `formatRg(value: string): string` (estendido), `stripContractDocumentFields(fields: ContractDocumentFields): ContractDocumentFields` (novo, exportado de `contracts.service.ts`).
+
+- [ ] **Step 1: Relaxar o limite de RG nos DTOs de registro (`backend/src/auth/dto/auth.ts`)**
+
+Nas 4 classes (`UserRegisterDto`, `RegisterConsultantDto`, `RegisterOfficeDto`, `RegisterSpecialistDto`), trocar cada ocorrência de:
+
+```typescript
+@Length(7, 10, { message: 'RG deve ter entre 7 e 10 dígitos' })
+@Matches(/^\d{7,10}$/, {
+  message: 'RG deve conter apenas números (7-10 dígitos)',
+})
+rg: string;
+```
+
+por:
+
+```typescript
+@Length(7, 11, { message: 'RG deve ter entre 7 e 11 dígitos' })
+@Matches(/^\d{7,11}$/, {
+  message: 'RG deve conter apenas números (7-11 dígitos)',
+})
+rg: string;
+```
+
+- [ ] **Step 2: Relaxar `create-consultant.dto.ts`**
+
+Em `backend/src/features/consultants/dto/create-consultant.dto.ts`, trocar:
+
+```typescript
+@Length(9, 10, { message: 'RG deve ter entre 9 e 10 dígitos' })
+```
+
+por:
+
+```typescript
+@Length(9, 11, { message: 'RG deve ter entre 9 e 11 dígitos' })
+```
+
+(`@Matches(/^\d+$/)` já aceita qualquer quantidade de dígitos — não precisa mudar.)
+
+- [ ] **Step 3: Relaxar `create-specialist.dto.ts`**
+
+Em `backend/src/features/specialists/dto/create-specialist.dto.ts`, trocar:
+
+```typescript
+@Length(9, 9, { message: 'RG deve ter exatamente 9 dígitos' })
+```
+
+por:
+
+```typescript
+@Length(9, 11, { message: 'RG deve ter entre 9 e 11 dígitos' })
+```
+
+- [ ] **Step 4: Relaxar `update-specialist.dto.ts`**
+
+Em `backend/src/features/specialists/dto/update-specialist.dto.ts`, trocar:
+
+```typescript
+@Matches(/^\d{9,10}$/, { message: 'RG deve conter 9 ou 10 dígitos' })
+```
+
+por:
+
+```typescript
+@Matches(/^\d{9,11}$/, { message: 'RG deve conter entre 9 e 11 dígitos' })
+```
+
+- [ ] **Step 5: Relaxar `update-user.dto.ts`**
+
+Em `backend/src/features/users/dto/update-user.dto.ts`, trocar:
+
+```typescript
+@Matches(/^\d{9,10}$/, {
+  message: 'RG deve conter entre 9 e 10 dígitos numéricos',
+})
+```
+
+por:
+
+```typescript
+@Matches(/^\d{9,11}$/, {
+  message: 'RG deve conter entre 9 e 11 dígitos numéricos',
+})
+```
+
+Atualizar também o comentário do cabeçalho da classe (linha ~17: `RG (de 9 a 10 dígitos)` → `RG (de 9 a 11 dígitos — 11 quando for um CPF, pela unificação RG/CPF)`).
+
+- [ ] **Step 6: Escrever o teste de `formatRg` estendido**
+
+```typescript
+// backend/src/shared/utils/format.utils.spec.ts
+import { formatRg } from './format.utils';
+
+describe('formatRg', () => {
+  it('formata RG de 7, 8 ou 9 dígitos', () => {
+    expect(formatRg('1234567')).toBe('1.234.567');
+    expect(formatRg('12345678')).toBe('12.345.678');
+    expect(formatRg('123456789')).toBe('12.345.678-9');
+  });
+
+  it('formata como CPF quando tiver 11 dígitos (unificação RG/CPF)', () => {
+    expect(formatRg('12345678900')).toBe('123.456.789-00');
+  });
+
+  it('devolve o valor original para tamanhos inválidos', () => {
+    expect(formatRg('123')).toBe('123');
+  });
+});
+```
+
+- [ ] **Step 7: Rodar o teste e confirmar que falha**
+
+Run: `cd backend && npm test -- --maxWorkers=2 format.utils.spec`
+Expected: FAIL no caso de 11 dígitos (hoje `formatRg` devolve o valor cru para qualquer tamanho fora de 7-9).
+
+- [ ] **Step 8: Estender `formatRg` em `backend/src/shared/utils/format.utils.ts`**
+
+Trocar:
+
+```typescript
+export function formatRg(value: string): string {
+  if (!value) return '';
+  const digits = value.replace(/\D/g, '');
+  if (digits.length < 7 || digits.length > 9) return value;
+  // RG pode ter 7, 8 ou 9 dígitos dependendo do estado
+  if (digits.length === 9) {
+    return digits.replace(/(\d{2})(\d{3})(\d{3})(\d{1})/, '$1.$2.$3-$4');
+  }
+  if (digits.length === 8) {
+    return digits.replace(/(\d{2})(\d{3})(\d{3})/, '$1.$2.$3');
+  }
+  return digits.replace(/(\d{1})(\d{3})(\d{3})/, '$1.$2.$3');
+}
+```
+
+por:
+
+```typescript
+export function formatRg(value: string): string {
+  if (!value) return '';
+  const digits = value.replace(/\D/g, '');
+  // Unificação RG/CPF: 10-11 dígitos é um CPF sendo usado como documento de RG.
+  if (digits.length >= 10 && digits.length <= 11) {
+    return formatCpf(digits);
+  }
+  if (digits.length < 7 || digits.length > 9) return value;
+  // RG pode ter 7, 8 ou 9 dígitos dependendo do estado
+  if (digits.length === 9) {
+    return digits.replace(/(\d{2})(\d{3})(\d{3})(\d{1})/, '$1.$2.$3-$4');
+  }
+  if (digits.length === 8) {
+    return digits.replace(/(\d{2})(\d{3})(\d{3})/, '$1.$2.$3');
+  }
+  return digits.replace(/(\d{1})(\d{3})(\d{3})/, '$1.$2.$3');
+}
+```
+
+- [ ] **Step 9: Rodar o teste e confirmar que passa**
+
+Run: `cd backend && npm test -- --maxWorkers=2 format.utils.spec`
+Expected: PASS
+
+- [ ] **Step 10: Escrever o teste de `stripContractDocumentFields`**
+
+Adicionar ao final de `backend/src/features/contracts/contracts.service.spec.ts` (novo `describe`, sem tocar nos existentes):
+
+```typescript
+import { stripContractDocumentFields } from './contracts.service';
+
+describe('stripContractDocumentFields', () => {
+  it('remove pontuação de todos os campos de documento e CEP', () => {
+    const result = stripContractDocumentFields({
+      seller_cpf: '123.456.789-00',
+      seller_rg: '12.345.678-9',
+      seller_cep: '01234-567',
+      buyer_cpf: '987.654.321-00',
+      buyer_rg: undefined,
+      buyer_cep: '09876-543',
+      platform_cnpj: '12.345.678/0001-99',
+      office_cnpj: '98.765.432/0001-11',
+      specialist_document: '11.222.333/0001-44',
+      testimonial1_cpf: '111.222.333-44',
+      testimonial2_cpf: undefined,
+    });
+
+    expect(result).toEqual({
+      seller_cpf: '12345678900',
+      seller_rg: '123456789',
+      seller_cep: '01234567',
+      buyer_cpf: '98765432100',
+      buyer_rg: undefined,
+      buyer_cep: '09876543',
+      platform_cnpj: '12345678000199',
+      office_cnpj: '98765432000111',
+      specialist_document: '11222333000144',
+      testimonial1_cpf: '11122233344',
+      testimonial2_cpf: undefined,
+    });
+  });
+
+  it('mantém undefined como undefined (não vira string vazia)', () => {
+    const result = stripContractDocumentFields({
+      seller_cpf: '12345678900',
+      seller_rg: undefined,
+      seller_cep: '01234567',
+      buyer_cpf: '98765432100',
+      buyer_rg: undefined,
+      buyer_cep: '09876543',
+      platform_cnpj: undefined,
+      office_cnpj: undefined,
+      specialist_document: undefined,
+      testimonial1_cpf: undefined,
+      testimonial2_cpf: undefined,
+    });
+
+    expect(result.platform_cnpj).toBeUndefined();
+    expect(result.testimonial1_cpf).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 11: Rodar o teste e confirmar que falha**
+
+Run: `cd backend && npm test -- --maxWorkers=2 contracts.service.spec`
+Expected: FAIL — `stripContractDocumentFields is not exported`
+
+- [ ] **Step 12: Implementar `stripContractDocumentFields` em `contracts.service.ts`**
+
+Adicionar `stripFormatting` ao import já existente de `src/shared/utils/format.utils`:
+
+```typescript
+import {
+  formatCpf,
+  formatCnpj,
+  formatDocument,
+  formatCep,
+  formatRg,
+  formatBRL,
+  numberToWords,
+  stripFormatting,
+} from 'src/shared/utils/format.utils';
+```
+
+Adicionar, antes da declaração da classe `ContractsService` (função pura de módulo, testável sem instanciar o serviço):
+
+```typescript
+export interface ContractDocumentFields {
+  seller_cpf?: string;
+  seller_rg?: string;
+  seller_cep?: string;
+  buyer_cpf?: string;
+  buyer_rg?: string;
+  buyer_cep?: string;
+  platform_cnpj?: string;
+  office_cnpj?: string;
+  specialist_document?: string;
+  testimonial1_cpf?: string;
+  testimonial2_cpf?: string;
+}
+
+/**
+ * Remove pontuação de todos os campos de documento/CEP do contrato antes de
+ * gravar no banco — defesa em profundidade caso o chamador (frontend ou
+ * integração futura) envie o valor já formatado. Recebe o DTO completo
+ * (que tem mais campos além destes 11) e devolve só os campos
+ * higienizados — os call sites leem `cleanDocs.seller_cpf` etc. e
+ * continuam lendo os demais campos direto de `dto`.
+ */
+export function stripContractDocumentFields(
+  fields: ContractDocumentFields,
+): ContractDocumentFields {
+  const strip = (v?: string) => (v ? stripFormatting(v) : v);
+  return {
+    seller_cpf: strip(fields.seller_cpf),
+    seller_rg: strip(fields.seller_rg),
+    seller_cep: strip(fields.seller_cep),
+    buyer_cpf: strip(fields.buyer_cpf),
+    buyer_rg: strip(fields.buyer_rg),
+    buyer_cep: strip(fields.buyer_cep),
+    platform_cnpj: strip(fields.platform_cnpj),
+    office_cnpj: strip(fields.office_cnpj),
+    specialist_document: strip(fields.specialist_document),
+    testimonial1_cpf: strip(fields.testimonial1_cpf),
+    testimonial2_cpf: strip(fields.testimonial2_cpf),
+  };
+}
+```
+
+- [ ] **Step 13: Rodar o teste e confirmar que passa**
+
+Run: `cd backend && npm test -- --maxWorkers=2 contracts.service.spec`
+Expected: PASS (inclusive os testes pré-existentes de `resolveCommissionFromTotal`/`buildFormFields` continuam passando).
+
+- [ ] **Step 14: Usar `stripContractDocumentFields` nos dois pontos onde o contrato é gravado**
+
+No método que grava o contrato direto (bloco `tx.contract.create` por volta da linha 734, dentro do fluxo de `generateContract`), logo antes do `const contract = await tx.contract.create({`, adicionar:
+
+```typescript
+const cleanDocs = stripContractDocumentFields(dto);
+```
+
+E dentro do `data: { ... }` desse `create`, trocar as 11 linhas correspondentes de `dto.X` para `cleanDocs.X`:
+
+```typescript
+seller_cpf: cleanDocs.seller_cpf,
+seller_rg: cleanDocs.seller_rg,
+seller_cep: cleanDocs.seller_cep,
+// ...
+buyer_cpf: cleanDocs.buyer_cpf,
+buyer_rg: cleanDocs.buyer_rg,
+buyer_cep: cleanDocs.buyer_cep,
+// ...
+platform_cnpj: cleanDocs.platform_cnpj,
+// ...
+office_cnpj: cleanDocs.office_cnpj,
+// ...
+specialist_document: cleanDocs.specialist_document,
+// ...
+testimonial1_cpf: cleanDocs.testimonial1_cpf || null,
+// ...
+testimonial2_cpf: cleanDocs.testimonial2_cpf || null,
+```
+
+(Manter todos os outros campos do `data: {...}` — `seller_name`, `seller_address`, `seller_bank` etc. — exatamente como estão, só os 11 campos de documento/CEP mudam de fonte.)
+
+Repetir exatamente o mesmo ajuste (`const cleanDocs = stripContractDocumentFields(dto);` + trocar as mesmas 11 linhas) no segundo bloco `tx.contract.create` dentro de `sendContractAfterPreview` (por volta da linha 1388).
+
+- [ ] **Step 15: Rodar a suíte de contratos e confirmar que passa**
+
+Run: `cd backend && npm test -- --maxWorkers=2 contracts.service.spec`
+Expected: PASS
+
+- [ ] **Step 16: Build do backend**
+
+Run: `cd backend && npm run build`
+Expected: sem erros de tipo.
+
+- [ ] **Step 17: Commit**
+
+```bash
+git add backend/src/auth/dto/auth.ts backend/src/features/consultants/dto/create-consultant.dto.ts backend/src/features/specialists/dto/create-specialist.dto.ts backend/src/features/specialists/dto/update-specialist.dto.ts backend/src/features/users/dto/update-user.dto.ts backend/src/shared/utils/format.utils.ts backend/src/shared/utils/format.utils.spec.ts backend/src/features/contracts/contracts.service.ts backend/src/features/contracts/contracts.service.spec.ts
+git commit -m "fix(backend): RG aceita CPF (unificação) e higieniza documentos antes de gravar contrato"
+```
+
+---
+
+### Task 5: `RegisterPage.tsx` — usar util compartilhado, mascarar RG
+
+**Files:**
+- Modify: `frontend/src/pages/auth/RegisterPage.tsx`
+
+**Interfaces:**
+- Consumes: `applyCpfMask`, `applyRgMask`, `applyPhoneMask` de `frontend/src/utils/mask.ts`.
+
+- [ ] **Step 1: Importar o util e remover as funções locais duplicadas**
+
+Adicionar import: `import { applyCpfMask, applyRgMask, applyPhoneMask } from "../../utils/mask";`
+
+Remover as declarações locais `formatCPF` (linhas ~135-144), `formatRG` (~146-149) e `formatPhone` (~151-159).
+
+- [ ] **Step 2: Trocar as chamadas `onChange`**
+
+- `e.target.value = formatCPF(e.target.value);` (linha ~344) → `e.target.value = applyCpfMask(e.target.value);`
+- `e.target.value = formatRG(e.target.value);` (linha ~370) → `e.target.value = applyRgMask(e.target.value);`
+- `e.target.value = formatPhone(e.target.value);` (linha ~399) → `e.target.value = applyPhoneMask(e.target.value);`
+
+- [ ] **Step 3: Ajustar validação e `maxLength` do RG para acomodar CPF (11 dígitos)**
+
+No bloco do input de RG (linhas ~354-374):
+- `maxLength={10}` → `maxLength={14}` (tamanho de um CPF pontuado, `"123.456.789-00"`)
+- Na validação inline de cor (`watch("rg") && (() => {...})()`, linha ~362) e no `validate` do `register("rg", {...})` (linha ~368): trocar `d >= 7 && d <= 10` por `d >= 7 && d <= 11`, e a mensagem `"RG deve ter entre 7 e 10 dígitos"` por `"RG deve ter entre 7 e 11 dígitos"`.
+- Placeholder `"0000000000"` (linha ~357) → `"0000000 ou CPF completo"`.
+
+- [ ] **Step 4: Build de tipos**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/auth/RegisterPage.tsx
+git commit -m "refactor(frontend): RegisterPage usa util compartilhado de máscara, RG aceita CPF"
+```
+
+---
+
+### Task 6: Telas de convite (`RegisterOfficePage`, `RegisterSpecialistPage`, `RegisterConsultantPage`) — aplicar máscara
+
+**Files:**
+- Modify: `frontend/src/pages/auth/RegisterOfficePage.tsx`
+- Modify: `frontend/src/pages/auth/RegisterSpecialistPage.tsx`
+- Modify: `frontend/src/pages/auth/RegisterConsultantPage.tsx`
+
+**Interfaces:**
+- Consumes: `applyCpfMask`, `applyCnpjMask`, `applyRgMask`, `applyPhoneMask` de `frontend/src/utils/mask.ts`.
+
+As três telas têm a mesma estrutura (`useState` + `onChange={(e) => setX(e.target.value)}`, sem máscara nenhuma). O padrão de edição é idêntico nas três, trocando `cpf`↔`cnpj` conforme o caso.
+
+- [ ] **Step 1: `RegisterOfficePage.tsx`**
+
+Adicionar import: `import { applyCpfMask, applyRgMask, applyPhoneMask } from "../../utils/mask";`
+
+Trocar os três `onChange`:
+
+```typescript
+// CPF (linha ~182)
+onChange={(e) => setCpf(applyCpfMask(e.target.value))}
+
+// RG (linha ~195)
+onChange={(e) => setRg(applyRgMask(e.target.value))}
+
+// Telefone (linha ~208)
+onChange={(e) => setPhone(applyPhoneMask(e.target.value))}
+```
+
+Ajustar o input de RG (linhas ~191-200): `maxLength={10}` → `maxLength={14}`; label `"RG (7-10 dígitos)"` → `"RG (7-11 dígitos, aceita CPF)"`.
+
+No `handleSubmit`, ajustar a validação de tamanho do RG (linha ~63): `cleanRg.length < 7 || cleanRg.length > 10` → `cleanRg.length < 7 || cleanRg.length > 11`, mensagem `"RG deve ter entre 7 e 10 dígitos."` → `"RG deve ter entre 7 e 11 dígitos."`.
+
+- [ ] **Step 2: `RegisterSpecialistPage.tsx`**
+
+Adicionar import: `import { applyCnpjMask, applyRgMask, applyPhoneMask } from "../../utils/mask";`
+
+Trocar os três `onChange`:
+
+```typescript
+// CNPJ (linha ~206)
+onChange={(e) => setCnpj(applyCnpjMask(e.target.value))}
+
+// RG (linha ~219)
+onChange={(e) => setRg(applyRgMask(e.target.value))}
+
+// Telefone (linha ~232)
+onChange={(e) => setPhone(applyPhoneMask(e.target.value))}
+```
+
+Ajustar o input de RG (linhas ~215-224): `maxLength={10}` → `maxLength={14}`; label `"RG (7-10 dígitos)"` → `"RG (7-11 dígitos, aceita CPF)"`.
+
+No `handleSubmit`, mesma alteração de validação do Step 1 (linha ~74).
+
+- [ ] **Step 3: `RegisterConsultantPage.tsx`**
+
+Adicionar import: `import { applyCpfMask, applyRgMask, applyPhoneMask } from "../../utils/mask";`
+
+Trocar os três `onChange`:
+
+```typescript
+// CPF (linha ~177)
+onChange={(e) => setCpf(applyCpfMask(e.target.value))}
+
+// RG (linha ~190)
+onChange={(e) => setRg(applyRgMask(e.target.value))}
+
+// Telefone (linha ~203)
+onChange={(e) => setPhone(applyPhoneMask(e.target.value))}
+```
+
+Ajustar o input de RG (linhas ~186-195): `maxLength={10}` → `maxLength={14}`; label `"RG (7-10 dígitos)"` → `"RG (7-11 dígitos, aceita CPF)"`.
+
+No `handleSubmit`, mesma alteração de validação do Step 1 (linha ~61).
+
+- [ ] **Step 4: Build de tipos**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/auth/RegisterOfficePage.tsx frontend/src/pages/auth/RegisterSpecialistPage.tsx frontend/src/pages/auth/RegisterConsultantPage.tsx
+git commit -m "feat(frontend): mascarar cpf/cnpj/rg/telefone nas telas de cadastro por convite"
+```
+
+---
+
+### Task 7: `ProfilePage.tsx` — mascarar, formatar prefill, corrigir strip no submit
+
+**Files:**
+- Modify: `frontend/src/pages/profile/ProfilePage.tsx`
+
+**Interfaces:**
+- Consumes: `applyCpfMask`, `applyRgMask`, `applyPhoneMask`, `stripFormatting` de `frontend/src/utils/mask.ts`.
+
+- [ ] **Step 1: Importar o util**
+
+Adicionar: `import { applyCpfMask, applyRgMask, applyPhoneMask, stripFormatting } from "../../utils/mask";`
+
+- [ ] **Step 2: Formatar o prefill (linhas ~86-93)**
+
+Trocar:
+
+```typescript
+setFormData({
+  name: userData.name || "",
+  surname: userData.surname || "",
+  cpf: userData.cpf || "",
+  rg: userData.rg || "",
+  phone: userData.phone || "",
+  calendly_url: userData.calendly_url || "",
+});
+```
+
+por:
+
+```typescript
+setFormData({
+  name: userData.name || "",
+  surname: userData.surname || "",
+  cpf: userData.cpf ? applyCpfMask(userData.cpf) : "",
+  rg: userData.rg ? applyRgMask(userData.rg) : "",
+  phone: userData.phone ? applyPhoneMask(userData.phone) : "",
+  calendly_url: userData.calendly_url || "",
+});
+```
+
+- [ ] **Step 3: Aplicar máscara por campo em `handleInputChange` (linhas ~230-233)**
+
+`handleInputChange` hoje é genérico (usado por vários inputs, não só cpf/rg/phone). Trocar por:
+
+```typescript
+const MASKED_FIELDS: Record<string, (value: string) => string> = {
+  cpf: applyCpfMask,
+  rg: applyRgMask,
+  phone: applyPhoneMask,
+};
+
+const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const { name, value } = e.target;
+  const mask = MASKED_FIELDS[name];
+  setFormData((prev) => ({ ...prev, [name]: mask ? mask(value) : value }));
+};
+```
+
+- [ ] **Step 4: Corrigir o submit para enviar cpf/rg sem pontuação (linhas ~244-254)**
+
+Trocar:
+
+```typescript
+const dataToUpdate: UpdateUserData = {
+  name: formData.name,
+  surname: formData.surname,
+  cpf: formData.cpf,
+  rg: formData.rg,
+};
+
+const cleanPhone = formData.phone.replace(/\D/g, "");
+if (cleanPhone) {
+  dataToUpdate.phone = cleanPhone;
+}
+```
+
+por:
+
+```typescript
+const dataToUpdate: UpdateUserData = {
+  name: formData.name,
+  surname: formData.surname,
+  cpf: stripFormatting(formData.cpf),
+  rg: stripFormatting(formData.rg),
+};
+
+const cleanPhone = stripFormatting(formData.phone);
+if (cleanPhone) {
+  dataToUpdate.phone = cleanPhone;
+}
+```
+
+- [ ] **Step 5: Remover o placeholder "Apenas números" e ajustar `maxLength`/placeholder do RG**
+
+No input de CPF (linhas ~511-520): remover `placeholder="Apenas números"`, ajustar `maxLength={11}` → `maxLength={14}`.
+
+No input de RG (linhas ~528-537): remover `placeholder="Apenas números"`, ajustar `maxLength={10}` → `maxLength={14}`.
+
+No input de telefone (linhas ~545-553): `maxLength={16}` já comporta `"(11) 99999-9999"` (14 caracteres) — manter.
+
+- [ ] **Step 6: Build de tipos**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/pages/profile/ProfilePage.tsx
+git commit -m "fix(frontend): mascarar cpf/rg/telefone no perfil e corrigir strip antes do submit"
+```
+
+---
+
+### Task 8: Formulários de empresa (`OfficeCompanySettingsPage`, `NewCompanyForm`, `MyCompanyPage`) — mascarar CNPJ
+
+**Files:**
+- Modify: `frontend/src/pages/office/OfficeCompanySettingsPage.tsx`
+- Modify: `frontend/src/pages/admin/NewCompanyForm.tsx`
+- Modify: `frontend/src/pages/admin/MyCompanyPage.tsx`
+
+**Interfaces:**
+- Consumes: `applyCnpjMask`, `stripFormatting` de `frontend/src/utils/mask.ts`.
+
+- [ ] **Step 1: `OfficeCompanySettingsPage.tsx`**
+
+Adicionar import: `import { applyCnpjMask, stripFormatting } from "../../utils/mask";`
+
+No prefill (linha ~27), trocar `cnpj: c.cnpj,` por `cnpj: c.cnpj ? applyCnpjMask(c.cnpj) : c.cnpj,`.
+
+No input (linha ~159), trocar `onChange={(e) => setForm({ ...form, cnpj: e.target.value })}` por `onChange={(e) => setForm({ ...form, cnpj: applyCnpjMask(e.target.value) })}`.
+
+No `save` (antes de `officeService.updateCompany(form)`, linha ~43), stripar o CNPJ:
+
+```typescript
+const updated = await officeService.updateCompany({
+  ...form,
+  cnpj: form.cnpj ? stripFormatting(form.cnpj) : form.cnpj,
+});
+```
+
+- [ ] **Step 2: `NewCompanyForm.tsx`**
+
+Adicionar import: `import { applyCnpjMask } from "../../utils/mask";`
+
+No prefill (linha ~59), trocar `setCnpj(companyToEdit.cnpj);` por `setCnpj(applyCnpjMask(companyToEdit.cnpj));`.
+
+No input (linha ~238), trocar `onChange={(e) => setCnpj(e.target.value)}` por `onChange={(e) => setCnpj(applyCnpjMask(e.target.value))}`.
+
+O submit já faz `cnpj.replace(/\D/g, "")` antes de enviar (linha ~165) — não precisa mudar, mas pode trocar por `stripFormatting(cnpj)` (importar de `utils/mask`) para consistência; não é obrigatório.
+
+- [ ] **Step 3: `MyCompanyPage.tsx`**
+
+Adicionar import: `import { applyCnpjMask, stripFormatting } from "../../utils/mask";`
+
+No prefill (linha ~44), trocar `setCnpj(data.cnpj);` por `setCnpj(applyCnpjMask(data.cnpj));`.
+
+No input (linha ~167), trocar `onChange={(e) => setCnpj(e.target.value)}` por `onChange={(e) => setCnpj(applyCnpjMask(e.target.value))}`.
+
+No submit (linha ~85, dentro de `updatePlatformCompany({...})`), trocar `cnpj,` por `cnpj: stripFormatting(cnpj),`.
+
+- [ ] **Step 4: Build de tipos**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/pages/office/OfficeCompanySettingsPage.tsx frontend/src/pages/admin/NewCompanyForm.tsx frontend/src/pages/admin/MyCompanyPage.tsx
+git commit -m "feat(frontend): mascarar CNPJ nos formulários de empresa (escritório/plataforma)"
+```
+
+---
+
+### Task 9: Exibição — `CompaniesPage.tsx` e `ConsultantClientsPage.tsx`
+
+**Files:**
+- Modify: `frontend/src/pages/admin/CompaniesPage.tsx`
+- Modify: `frontend/src/pages/consultant/ConsultantClientsPage.tsx`
+
+**Interfaces:**
+- Consumes: `applyCnpjMask`, `applyCpfMask` de `frontend/src/utils/mask.ts`.
+
+- [ ] **Step 1: `CompaniesPage.tsx`**
+
+Adicionar import: `import { applyCnpjMask } from "../../utils/mask";`
+
+Na linha ~389, trocar:
+
+```tsx
+<span className="block text-xs text-subtle">
+  {company.cnpj}
+</span>
+```
+
+por:
+
+```tsx
+<span className="block text-xs text-subtle">
+  {applyCnpjMask(company.cnpj)}
+</span>
+```
+
+- [ ] **Step 2: `ConsultantClientsPage.tsx`**
+
+Remover a função local `formatCPF` (linhas ~29-33) e o import correspondente não é necessário (não havia). Adicionar: `import { applyCpfMask } from "../../utils/mask";`
+
+Na linha ~181, trocar `{formatCPF(client.cpf)}` por `{client.cpf ? applyCpfMask(client.cpf) : "-"}`.
+
+- [ ] **Step 3: Build de tipos**
+
+Run: `cd frontend && npx tsc -b --noEmit`
+Expected: sem erros.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/admin/CompaniesPage.tsx frontend/src/pages/consultant/ConsultantClientsPage.tsx
+git commit -m "fix(frontend): formatar CNPJ/CPF na exibição de empresas e clientes do consultor"
+```
+
+---
+
+### Task 10: Verificação final
+
+**Files:** nenhum (task só de verificação, sem código novo).
+
+- [ ] **Step 1: Lint do frontend**
+
+Run: `cd frontend && npm run lint`
+Expected: sem erros novos.
+
+- [ ] **Step 2: Build do frontend**
+
+Run: `cd frontend && npm run build`
+Expected: build passa.
+
+- [ ] **Step 3: Testes do frontend (arquivos tocados)**
+
+Run: `cd frontend && npx vitest run src/utils/mask.test.ts`
+Expected: PASS.
+
+- [ ] **Step 4: Lint do backend**
+
+Run: `cd backend && npm run lint`
+Expected: sem erros novos.
+
+- [ ] **Step 5: Build do backend**
+
+Run: `cd backend && npm run build`
+Expected: build passa.
+
+- [ ] **Step 6: Testes do backend (arquivos tocados)**
+
+Run: `cd backend && npm test -- --maxWorkers=2 format.utils.spec`
+Run: `cd backend && npm test -- --maxWorkers=2 contracts.service.spec`
+Expected: PASS em ambos (incluindo os testes pré-existentes de `resolveCommissionFromTotal`/`buildFormFields` — se algum falhar por motivo já conhecido e não relacionado a este trabalho, confirmar contra o histórico do projeto antes de investigar como regressão nova).
+
+- [ ] **Step 7: Smoke test manual (opcional, se houver ambiente local rodável)**
+
+Não subir `nest start --watch` nesta máquina (histórico de travamento). Se for validar manualmente, usar apenas o frontend com a API já rodando via outro meio, ou revisar via leitura de diff — build + testes automatizados acima já cobrem o essencial.

--- a/docs/superpowers/specs/2026-08-03-calculadora-spread-comissoes-design.md
+++ b/docs/superpowers/specs/2026-08-03-calculadora-spread-comissoes-design.md
@@ -1,0 +1,124 @@
+# Calculadora de spread de comissões (admin) + remoção da aba "Meus Assessorados"
+
+**Data:** 2026-08-03
+**Escopo:** frontend apenas. Zero mudanças no backend.
+
+## Contexto
+
+Dois ajustes na visão do admin da plataforma:
+
+1. **Calculadora de spread de comissões** — permite ao admin simular como a comissão
+   de uma venda se divide entre especialista, escritório (opcional) e plataforma,
+   escolhendo produto/especialista/escritório para pré-preencher, mas com todos os
+   campos numéricos sempre editáveis (modo livre). Inclui uma versão reduzida no dashboard.
+2. **Remover "Meus Assessorados"** da navegação — a aba não faz sentido; só consultores
+   têm carteira de clientes e já têm a aba exclusiva "Meus Clientes".
+
+## Modelo de cálculo (fonte de verdade: backend)
+
+A matemática já existe e é pura, em `backend/src/features/contracts/commission-split.ts`
+(`computeNestedCommissionSplit`). Split aninhado ("bolo"):
+
+```
+bolo         = venda × totalCommissionRate%
+especialista = bolo × specialistShareRate%
+restante     = bolo − especialista
+escritório   = restante × officeShareRate%
+plataforma   = restante − escritório        (resíduo — soma sempre bate no bolo)
+```
+
+Cada valor é arredondado a 2 casas; a plataforma absorve o resíduo de arredondamento,
+então especialista + escritório + plataforma = bolo exatamente.
+
+**Drivers da calculadora** (os únicos inputs que movem o resultado):
+
+| Input | Origem do pré-preenchimento | Semântica |
+|-------|------------------------------|-----------|
+| Valor de venda (R$) | Produto (`car/boat/aircraft.valor`) ou manual | `proposalValue` |
+| Comissão total da venda (%) | Manual (alavanca do especialista); seed 10% | `totalCommissionRate` |
+| Fatia do especialista sobre o bolo (%) | `specialist.commission_rate` | `specialistShareRate` |
+| Fatia do escritório sobre o restante (%) | `company.commission_rate` (0 se "Nenhum") | `officeShareRate` |
+
+**Plataforma = resíduo.** Não tem campo de taxa de entrada — é fiel ao que o contrato
+gera hoje. `PlatformCompany.default_commission_rate` e `Company.platform_commission_rate`
+NÃO entram no split aninhado (confirmado em `resolveCommissionFromTotal`, que não usa
+`platformRate` no cálculo).
+
+**Modo livre:** todos os 4 campos numéricos são sempre editáveis. Selecionar
+produto/especialista/escritório apenas pré-preenche; o admin pode sobrescrever qualquer
+valor. Não há toggle de "modo livre" separado — é inerente aos campos editáveis.
+
+## Arquitetura (frontend)
+
+Dados já expostos por serviços existentes — nenhum endpoint novo:
+
+- `getSpecialists()` → `Specialist[]` com `commission_rate`
+- `getCompanies()` → `Company[]` com `commission_rate` (`platform_commission_rate` ignorado aqui)
+- `getPlatformCompany()` → informativo apenas (não usado no split)
+- `getCars()` / `getBoats()` / `getAircrafts()` → `valor` (busca opcional de produto)
+
+### Componentes
+
+1. **`frontend/src/lib/commission-split.ts`** — função pura portada do backend.
+   Copia de `computeNestedCommissionSplit` (~8 linhas) + tipos. Comentário `ponytail:`
+   apontando `backend/src/features/contracts/commission-split.ts` como fonte de verdade
+   ("manter em sync"). Acompanha teste (`commission-split.test.ts`) que trava os mesmos
+   números do `commission-split.spec.ts` do backend.
+
+2. **`frontend/src/components/commission/CommissionSplitResult.tsx`** — apresentacional.
+   Recebe o `breakdown` pronto (`{ bolo, specialistValue, officeValue, platformValue }`)
+   + `saleValue` e renderiza uma tabela estilo planilha: Bolo → Especialista → Restante →
+   Escritório → **Plataforma (linha-âncora destacada)**. Cada linha mostra valor R$ e taxa
+   efetiva sobre a venda (%). Prop `compact` reduz densidade para o card do dashboard.
+   Zero cálculo além da taxa efetiva (`valor / venda × 100`).
+
+3. **`frontend/src/pages/admin/CommissionCalculatorPage.tsx`** — página completa.
+   Layout duas colunas: inputs à esquerda, `CommissionSplitResult` sticky à direita.
+   Estado local dos 4 drivers; selects de especialista/escritório e busca de produto
+   só chamam os setters dos campos. Reusa componentes de UI já existentes do projeto
+   (`Card`, `Input`, selects) — segue o padrão do `DashboardPage`/`CommissionsPage`,
+   NÃO importa HeroUI (o locpay é referência de UX, não de stack).
+
+4. **`frontend/src/components/commission/CommissionMiniCalculator.tsx`** — card do dashboard.
+   Inputs mínimos (valor de venda + comissão total % + especialista) → `CommissionSplitResult`
+   em modo `compact` + link "Abrir calculadora completa" → `/admin/calculator`.
+
+### Navegação e rotas
+
+- **Sidebar** (`frontend/src/layouts/Sidebar.tsx`): adicionar item "Calculadora"
+  (`/admin/calculator`) ao bloco ADMIN (linhas ~126-168). Ícone: `Calculator` (lucide).
+- **Rotas** (`frontend/src/routes/routes.tsx`): nova rota
+  `<ProtectedRoute allowedRoles={["ADMIN"]}>` → `CommissionCalculatorPage`.
+- **Dashboard** (`frontend/src/pages/admin/DashboardPage.tsx`): encaixar
+  `CommissionMiniCalculator` no grid `lg:grid-cols-2` (~linha 176), como card no
+  mesmo padrão do card "Comissão por processo".
+
+### Remoção de "Meus Assessorados"
+
+- `Sidebar.tsx:196-202`: deletar o bloco `if (user.role !== "OFFICE") { links.push(...) }`
+  que empurra o item "Meus Assessorados" para todos os papéis. Some da navegação de
+  **todos** os papéis.
+- **Manter intactos:** a rota `/advisor/dashboard`, `AdvisorDashboardPage.tsx`,
+  a rota `/advisor/accept` e `advisor.service.ts` — o fluxo de convite/aceite do assessor
+  continua funcionando; só o item de menu sai.
+
+## Busca de produto (opcional, cortável)
+
+Dropdown de categoria (Carro/Barco/Aeronave) + select buscável que lazy-carrega a lista
+daquela categoria via o service correspondente; selecionar preenche o valor de venda.
+É conveniência pura — o valor sempre pode ser digitado à mão. **Se o tempo apertar,
+esta é a parte a cortar** (v1 pode entregar só valor manual).
+
+## Testes / verificação
+
+- `commission-split.test.ts` (frontend): assert que a função portada devolve os mesmos
+  valores do caso canônico do `commission-split.spec.ts` do backend (mesma soma exata,
+  plataforma como resíduo).
+- Verificação final: `cd frontend && npm run lint && npm run build`.
+- QA visual: frontend isolado + Playwright mockando a API (sem subir o backend nesta máquina).
+
+## Fora de escopo
+
+- Persistir/salvar simulações (locpay salva; aqui não pedido — YAGNI).
+- Qualquer mudança no cálculo real do contrato ou no backend.
+- Expor taxa de plataforma como driver (confirmado: plataforma é resíduo).

--- a/docs/superpowers/specs/2026-08-03-identificador-produto-e-uuid-design.md
+++ b/docs/superpowers/specs/2026-08-03-identificador-produto-e-uuid-design.md
@@ -1,0 +1,152 @@
+# Identificador de produto no import + PK de produtos em UUID
+
+**Data:** 2026-08-03
+**Status:** Aprovado para planejamento
+**Autor:** Messias-Olivindo (com Claude)
+
+## Problema
+
+O cliente pediu que um especialista possa cadastrar **mais de um produto do mesmo
+tipo** — ex.: duas "Ferrari X" que são carros fisicamente diferentes, cada um com
+seu identificador, informados via CSV/XLSX de import.
+
+Hoje isso **não funciona**. O import (assíncrono em `ProductImportJobsService` e
+síncrono em `cars/boats/aircrafts.service`) deduplica produtos pela chave
+`(marca, modelo, specialist_id)`. Duas linhas "Ferrari / X" do mesmo especialista
+colapsam: a segunda linha faz **UPDATE** da primeira em vez de criar um segundo
+registro. Resultado: sobra 1 carro só, com os dados da última linha sobrescrevendo
+a primeira. Não existe nenhuma coluna de identificador nos templates nem campo
+identificador em `Car`/`Boat`/`Aircraft`.
+
+Além disso, o import é **full-sync**: `deactivateMissingProducts` desativa
+(`is_active=false`) todo produto ativo do especialista que não apareça no arquivo.
+Ou seja, o CSV é tratado como a verdade completa do estoque.
+
+Aproveitando a mudança, migrar a PK dos produtos de `Int autoincrement` para
+`UUID` (IDs incrementais são enumeráveis/inseguros; já existe
+`// TODO: converter ... para UUID` em `Product` no schema).
+
+## Decisões (do brainstorming)
+
+- **Identificador obrigatório.** Toda linha do import precisa de `identificador`.
+  Linha sem identificador → erro de validação (não cria). Isso elimina o caso
+  "sem id" e, com ele, o churn de re-upload.
+- **Full-sync mantido.** Com uma chave estável (identificador), o full-sync fica
+  saudável: re-upload casa por identificador → update; ausência real → desativa.
+- **Escopo: os 3 tipos** (carro, barco, aeronave) — o sistema de import trata os
+  três igual; manter simétrico evita comportamento divergente por tipo.
+- **UUID nos 3 produtos.** Banco é de **dev/demo** → wipe autorizado, sem migração
+  de dados de produto. Perda de processos/imagens ligados é aceitável.
+- **Entrega: um spec, três fases** (A → B → C).
+- **Identificador inicial no CSV exportado:** código gerado legível
+  `MARCA-MODELO-seq` (ex.: `FERRARI-X-1`, `FERRARI-X-2`).
+
+## Design
+
+### Fase A — Identificador de produto (chave natural)
+
+**Schema** (`backend/prisma/schema.prisma`), em `Car`, `Boat`, `Aircraft`:
+
+```prisma
+identificador String
+// ...
+@@unique([specialist_id, identificador])
+```
+
+O `@@unique` garante que um especialista não tenha dois produtos com o mesmo
+identificador e transforma o dedup em uma consulta determinística.
+
+**Templates de import** (colunas em `ProductImportJobsService`
+`carColumns`/`boatColumns`/`aircraftColumns`): adicionar
+`{ name: 'identificador', required: true, type: 'string' }`. O template gerado
+para download (`getCsvTemplate` / `xlsxImportService.generateTemplate`) passa a
+incluir a coluna.
+
+**Dedup — mudar a chave em todos os pontos de upsert.** A chave passa de
+`(marca, modelo, specialist_id)` para `(specialist_id, identificador)`. Pontos
+identificados (9):
+
+- `product-import-jobs.service.ts` → `upsertProductFromRow`: 3 ramos (car/boat/aircraft).
+- `cars.service.ts` → `importFromCsv` (linha ~442) e `importFromXlsx` (~556).
+- `boats.service.ts` → `importFromCsv` (~478) e `importFromXlsx` (~596).
+- `aircrafts.service.ts` → `importFromCsv` (~513) e `importFromXlsx` (~645).
+
+> **Atenção (dívida a resolver na fase):** a mesma lógica de dedup+upsert está
+> copiada nesses 9 lugares. Mudar a chave em 9 pontos à mão é frágil. Avaliar
+> extrair um helper único de "encontra-ou-cria produto por identificador" que os
+> caminhos síncrono e assíncrono compartilhem. Se a extração for grande demais
+> para esta fase, no mínimo padronizar a chave e cobrir com teste.
+
+**Validação:** `identificador` obrigatório na definição de coluna já faz
+`validateStructure` rejeitar arquivo sem a coluna. Linha com a coluna presente mas
+valor vazio → tratar como erro de linha (não cria, entra em `errorRows`).
+
+**Comportamento resultante:**
+- Ferrari X `FERRARI-X-1` e Ferrari X `FERRARI-X-2` → 2 registros distintos.
+- Re-upload do mesmo arquivo → casa por identificador → UPDATE, nada duplica.
+- Produto que sai do CSV → full-sync desativa (comportamento atual preservado).
+
+### Fase B — PK de produtos `Int` → `UUID`
+
+Independente de A. Sem migração de dados (wipe na fase C).
+
+**Schema:** em `Car`, `Boat`, `Aircraft`:
+`id  String  @id @default(uuid()) @db.Uuid` (era `Int @default(autoincrement())`).
+
+**FKs para atualizar** (`Int?` → `String? @db.Uuid`):
+- `Car_image.car_id`, `Boat_image.boat_id`, `Aircraft_image.aircraft_id`.
+- `Process.car_id`, `Process.boat_id`, `Process.aircraft_id`.
+- `Product.car_id`, `Product.boat_id`, `Product.aircraft_id` (camada de abstração;
+  remover o TODO do schema).
+
+**Backend — remover suposição de id numérico:**
+- `processes/dto/create-process.dto.ts` e `assign-product.dto.ts`: `@IsInt` no
+  `product_id` → `@IsString`/`@IsUUID`.
+- `processes.service.ts`: remover `Number(createProcessDto.product_id)` (linhas
+  ~214, 274, 278, 282).
+- Controllers de car/boat/aircraft: `ParseIntPipe` em params de id → sem pipe
+  (id string).
+
+**Frontend — ~23 pontos** que assumem id numérico (rotas `/catalog/...`,
+`Number(id)`/`parseInt`, tipos de props) em `pages/catalog`, `pages/customer`,
+`services`. Trocar para string. Levantar a lista exata no plano de implementação.
+
+### Fase C — Wipe + CSV de re-import
+
+1. **Script de export (roda ANTES do wipe).** Script Prisma em
+   `backend/prisma/` (ou `scripts/`) que lê `Car`/`Boat`/`Aircraft` atuais e gera
+   um CSV por tipo no formato novo (com coluna `identificador` preenchida como
+   `MARCA-MODELO-seq`, sequência por especialista+marca+modelo). **O usuário roda**
+   no ambiente dele — Claude não conecta no banco.
+2. **Wipe.** Migration/script que apaga produtos e dependências (imagens,
+   processos órfãos). Perda autorizada (banco dev).
+3. **Re-import.** Usuário sobe os CSVs gerados pela própria plataforma → produtos
+   recriados já com UUID e identificador.
+
+## Fora de escopo
+
+- Comissão/wallet de consultor (regra de negócio: consultor não recebe comissão).
+- Qualquer mudança no full-sync além da troca de chave.
+- Backfill preservando processos/contratos antigos (explicitamente descartado —
+  banco é dev).
+
+## Riscos
+
+- **Banco Supabase tem drift de schema vs migrations.** As mudanças de schema
+  (identificador + UUID) precisam ir por `prisma db push` no ambiente dev, com
+  verificação — não `migrate deploy` cego. Confirmar antes de aplicar.
+- **UUID toca frontend (~23 pontos).** Levantar a lista exata no plano; risco de
+  esquecer um parse numérico e quebrar rota de catálogo.
+- **9 pontos de dedup.** Se não centralizar, alto risco de deixar um com a chave
+  antiga. Teste cobrindo "dois produtos mesmo marca/modelo, identificadores
+  diferentes → 2 registros" é obrigatório.
+
+## Critérios de aceitação
+
+1. Import com 2 linhas mesma marca/modelo e identificadores diferentes → 2 produtos ativos.
+2. Re-upload do mesmo arquivo → 0 novos, N atualizados, 0 duplicados.
+3. Linha sem identificador → erro na linha, produto não criado.
+4. Produto removido do CSV → desativado pelo full-sync.
+5. IDs de `Car`/`Boat`/`Aircraft` são UUID; catálogo e fluxo de processo funcionam
+   ponta a ponta com id string.
+6. Script de export gera CSV re-importável pela plataforma sem erro de estrutura.

--- a/docs/superpowers/specs/2026-08-04-identificador-manual-e-modal-csv-design.md
+++ b/docs/superpowers/specs/2026-08-04-identificador-manual-e-modal-csv-design.md
@@ -1,0 +1,132 @@
+# Identificador no formulário manual e no modal de import CSV
+
+**Data:** 2026-08-04
+**Status:** Aprovado para planejamento
+**Autor:** Messias-Olivindo (com Claude)
+
+## Problema
+
+O spec anterior ([2026-08-03-identificador-produto-e-uuid-design.md](2026-08-03-identificador-produto-e-uuid-design.md))
+introduziu o campo `identificador` (string única por especialista, chave de
+dedup) **só no fluxo de import CSV/XLSX**. O formulário manual de criação de
+produto e o modal que explica a estrutura do CSV nunca entraram no escopo
+daquele spec — não foi bug de implementação, é lacuna do spec original.
+
+Isso quebrou duas coisas hoje:
+
+1. **Criação manual está impossível.** `CreateCarDto`/`CreateBoatDto`/
+   `CreateAircraftDto` exigem `identificador` (`@IsString()`, sem
+   `@IsOptional()`), e o `ValidationPipe` global (`main.ts:60`) valida toda
+   requisição. `ProductForm.tsx` nunca coleta nem envia esse campo — toda
+   tentativa de criar um produto pela tela (não via CSV) recebe 400.
+2. **O modal de import mostra informação errada.** `XlsxImporter.tsx:53-95`
+   mantém uma cópia própria, hardcoded, das colunas obrigatórias/opcionais —
+   `identificador` não aparece em nenhuma das duas listas, para nenhum dos 3
+   tipos de produto. O texto de dica (`XlsxImporter.tsx:338-342`) afirma que
+   "produtos com mesma marca + modelo serão atualizados ao invés de
+   duplicados" — isso descreve o comportamento **anterior** ao spec de
+   2026-08-03; hoje o dedup é por `identificador`, e marca+modelo são só
+   dados descritivos.
+
+## Decisões (do brainstorming)
+
+- **`identificador` no formulário manual é digitado pelo especialista**, campo
+  de texto livre — mesmo padrão de preenchimento do CSV, sem geração
+  automática. Consistência entre os dois fluxos de criação.
+- **Validação de unicidade só no submit.** Sem endpoint novo de checagem em
+  tempo real — o `PrismaExceptionFilter` já trata `P2002` globalmente
+  (`prisma-exception.filter.ts:60`) e devolve 409 com mensagem amigável; o
+  form só precisa exibir esse erro como já faz para outros campos únicos
+  (ex.: `identification_number`).
+- **Fix pontual, não fonte única compartilhada.** `XlsxImporter.tsx` mantém
+  sua própria cópia hardcoded das colunas (já duplicada do backend hoje) —
+  só corrigi-la para bater com a realidade atual. Unificar backend+frontend
+  numa fonte única de verdade é melhoria futura, não necessária para resolver
+  o bug relatado (o próprio spec anterior já registrou duplicação equivalente
+  no backend como "dívida a resolver depois", não bloqueante).
+- **Sem testes de componente novos.** Não existe infraestrutura de teste de
+  componente React neste frontend (só testes de função pura em `lib/*.test.ts`
+  via vitest). Criar essa infraestrutura do zero para cobrir um input de
+  formulário é desproporcional ao tamanho do bug. Verificação é manual (ver
+  Critérios de aceitação).
+
+## Design
+
+### 1. Formulário manual — `frontend/src/components/specialist/CommonProductFields.tsx`
+
+Campo compartilhado pelos 3 tipos de produto (carro/barco/aeronave), no mesmo
+padrão `react-hook-form` já usado por `marca`/`modelo` (linhas 37-65):
+
+- Novo `<input id="identificador" {...register("identificador", { required: "Identificador é obrigatório" })} />`
+  com label "Identificador" e placeholder de exemplo (ex.: `"Ex: BMW-X5-1"`).
+- Renderizar logo após o campo `modelo`, antes de `ano`.
+- Exibir erro de validação client-side igual aos campos vizinhos
+  (`errors.identificador && <span>...`).
+
+### 2. Payload — `frontend/src/pages/specialist/ProductFormPage.tsx` ou `frontend/src/components/specialist/ProductForm.tsx`
+
+Em `formattedData` (`ProductForm.tsx:205-207`, onde `marca`/`modelo` já são
+copiados de `data`), adicionar `formattedData.identificador = data.identificador`.
+Vale para os 3 ramos (`CAR`/`BOAT`/`AIRCRAFT`) — o campo é comum, então entra
+uma vez só, junto com `marca`/`modelo`, não dentro dos `if` por tipo.
+
+### 3. Modal de import — `frontend/src/components/shared/XlsxImporter.tsx`
+
+- `COLUMN_DEFINITIONS` (linhas 53-95): adicionar `"identificador"` no array
+  `required` de `CAR`, `BOAT` e `AIRCRAFT`.
+- Texto de dica (linhas 338-342): substituir a afirmação de dedup por
+  marca+modelo por uma frase correta — dedup é por `identificador` (único por
+  especialista); marca+modelo são só descritivos e podem se repetir entre
+  produtos diferentes.
+
+### Fluxo de erro (sem mudança de backend)
+
+- Requisição sem `identificador` → `ValidationPipe` global rejeita com 400
+  antes de chegar no service (comportamento já existente, hoje inatingível
+  pela UI porque o campo nunca era enviado).
+- `identificador` duplicado para o mesmo especialista → `P2002` →
+  `PrismaExceptionFilter` → 409 "Já existe um registro com specialist_id,
+  identificador informado(s)" (ordem dos campos segue a declaração
+  `@@unique([specialist_id, identificador])` no schema). O formulário precisa
+  capturar e exibir essa mensagem de erro (mesmo tratamento de erro genérico
+  que outros campos únicos já usam no componente).
+
+## Fora de escopo
+
+- Fonte única de colunas compartilhada entre backend e frontend (Abordagem
+  B/C consideradas e descartadas por desproporcionais ao bug — ver Decisões).
+- Geração automática/sugestão de `identificador` no formulário manual.
+- Checagem de unicidade em tempo real (endpoint novo).
+- Qualquer mudança no comportamento de dedup do import CSV (já correto desde
+  o spec de 2026-08-03; aqui só a *comunicação* sobre ele está sendo
+  corrigida).
+- Melhorar a mensagem de erro do `PrismaExceptionFilter` para P2002 (hoje
+  mostra nomes de campos técnicos tipo `specialist_id, identificador`) — não
+  bloqueia a funcionalidade, fica como possível polish futuro.
+
+## Riscos
+
+- **Campos por tipo de produto podem ter nomes de placeholder diferentes.**
+  `CommonProductFields.tsx` já usa `placeholders.marca[productType]` /
+  `placeholders.modelo[productType]` por tipo — confirmar no plano se
+  `identificador` precisa de exemplo específico por tipo (carro vs. barco vs.
+  aeronave) ou se um placeholder genérico serve.
+- **Edição de produto existente.** O formulário também é usado em modo
+  "editar" (`mode="create" | "edit"` mencionado em `ProductForm.tsx:191`).
+  Produtos criados antes desta mudança (se houver) não têm `identificador`
+  no banco atual — como o banco é dev/demo e foi recém resetado (ver
+  contexto da conversa), não há dado legado a migrar, mas o plano deve
+  confirmar que o modo edição também envia/exibe `identificador` do produto
+  carregado.
+
+## Critérios de aceitação
+
+1. Criar um carro/barco/aeronave pelo formulário manual, preenchendo
+   `identificador`, salva com sucesso (sem 400).
+2. Tentar criar um segundo produto do mesmo especialista com o mesmo
+   `identificador` mostra mensagem de erro amigável na tela (não crasha, não
+   mostra erro técnico cru).
+3. Modal de import CSV mostra `identificador` na lista de colunas
+   obrigatórias, para os 3 tipos de produto.
+4. Texto de dica do modal não afirma mais que dedup é por marca+modelo;
+   descreve corretamente o dedup por `identificador`.

--- a/docs/superpowers/specs/2026-08-04-mascara-documentos-telefone-design.md
+++ b/docs/superpowers/specs/2026-08-04-mascara-documentos-telefone-design.md
@@ -1,0 +1,138 @@
+# Design: máscara de CPF/CNPJ/RG/telefone em toda a plataforma
+
+## Contexto
+
+No fluxo de cadastro (customer, consultor, especialista, escritório) e nas telas
+de perfil/admin, os campos de documento (CPF/RG/CNPJ) e telefone são
+inconsistentes: alguns aplicam pontuação ao digitar, outros pedem "apenas
+números" no placeholder, outros exibem o valor salvo cru (sem pontuação). O
+valor **sempre** deve ser salvo no banco sem pontuação, mas exibido ao usuário
+sempre pontuado — nunca com dígitos ocultos (não é mascaramento de segurança,
+é só formatação).
+
+Além disso, com a unificação RG/CPF, o campo RG deve aceitar um CPF completo
+(11 dígitos) como valor válido.
+
+Referência de padrão usada: `locpay_full/app/frontend/lib/validation.ts`
+(`maskCPF`, `maskCNPJ`, `maskPhone`/`maskPhoneLocal`, aplicados via
+`onChange={(e) => onChange({ field: formatX(e.target.value) })}`, com
+`stripFormatting` antes do submit).
+
+## Estado atual (auditoria)
+
+- `frontend/src/services/contracts.service.ts` já tem `stripFormatting`,
+  `applyCpfMask`, `applyCnpjMask`, `applyCepMask` — local errado (deveria ser
+  um util), sem máscara de telefone, e um `formatRg` morto (nunca importado).
+- `backend/src/shared/utils/format.utils.ts` já tem o espelho pro backend
+  (`formatCpf/formatCnpj/formatRg/formatCep/stripFormatting`), usado só para
+  montar o envelope do DocuSign.
+- Telas sem máscara nenhuma ao digitar: `RegisterOfficePage.tsx`,
+  `RegisterSpecialistPage.tsx`, `RegisterConsultantPage.tsx`,
+  `ProfilePage.tsx` (placeholder "Apenas números"),
+  `OfficeCompanySettingsPage.tsx`, `NewCompanyForm.tsx`, `MyCompanyPage.tsx`.
+- Telas com lógica duplicada (funciona, mas não usa o util compartilhado):
+  `RegisterPage.tsx` (formatCPF/formatRG/formatPhone locais),
+  `ConsultantClientsPage.tsx` (formatCPF local, só para exibição).
+- Exibição crua (sem formatar) de valor salvo: `CompaniesPage.tsx` (cnpj na
+  tabela), `ProfilePage.tsx` (prefill de cpf/rg), `CreateContractPage.tsx`
+  (prefill de seller_rg/buyer_rg).
+- **Bug real**: `CreateContractPage.tsx` monta o payload de
+  `seller_cpf/buyer_cpf/*_cnpj` com o valor **pontuado** (sem
+  `stripFormatting`) e envia para `generate-contract.dto.ts`/
+  `preview-contract.dto.ts`, que não validam formato. O backend
+  (`contracts.service.ts`) grava esse valor pontuado como veio, direto em
+  colunas de `PlatformCompany`. A coluna `specialist_document` é
+  `VARCHAR(14)` — um CNPJ pontuado tem 18 caracteres e não cabe.
+- Backend limita RG a 7-10 dígitos (ou exatamente 9, em
+  `create-specialist.dto.ts`) em 6 DTOs: `auth.ts` (4 classes),
+  `create-consultant.dto.ts`, `create-specialist.dto.ts`,
+  `update-specialist.dto.ts`, `update-user.dto.ts`. Isso rejeita um CPF de 11
+  dígitos no campo RG — precisa relaxar para aceitar a unificação.
+- Fora de escopo: `DatabasePage.tsx` — visualizador genérico de registros
+  brutos do banco para debug administrativo, não é um fluxo de cadastro de
+  usuário final. Fica como está.
+
+## Design
+
+### 1. Util compartilhado: `frontend/src/utils/mask.ts`
+
+Novo módulo, único local das funções de máscara de documento/telefone:
+
+- `stripFormatting(value)` — remove tudo que não é dígito.
+- `applyCpfMask(value)` — `###.###.###-##`, como já existe hoje.
+- `applyCnpjMask(value)` — `##.###.###/####-##`, como já existe hoje.
+- `applyCepMask(value)` — `#####-###`, como já existe hoje.
+- `applyRgMask(value)` — agrupa RG de 7-9 dígitos (`#.###.###`,
+  `##.###.###`, `##.###.###-#`, mesma lógica de
+  `backend/src/shared/utils/format.utils.ts#formatRg`); a partir de 10
+  dígitos delega para `applyCpfMask` (cobre a unificação RG/CPF).
+- `applyPhoneMask(value)` — `(##) ####-####` ou `(##) #####-####`
+  dependendo do tamanho do número local (8 ou 9 dígitos), mesma lógica de
+  `maskPhoneLocal` do locpay.
+
+`contracts.service.ts` (frontend) passa a importar dessas funções em vez de
+declará-las; `formatBRL` permanece onde está (fora do escopo, não é
+documento). As duplicatas locais em `RegisterPage.tsx` e
+`ConsultantClientsPage.tsx` são removidas em favor do import compartilhado.
+
+### 2. Aplicar máscara ao digitar
+
+Em todos os inputs de cpf/cnpj/rg/telefone das telas listadas acima:
+`onChange` passa a aplicar a função de máscara correspondente antes de
+atualizar o state/form, igual ao padrão já usado em `CreateContractPage.tsx`
+para `seller_cpf`. Remove o placeholder "Apenas números" do `ProfilePage`
+(deixa de fazer sentido).
+
+`CreateContractPage.tsx`: adiciona a máscara que falta em `buyer_cpf`
+(hoje só `seller_cpf` tem) e em `seller_rg`/`buyer_rg` (nunca foram
+mascarados).
+
+### 3. Aplicar formatação na exibição
+
+Mesma função de máscara, aplicada sobre o valor já salvo (são funções puras
+do dígito, servem tanto para "enquanto digita" quanto para "exibir valor
+existente"): `CompaniesPage.tsx` (cnpj na tabela), prefill de
+`ProfilePage.tsx` e `CreateContractPage.tsx`.
+
+### 4. Corrigir o bug de dados pontuados indo pro banco
+
+- `CreateContractPage.tsx`: `stripFormatting()` em todos os campos de
+  documento (cpf/cnpj) antes de montar o payload de submit — mesmo padrão já
+  usado no restante do arquivo para `seller_cpf`/`buyer_cpf`/`*_cep` em
+  outras chamadas.
+- Backend `contracts.service.ts` (`features/contracts/`): aplica
+  `stripFormatting()` (de `shared/utils/format.utils.ts`) nos campos de
+  documento antes de persistir em `PlatformCompany` — defesa em
+  profundidade, evita o overflow de `specialist_document` independente do
+  que o frontend mandar.
+
+### 5. Backend: RG aceita CPF (unificação)
+
+Relaxar `@Length`/`@Matches` do campo `rg` de `7,10` (ou `9,9`, no caso de
+`create-specialist.dto.ts`) para `7,11` dígitos em:
+`backend/src/auth/dto/auth.ts` (`UserRegisterDto`, `RegisterConsultantDto`,
+`RegisterOfficeDto`, `RegisterSpecialistDto`),
+`backend/src/features/consultants/dto/create-consultant.dto.ts`,
+`backend/src/features/specialists/dto/create-specialist.dto.ts`,
+`backend/src/features/specialists/dto/update-specialist.dto.ts`,
+`backend/src/features/users/dto/update-user.dto.ts`.
+
+`backend/src/shared/utils/format.utils.ts#formatRg`: estende para
+reconhecer 11 dígitos e formatar como CPF (hoje só formata 7-9 dígitos e
+devolve o valor cru para qualquer outro tamanho).
+
+## Testes
+
+- `frontend/src/utils/mask.ts`: teste unitário cobrindo os 5 casos de RG
+  (7/8/9 dígitos, e 10-11 delegando para CPF), CPF, CNPJ, CEP, telefone
+  (8 e 9 dígitos locais).
+- Backend: ajustar/adicionar teste dos DTOs relaxados aceitando RG de 11
+  dígitos; teste de `contracts.service.ts` confirmando que documentos
+  pontuados chegando do DTO são salvos sem pontuação.
+
+## Fora de escopo
+
+- `DatabasePage.tsx` (viewer genérico de debug).
+- Checksum de CPF quando usado como valor do campo RG (a validação de RG
+  hoje não tem checksum nenhum; não adicionamos um para o caso unificado).
+- `formatBRL` e demais formatadores não relacionados a documento/telefone.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -40,7 +40,8 @@
         "globals": "^16.4.0",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
-        "vite": "^7.1.7"
+        "vite": "^7.1.7",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1640,9 +1641,10 @@
       ]
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
@@ -1968,6 +1970,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2021,6 +2034,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2383,6 +2403,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@wojtekmaj/date-utils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
@@ -2464,6 +2597,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -2588,6 +2731,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2928,6 +3081,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3195,6 +3355,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3209,6 +3379,16 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4002,9 +4182,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.19",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz",
-      "integrity": "sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -4153,6 +4333,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4236,11 +4430,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -4680,6 +4893,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4688,6 +4908,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -4774,6 +5008,23 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4807,16 +5058,14 @@
         }
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5102,16 +5351,94 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
       "engines": {
-        "node": ">=12"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
       }
     },
     "node_modules/warning": {
@@ -5137,6 +5464,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build --configLoader runner",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -42,6 +43,7 @@
     "globals": "^16.4.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
-    "vite": "^7.1.7"
+    "vite": "^7.1.7",
+    "vitest": "^4.1.10"
   }
 }

--- a/frontend/src/components/appointments/ConfirmAppointmentModal.tsx
+++ b/frontend/src/components/appointments/ConfirmAppointmentModal.tsx
@@ -8,7 +8,7 @@ interface ConfirmAppointmentModalProps {
   specialistId: string;
   clientId: string;
   productType: "CAR" | "BOAT" | "AIRCRAFT";
-  productId: string | number;
+  productId: string;
   specialistName?: string;
   isEmailOnly?: boolean; // Se true, mostra fluxo para agendamento por email
 }

--- a/frontend/src/components/commission/CommissionMiniCalculator.tsx
+++ b/frontend/src/components/commission/CommissionMiniCalculator.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { ArrowRight, Calculator } from "lucide-react";
+import { Card } from "../ui/card";
+import { Input } from "../ui/input";
+import { CommissionSplitResult } from "./CommissionSplitResult";
+import { computeNestedCommissionSplit } from "../../lib/commission-split";
+import {
+  getSpecialists,
+  type Specialist,
+} from "../../services/specialists.service";
+
+const numericValue = (value: string) => Number(value) || 0;
+
+export function CommissionMiniCalculator() {
+  const [saleValue, setSaleValue] = useState("0");
+  const [totalCommissionRate, setTotalCommissionRate] = useState("10");
+  const [specialistShareRate, setSpecialistShareRate] = useState("0");
+  const [specialists, setSpecialists] = useState<Specialist[]>([]);
+
+  useEffect(() => {
+    getSpecialists().then(setSpecialists).catch(() => setSpecialists([]));
+  }, []);
+
+  const split = useMemo(
+    () =>
+      computeNestedCommissionSplit({
+        proposalValue: numericValue(saleValue),
+        totalCommissionRate: numericValue(totalCommissionRate),
+        specialistShareRate: numericValue(specialistShareRate),
+        officeShareRate: 0,
+      }),
+    [saleValue, totalCommissionRate, specialistShareRate],
+  );
+
+  return (
+    <Card className="h-full flex flex-col">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+        <div className="flex items-center gap-2">
+          <Calculator className="w-5 h-5 text-ink-soft" />
+          <h2 className="text-lg font-semibold text-ink">Calculadora rápida</h2>
+        </div>
+        <Link
+          to="/admin/calculator"
+          className="flex items-center gap-1 text-sm text-ink-soft hover:text-ink shrink-0 whitespace-nowrap"
+        >
+          calculadora completa <ArrowRight className="w-4 h-4" />
+        </Link>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 mb-4">
+        <div>
+          <label htmlFor="mini-calculator-sale-value" className="block text-xs text-muted mb-1">
+            Valor de venda (R$)
+          </label>
+          <Input
+            id="mini-calculator-sale-value"
+            type="number"
+            min={0}
+            step="0.01"
+            value={saleValue}
+            onChange={(e) => setSaleValue(e.target.value)}
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="mini-calculator-total-commission-rate"
+            className="block text-xs text-muted mb-1"
+          >
+            Comissão total (%)
+          </label>
+          <Input
+            id="mini-calculator-total-commission-rate"
+            type="number"
+            min={0}
+            max={100}
+            step="0.01"
+            value={totalCommissionRate}
+            onChange={(e) => setTotalCommissionRate(e.target.value)}
+          />
+        </div>
+        <div>
+          <label htmlFor="mini-calculator-specialist" className="block text-xs text-muted mb-1">
+            Especialista
+          </label>
+          <select
+            id="mini-calculator-specialist"
+            onChange={(e) => {
+              const specialist = specialists.find((s) => s.id === e.target.value);
+              setSpecialistShareRate(String(specialist?.commission_rate ?? 0));
+            }}
+            className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-focus-ring"
+          >
+            <option value="">Nenhum</option>
+            {specialists.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name} {s.surname}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="border-t border-border pt-4">
+        <CommissionSplitResult saleValue={numericValue(saleValue)} split={split} compact />
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/components/commission/CommissionMiniCalculator.tsx
+++ b/frontend/src/components/commission/CommissionMiniCalculator.tsx
@@ -5,12 +5,11 @@ import { Card } from "../ui/card";
 import { Input } from "../ui/input";
 import { CommissionSplitResult } from "./CommissionSplitResult";
 import { computeNestedCommissionSplit } from "../../lib/commission-split";
+import { normalizeCommissionCalculatorInput } from "../../lib/commission-calculator-input";
 import {
   getSpecialists,
   type Specialist,
 } from "../../services/specialists.service";
-
-const numericValue = (value: string) => Number(value) || 0;
 
 export function CommissionMiniCalculator() {
   const [saleValue, setSaleValue] = useState("0");
@@ -22,15 +21,26 @@ export function CommissionMiniCalculator() {
     getSpecialists().then(setSpecialists).catch(() => setSpecialists([]));
   }, []);
 
+  const calculationInput = useMemo(
+    () =>
+      normalizeCommissionCalculatorInput({
+        saleValue,
+        totalCommissionRate,
+        specialistShareRate,
+        officeShareRate: "0",
+      }),
+    [saleValue, totalCommissionRate, specialistShareRate],
+  );
+
   const split = useMemo(
     () =>
       computeNestedCommissionSplit({
-        proposalValue: numericValue(saleValue),
-        totalCommissionRate: numericValue(totalCommissionRate),
-        specialistShareRate: numericValue(specialistShareRate),
-        officeShareRate: 0,
+        proposalValue: calculationInput.saleValue,
+        totalCommissionRate: calculationInput.totalCommissionRate,
+        specialistShareRate: calculationInput.specialistShareRate,
+        officeShareRate: calculationInput.officeShareRate,
       }),
-    [saleValue, totalCommissionRate, specialistShareRate],
+    [calculationInput],
   );
 
   return (
@@ -102,7 +112,11 @@ export function CommissionMiniCalculator() {
       </div>
 
       <div className="border-t border-border pt-4">
-        <CommissionSplitResult saleValue={numericValue(saleValue)} split={split} compact />
+        <CommissionSplitResult
+          saleValue={calculationInput.saleValue}
+          split={split}
+          compact
+        />
       </div>
     </Card>
   );

--- a/frontend/src/components/commission/CommissionSplitResult.tsx
+++ b/frontend/src/components/commission/CommissionSplitResult.tsx
@@ -1,0 +1,105 @@
+import type { NestedCommissionSplit } from "../../lib/commission-split";
+import { effectiveRate } from "../../lib/commission-split";
+
+export interface CommissionSplitResultProps {
+  saleValue: number;
+  split: NestedCommissionSplit;
+  /** Versão reduzida (card do dashboard): sem tabela, sem linha de bolo. */
+  compact?: boolean;
+}
+
+const brl = (n: number) =>
+  n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+
+const DOT = {
+  specialist: "bg-emerald-500",
+  office: "bg-sky-500",
+  platform: "bg-violet-500",
+} as const;
+
+export function CommissionSplitResult({
+  saleValue,
+  split,
+  compact = false,
+}: CommissionSplitResultProps) {
+  if (compact) {
+    const rows = [
+      {
+        label: "Especialista",
+        value: split.specialistValue,
+        dot: DOT.specialist,
+      },
+      { label: "Escritório", value: split.officeValue, dot: DOT.office },
+      {
+        label: "Plataforma",
+        value: split.platformValue,
+        dot: DOT.platform,
+      },
+    ];
+    return (
+      <div className="flex flex-col gap-2">
+        {rows.map((row) => (
+          <div key={row.label} className="flex items-center justify-between text-sm">
+            <span className="inline-flex items-center gap-1.5 text-ink-soft">
+              <span className={`w-2 h-2 rounded-full shrink-0 ${row.dot}`} />
+              {row.label}
+            </span>
+            <span className="font-semibold text-ink">{brl(row.value)}</span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const bodyRows = [
+    { label: "Comissão total (bolo)", value: split.bolo, dot: null as string | null },
+    { label: "Especialista", value: split.specialistValue, dot: DOT.specialist },
+    { label: "Escritório", value: split.officeValue, dot: DOT.office },
+  ];
+
+  return (
+    <table className="w-full text-sm border border-border rounded-lg overflow-hidden">
+      <thead>
+        <tr className="bg-border-soft text-ink-soft">
+          <th className="text-left px-3 py-2 font-medium">Indicador</th>
+          <th className="text-right px-3 py-2 font-medium">Valor</th>
+          <th className="text-right px-3 py-2 font-medium">% da venda</th>
+        </tr>
+      </thead>
+      <tbody>
+        {bodyRows.map((row) => (
+          <tr key={row.label} className="border-t border-border">
+            <td className="px-3 py-2 text-ink-soft">
+              <span className="inline-flex items-center gap-1.5">
+                {row.dot && (
+                  <span className={`w-2 h-2 rounded-full shrink-0 ${row.dot}`} />
+                )}
+                {row.label}
+              </span>
+            </td>
+            <td className="px-3 py-2 text-right font-medium text-ink">
+              {brl(row.value)}
+            </td>
+            <td className="px-3 py-2 text-right text-ink-soft">
+              {effectiveRate(row.value, saleValue)}%
+            </td>
+          </tr>
+        ))}
+      </tbody>
+      <tfoot>
+        <tr className="bg-ink text-surface font-bold">
+          <td className="px-3 py-2">
+            <span className="inline-flex items-center gap-1.5">
+              <span className={`w-2 h-2 rounded-full shrink-0 ${DOT.platform}`} />
+              Plataforma
+            </span>
+          </td>
+          <td className="px-3 py-2 text-right">{brl(split.platformValue)}</td>
+          <td className="px-3 py-2 text-right">
+            {effectiveRate(split.platformValue, saleValue)}%
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  );
+}

--- a/frontend/src/components/commission/CommissionSplitResult.tsx
+++ b/frontend/src/components/commission/CommissionSplitResult.tsx
@@ -54,6 +54,11 @@ export function CommissionSplitResult({
   const bodyRows = [
     { label: "Comissão total (bolo)", value: split.bolo, dot: null as string | null },
     { label: "Especialista", value: split.specialistValue, dot: DOT.specialist },
+    {
+      label: "Restante",
+      value: split.bolo - split.specialistValue,
+      dot: null as string | null,
+    },
     { label: "Escritório", value: split.officeValue, dot: DOT.office },
   ];
 

--- a/frontend/src/components/processes/ProcessCard.tsx
+++ b/frontend/src/components/processes/ProcessCard.tsx
@@ -59,7 +59,7 @@ interface ProcessCardProps {
   product?:
     | Product
     | {
-        id: number | string;
+        id: string;
         marca?: string;
         modelo?: string;
         descricao?: string;

--- a/frontend/src/components/product/ProductSelectorModal.tsx
+++ b/frontend/src/components/product/ProductSelectorModal.tsx
@@ -39,7 +39,7 @@ type ModalState =
   | "error";
 
 interface ProductItem {
-  id: number;
+  id: string;
   type: SpecialityType;
   marca: string;
   modelo: string;

--- a/frontend/src/components/shared/XlsxImporter.tsx
+++ b/frontend/src/components/shared/XlsxImporter.tsx
@@ -56,7 +56,7 @@ const COLUMN_DEFINITIONS: Record<
   { required: string[]; optional: string[] }
 > = {
   CAR: {
-    required: ["marca", "modelo", "valor", "estado", "ano"],
+    required: ["marca", "modelo", "identificador", "valor", "estado", "ano"],
     optional: [
       "cor",
       "km",
@@ -68,7 +68,7 @@ const COLUMN_DEFINITIONS: Record<
     ],
   },
   BOAT: {
-    required: ["marca", "modelo", "valor", "estado", "ano"],
+    required: ["marca", "modelo", "identificador", "valor", "estado", "ano"],
     optional: [
       "fabricante",
       "tamanho",
@@ -83,7 +83,7 @@ const COLUMN_DEFINITIONS: Record<
     ],
   },
   AIRCRAFT: {
-    required: ["marca", "modelo", "valor", "estado", "ano"],
+    required: ["marca", "modelo", "identificador", "valor", "estado", "ano"],
     optional: [
       "categoria",
       "assentos",
@@ -336,9 +336,10 @@ export function XlsxImporter({
               </li>
               <li className="flex items-start gap-2">
                 <span className="w-1 h-1 mt-2 bg-gray-400 rounded-full shrink-0"></span>
-                Produtos com mesma{" "}
-                <strong className="text-gray-900">marca + modelo</strong> serao
-                atualizados ao inves de duplicados.
+                Produtos com mesmo{" "}
+                <strong className="text-gray-900">identificador</strong> serao
+                atualizados ao inves de duplicados (marca e modelo podem se
+                repetir entre produtos diferentes).
               </li>
             </ul>
           </div>

--- a/frontend/src/components/specialist/CommonProductFields.tsx
+++ b/frontend/src/components/specialist/CommonProductFields.tsx
@@ -79,7 +79,10 @@ export default function CommonProductFields({ register, errors, productType }: C
         <input
           id="identificador"
           type="text"
-          {...register("identificador", { required: "Identificador é obrigatório" })}
+          {...register("identificador", {
+            required: "Identificador é obrigatório",
+            setValueAs: (v) => (typeof v === "string" ? v.trim() : v),
+          })}
           className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
           placeholder={productType ? placeholders.identificador[productType] : "Ex: BMW-X5-1"}
         />

--- a/frontend/src/components/specialist/CommonProductFields.tsx
+++ b/frontend/src/components/specialist/CommonProductFields.tsx
@@ -19,6 +19,11 @@ export default function CommonProductFields({ register, errors, productType }: C
       BOAT: "Ex: S6, Flybridge 68, Manhattan 55",
       AIRCRAFT: "Ex: Phenom 300, G650, Citation X",
     },
+    identificador: {
+      CAR: "Ex: BMW-X5-1",
+      BOAT: "Ex: AZIMUT-S6-1",
+      AIRCRAFT: "Ex: EMBRAER-PHENOM300-1",
+    },
     ano: {
       CAR: "Ex: 2024",
       BOAT: "Ex: 2023",
@@ -63,6 +68,23 @@ export default function CommonProductFields({ register, errors, productType }: C
         />
         {errors.modelo && (
           <span className="text-sm text-red-500">{errors.modelo.message as string}</span>
+        )}
+      </div>
+
+      {/* Identificador */}
+      <div className="flex flex-col gap-2">
+        <label htmlFor="identificador" className="text-sm font-medium text-text-primary">
+          Identificador *
+        </label>
+        <input
+          id="identificador"
+          type="text"
+          {...register("identificador", { required: "Identificador é obrigatório" })}
+          className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder={productType ? placeholders.identificador[productType] : "Ex: BMW-X5-1"}
+        />
+        {errors.identificador && (
+          <span className="text-sm text-red-500">{errors.identificador.message as string}</span>
         )}
       </div>
 

--- a/frontend/src/components/specialist/ProductForm.tsx
+++ b/frontend/src/components/specialist/ProductForm.tsx
@@ -51,7 +51,7 @@ interface ProductFormProps {
   mode: "create" | "edit";
   productType?: ProductType;
   productData?: RawCar | RawBoat | RawAircraft;
-  productId?: number;
+  productId?: string;
   // Quando informado (cadastro disparado a partir de um processo em negociação),
   // o produto recém-criado é atribuído automaticamente a este processo.
   processId?: string;
@@ -254,7 +254,7 @@ export default function ProductForm({
 
       if (mode === "create") {
         // Criar novo produto
-        let createdId: number;
+        let createdId: string;
         if (productType === "CAR") {
           createdId = (await createCar(formattedData)).id;
         } else if (productType === "BOAT") {

--- a/frontend/src/components/specialist/ProductForm.tsx
+++ b/frontend/src/components/specialist/ProductForm.tsx
@@ -205,6 +205,7 @@ export default function ProductForm({
       const formattedData: any = {
         marca: data.marca,
         modelo: data.modelo,
+        identificador: data.identificador,
         ano: Number(data.ano),
         valor: Number(data.valor),
         estado: data.estado,

--- a/frontend/src/hooks/useCheckAppointment.ts
+++ b/frontend/src/hooks/useCheckAppointment.ts
@@ -35,7 +35,7 @@ export function useCheckAppointment(
   clientId: string | undefined,
   specialistId: string | undefined,
   productType: "CAR" | "BOAT" | "AIRCRAFT" | undefined,
-  productId: number | undefined
+  productId: string | undefined
 ): UseCheckAppointmentResult {
   const [existingAppointment, setExistingAppointment] =
     useState<Appointment | null>(null);

--- a/frontend/src/hooks/useCreateAppointment.ts
+++ b/frontend/src/hooks/useCreateAppointment.ts
@@ -5,7 +5,7 @@ export interface AppointmentData {
   specialist_id: string;
   client_id: string;
   product_type: "CAR" | "BOAT" | "AIRCRAFT";
-  product_id: string | number;
+  product_id: string;
   appointment_datetime?: string;
   notes?: string;
 }

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -14,6 +14,7 @@ import {
   Percent,
   Database,
   UserCheck,
+  Calculator,
 } from "lucide-react";
 import { useContext } from "react";
 import { AppContext } from "../contexts/AppContext";
@@ -149,6 +150,11 @@ export default function Sidebar() {
             to: "/admin/commissions",
             label: "Comissões",
             icon: <Percent size={20} />,
+          },
+          {
+            to: "/admin/calculator",
+            label: "Calculadora",
+            icon: <Calculator size={20} />,
           },
           {
             to: "/admin/database",

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -13,7 +13,6 @@ import {
   Settings,
   Percent,
   Database,
-  UserCheck,
   Calculator,
 } from "lucide-react";
 import { useContext } from "react";
@@ -199,13 +198,6 @@ export default function Sidebar() {
         break;
     }
 
-    if (user.role !== "OFFICE") {
-      links.push({
-        to: "/advisor/dashboard",
-        label: "Meus Assessorados",
-        icon: <UserCheck size={20} />,
-      });
-    }
   }
 
   return (

--- a/frontend/src/lib/commission-calculator-input.test.ts
+++ b/frontend/src/lib/commission-calculator-input.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCommissionCalculatorInput } from "./commission-calculator-input";
+
+describe("normalizeCommissionCalculatorInput", () => {
+  it("normaliza valores fora do domínio antes de calcular o split", () => {
+    expect(
+      normalizeCommissionCalculatorInput({
+        saleValue: "-250",
+        totalCommissionRate: "101",
+        specialistShareRate: "-1",
+        officeShareRate: "250",
+      }),
+    ).toEqual({
+      saleValue: 0,
+      totalCommissionRate: 100,
+      specialistShareRate: 0,
+      officeShareRate: 100,
+    });
+  });
+
+  it("descarta entradas não finitas sem alterar o texto que o campo controla", () => {
+    expect(
+      normalizeCommissionCalculatorInput({
+        saleValue: "Infinity",
+        totalCommissionRate: "NaN",
+        specialistShareRate: "",
+        officeShareRate: "1e309",
+      }),
+    ).toEqual({
+      saleValue: 0,
+      totalCommissionRate: 0,
+      specialistShareRate: 0,
+      officeShareRate: 0,
+    });
+  });
+});

--- a/frontend/src/lib/commission-calculator-input.test.ts
+++ b/frontend/src/lib/commission-calculator-input.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { normalizeCommissionCalculatorInput } from "./commission-calculator-input";
+import { computeNestedCommissionSplit } from "./commission-split";
 
 describe("normalizeCommissionCalculatorInput", () => {
   it("normaliza valores fora do domínio antes de calcular o split", () => {
@@ -32,5 +33,23 @@ describe("normalizeCommissionCalculatorInput", () => {
       specialistShareRate: 0,
       officeShareRate: 0,
     });
+  });
+
+  it("limita a venda máxima para manter cada etapa do split finita", () => {
+    const input = normalizeCommissionCalculatorInput({
+      saleValue: String(Number.MAX_VALUE),
+      totalCommissionRate: "100",
+      specialistShareRate: "50",
+      officeShareRate: "100",
+    });
+    const split = computeNestedCommissionSplit({
+      proposalValue: input.saleValue,
+      totalCommissionRate: input.totalCommissionRate,
+      specialistShareRate: input.specialistShareRate,
+      officeShareRate: input.officeShareRate,
+    });
+
+    expect(input.saleValue).toBe(Number.MAX_VALUE / 100);
+    expect(Object.values(split).every(Number.isFinite)).toBe(true);
   });
 });

--- a/frontend/src/lib/commission-calculator-input.ts
+++ b/frontend/src/lib/commission-calculator-input.ts
@@ -1,0 +1,36 @@
+export interface CommissionCalculatorTextInput {
+  saleValue: string;
+  totalCommissionRate: string;
+  specialistShareRate: string;
+  officeShareRate: string;
+}
+
+export interface NormalizedCommissionCalculatorInput {
+  saleValue: number;
+  totalCommissionRate: number;
+  specialistShareRate: number;
+  officeShareRate: number;
+}
+
+const finiteNumber = (value: string): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const inRange = (value: string, min: number, max: number): number =>
+  Math.min(max, Math.max(min, finiteNumber(value)));
+
+/**
+ * Converte somente para o cálculo. Os campos continuam controlados pelo texto
+ * digitado, inclusive enquanto o usuário está no meio de uma edição decimal.
+ */
+export function normalizeCommissionCalculatorInput(
+  input: CommissionCalculatorTextInput,
+): NormalizedCommissionCalculatorInput {
+  return {
+    saleValue: inRange(input.saleValue, 0, Number.MAX_VALUE),
+    totalCommissionRate: inRange(input.totalCommissionRate, 0, 100),
+    specialistShareRate: inRange(input.specialistShareRate, 0, 100),
+    officeShareRate: inRange(input.officeShareRate, 0, 100),
+  };
+}

--- a/frontend/src/lib/commission-calculator-input.ts
+++ b/frontend/src/lib/commission-calculator-input.ts
@@ -20,6 +20,9 @@ const finiteNumber = (value: string): number => {
 const inRange = (value: string, min: number, max: number): number =>
   Math.min(max, Math.max(min, finiteNumber(value)));
 
+// `round2` multiplica por 100 e as taxas podem chegar a 100 antes da divisão.
+const MAX_SAFE_SALE_VALUE = Number.MAX_VALUE / 100;
+
 /**
  * Converte somente para o cálculo. Os campos continuam controlados pelo texto
  * digitado, inclusive enquanto o usuário está no meio de uma edição decimal.
@@ -28,7 +31,7 @@ export function normalizeCommissionCalculatorInput(
   input: CommissionCalculatorTextInput,
 ): NormalizedCommissionCalculatorInput {
   return {
-    saleValue: inRange(input.saleValue, 0, Number.MAX_VALUE),
+    saleValue: inRange(input.saleValue, 0, MAX_SAFE_SALE_VALUE),
     totalCommissionRate: inRange(input.totalCommissionRate, 0, 100),
     specialistShareRate: inRange(input.specialistShareRate, 0, 100),
     officeShareRate: inRange(input.officeShareRate, 0, 100),

--- a/frontend/src/lib/commission-split.test.ts
+++ b/frontend/src/lib/commission-split.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { computeNestedCommissionSplit, effectiveRate } from "./commission-split";
+
+describe("computeNestedCommissionSplit", () => {
+  it("divide bolo em especialista / escritório / plataforma (aninhado)", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 100_000,
+      totalCommissionRate: 10, // bolo = 10.000
+      specialistShareRate: 70, // 70% do bolo
+      officeShareRate: 40, // 40% do restante
+    });
+    expect(r.bolo).toBe(10_000);
+    expect(r.specialistValue).toBe(7_000);
+    expect(r.officeValue).toBe(1_200); // 40% de 3.000
+    expect(r.platformValue).toBe(1_800); // resto do restante
+  });
+
+  it("sem escritório: restante inteiro vai pra plataforma", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 100_000,
+      totalCommissionRate: 10,
+      specialistShareRate: 70,
+      officeShareRate: 0,
+    });
+    expect(r.officeValue).toBe(0);
+    expect(r.platformValue).toBe(3_000);
+  });
+
+  it("as três fatias somam exatamente o bolo (sem drift de centavos)", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 99_999.99,
+      totalCommissionRate: 7.33,
+      specialistShareRate: 63.5,
+      officeShareRate: 41.7,
+    });
+    expect(r.specialistValue + r.officeValue + r.platformValue).toBe(r.bolo);
+  });
+
+  it("especialista com 100% do bolo zera escritório e plataforma", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 50_000,
+      totalCommissionRate: 8,
+      specialistShareRate: 100,
+      officeShareRate: 50,
+    });
+    expect(r.specialistValue).toBe(r.bolo);
+    expect(r.officeValue).toBe(0);
+    expect(r.platformValue).toBe(0);
+  });
+});
+
+describe("effectiveRate", () => {
+  it("calcula a taxa efetiva sobre a venda", () => {
+    expect(effectiveRate(7_000, 100_000)).toBe(7);
+    expect(effectiveRate(1_200, 100_000)).toBe(1.2);
+  });
+
+  it("retorna 0 quando a venda é 0", () => {
+    expect(effectiveRate(100, 0)).toBe(0);
+  });
+});

--- a/frontend/src/lib/commission-split.test.ts
+++ b/frontend/src/lib/commission-split.test.ts
@@ -26,14 +26,30 @@ describe("computeNestedCommissionSplit", () => {
     expect(r.platformValue).toBe(3_000);
   });
 
-  it("as três fatias somam exatamente o bolo (sem drift de centavos)", () => {
+  it("as três fatias somam o bolo em centavos (sem drift monetário)", () => {
     const r = computeNestedCommissionSplit({
       proposalValue: 99_999.99,
       totalCommissionRate: 7.33,
       specialistShareRate: 63.5,
       officeShareRate: 41.7,
     });
-    expect(r.specialistValue + r.officeValue + r.platformValue).toBe(r.bolo);
+    expect(
+      Math.round((r.specialistValue + r.officeValue + r.platformValue) * 100),
+    ).toBe(Math.round(r.bolo * 100));
+  });
+
+  it("preserva o bolo em centavos no limite de arredondamento", () => {
+    const r = computeNestedCommissionSplit({
+      proposalValue: 0.06,
+      totalCommissionRate: 100,
+      specialistShareRate: 0,
+      officeShareRate: 8.34,
+    });
+    expect(r.officeValue).toBe(0.01);
+    expect(r.platformValue).toBe(0.05);
+    expect(
+      Math.round((r.specialistValue + r.officeValue + r.platformValue) * 100),
+    ).toBe(Math.round(r.bolo * 100));
   });
 
   it("especialista com 100% do bolo zera escritório e plataforma", () => {

--- a/frontend/src/lib/commission-split.ts
+++ b/frontend/src/lib/commission-split.ts
@@ -1,0 +1,47 @@
+// ponytail: cópia da lógica pura de backend/src/features/contracts/commission-split.ts
+// (fonte de verdade do split real do contrato) — manter em sync manualmente se aquele
+// arquivo mudar; sem endpoint novo, calculadora roda 100% no client.
+
+export interface NestedCommissionInput {
+  /** Valor de referência da venda (produto ou manual). */
+  proposalValue: number;
+  /** % da venda que vira o "bolo" (comissão total), 0–100. */
+  totalCommissionRate: number;
+  /** Fatia do especialista SOBRE O BOLO, 0–100. */
+  specialistShareRate: number;
+  /** Fatia do escritório SOBRE O RESTANTE, 0–100; 0 quando não há escritório. */
+  officeShareRate: number;
+}
+
+export interface NestedCommissionSplit {
+  bolo: number;
+  specialistValue: number;
+  officeValue: number;
+  platformValue: number;
+}
+
+const round2 = (n: number): number => Math.round(n * 100) / 100;
+
+/**
+ * Split aninhado da comissão:
+ *   bolo         = venda × total%
+ *   especialista = bolo × fatiaEspecialista%
+ *   restante     = bolo − especialista
+ *   escritório   = restante × fatiaEscritório%
+ *   plataforma   = restante − escritório   (resíduo)
+ */
+export function computeNestedCommissionSplit(
+  input: NestedCommissionInput,
+): NestedCommissionSplit {
+  const bolo = round2((input.proposalValue * input.totalCommissionRate) / 100);
+  const specialistValue = round2((bolo * input.specialistShareRate) / 100);
+  const restante = round2(bolo - specialistValue);
+  const officeValue = round2((restante * input.officeShareRate) / 100);
+  const platformValue = round2(restante - officeValue);
+  return { bolo, specialistValue, officeValue, platformValue };
+}
+
+/** Taxa efetiva de um valor sobre a venda, em %. */
+export function effectiveRate(value: number, saleValue: number): number {
+  return saleValue > 0 ? round2((value / saleValue) * 100) : 0;
+}

--- a/frontend/src/pages/admin/CommissionCalculatorPage.tsx
+++ b/frontend/src/pages/admin/CommissionCalculatorPage.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useMemo, useState } from "react";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { Card } from "../../components/ui/card";
+import { Input } from "../../components/ui/input";
+import { CommissionSplitResult } from "../../components/commission/CommissionSplitResult";
+import { computeNestedCommissionSplit } from "../../lib/commission-split";
+import {
+  getSpecialists,
+  type Specialist,
+} from "../../services/specialists.service";
+import { getCompanies, type Company } from "../../services/companies.service";
+import { getCars } from "../../services/cars.service";
+import { getBoats } from "../../services/boats.service";
+import { getAircrafts } from "../../services/aircrafts.service";
+import type { Product } from "../../types/types";
+
+type ProductCategory = "CAR" | "BOAT" | "AIRCRAFT";
+
+const CATEGORY_LABEL: Record<ProductCategory, string> = {
+  CAR: "Carro",
+  BOAT: "Embarcação",
+  AIRCRAFT: "Aeronave",
+};
+
+const brl = (n: number) =>
+  n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+
+async function fetchProductsByCategory(
+  category: ProductCategory,
+): Promise<Product[]> {
+  if (category === "CAR") return (await getCars(1, 100)).cars;
+  if (category === "BOAT") return (await getBoats(1, 100)).boats;
+  return (await getAircrafts(1, 100)).aircrafts;
+}
+
+const selectClass =
+  "w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-focus-ring";
+const labelClass = "block text-sm font-medium text-ink-soft mb-1";
+
+export default function CommissionCalculatorPage() {
+  const [saleValue, setSaleValue] = useState(0);
+  const [totalCommissionRate, setTotalCommissionRate] = useState(10);
+  const [specialistShareRate, setSpecialistShareRate] = useState(0);
+  const [officeShareRate, setOfficeShareRate] = useState(0);
+
+  const [specialists, setSpecialists] = useState<Specialist[]>([]);
+  const [companies, setCompanies] = useState<Company[]>([]);
+  const [category, setCategory] = useState<ProductCategory | "">("");
+  const [products, setProducts] = useState<Product[]>([]);
+  const [isLoadingProducts, setIsLoadingProducts] = useState(false);
+
+  useEffect(() => {
+    getSpecialists().then(setSpecialists).catch(() => setSpecialists([]));
+    getCompanies().then(setCompanies).catch(() => setCompanies([]));
+  }, []);
+
+  useEffect(() => {
+    if (!category) {
+      setProducts([]);
+      return;
+    }
+    setIsLoadingProducts(true);
+    fetchProductsByCategory(category)
+      .then(setProducts)
+      .catch(() => setProducts([]))
+      .finally(() => setIsLoadingProducts(false));
+  }, [category]);
+
+  const split = useMemo(
+    () =>
+      computeNestedCommissionSplit({
+        proposalValue: saleValue,
+        totalCommissionRate,
+        specialistShareRate,
+        officeShareRate,
+      }),
+    [saleValue, totalCommissionRate, specialistShareRate, officeShareRate],
+  );
+
+  return (
+    <div className="w-full">
+      <PageHeader title="Calculadora de comissões" />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2 flex flex-col gap-6">
+          <Card className="flex flex-col gap-4">
+            <h2 className="text-lg font-semibold text-ink">Venda</h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className={labelClass}>
+                  Categoria do produto (opcional)
+                </label>
+                <select
+                  value={category}
+                  onChange={(e) =>
+                    setCategory(e.target.value as ProductCategory | "")
+                  }
+                  className={selectClass}
+                >
+                  <option value="">Nenhuma — valor manual</option>
+                  <option value="CAR">Carro</option>
+                  <option value="BOAT">Embarcação</option>
+                  <option value="AIRCRAFT">Aeronave</option>
+                </select>
+              </div>
+
+              <div>
+                <label className={labelClass}>
+                  Produto {category && `(${CATEGORY_LABEL[category]})`}
+                </label>
+                <select
+                  disabled={!category || isLoadingProducts}
+                  onChange={(e) => {
+                    const product = products.find(
+                      (p) => String(p.id) === e.target.value,
+                    );
+                    if (product) setSaleValue(product.valor);
+                  }}
+                  className={selectClass}
+                >
+                  <option value="">
+                    {isLoadingProducts ? "Carregando..." : "Selecionar produto"}
+                  </option>
+                  {products.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.marca} {p.modelo} — {brl(p.valor)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div>
+              <label className={labelClass}>Valor de venda (R$)</label>
+              <Input
+                type="number"
+                min={0}
+                step="0.01"
+                value={saleValue}
+                onChange={(e) => setSaleValue(Number(e.target.value) || 0)}
+              />
+            </div>
+
+            <div>
+              <label className={labelClass}>Comissão total da venda (%)</label>
+              <Input
+                type="number"
+                min={0}
+                max={100}
+                step="0.01"
+                value={totalCommissionRate}
+                onChange={(e) =>
+                  setTotalCommissionRate(Number(e.target.value) || 0)
+                }
+              />
+            </div>
+          </Card>
+
+          <Card className="flex flex-col gap-4">
+            <h2 className="text-lg font-semibold text-ink">
+              Especialista e escritório
+            </h2>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className={labelClass}>Especialista (opcional)</label>
+                <select
+                  onChange={(e) => {
+                    const specialist = specialists.find(
+                      (s) => s.id === e.target.value,
+                    );
+                    setSpecialistShareRate(specialist?.commission_rate ?? 0);
+                  }}
+                  className={selectClass}
+                >
+                  <option value="">Nenhum — fatia manual</option>
+                  {specialists.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name} {s.surname}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className={labelClass}>
+                  Fatia do especialista sobre o bolo (%)
+                </label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  value={specialistShareRate}
+                  onChange={(e) =>
+                    setSpecialistShareRate(Number(e.target.value) || 0)
+                  }
+                />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className={labelClass}>Escritório (opcional)</label>
+                <select
+                  onChange={(e) => {
+                    const company = companies.find((c) => c.id === e.target.value);
+                    setOfficeShareRate(company?.commission_rate ?? 0);
+                  }}
+                  className={selectClass}
+                >
+                  <option value="">Nenhum</option>
+                  {companies.map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className={labelClass}>
+                  Fatia do escritório sobre o restante (%)
+                </label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="0.01"
+                  value={officeShareRate}
+                  onChange={(e) =>
+                    setOfficeShareRate(Number(e.target.value) || 0)
+                  }
+                />
+              </div>
+            </div>
+          </Card>
+        </div>
+
+        <div className="lg:sticky lg:top-6 h-fit">
+          <Card>
+            <h2 className="text-lg font-semibold text-ink mb-4">Resultado</h2>
+            <CommissionSplitResult saleValue={saleValue} split={split} />
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/CommissionCalculatorPage.tsx
+++ b/frontend/src/pages/admin/CommissionCalculatorPage.tsx
@@ -25,6 +25,8 @@ const CATEGORY_LABEL: Record<ProductCategory, string> = {
 const brl = (n: number) =>
   n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 
+const numericValue = (value: string) => Number(value) || 0;
+
 async function fetchProductsByCategory(
   category: ProductCategory,
 ): Promise<Product[]> {
@@ -38,10 +40,10 @@ const selectClass =
 const labelClass = "block text-sm font-medium text-ink-soft mb-1";
 
 export default function CommissionCalculatorPage() {
-  const [saleValue, setSaleValue] = useState(0);
-  const [totalCommissionRate, setTotalCommissionRate] = useState(10);
-  const [specialistShareRate, setSpecialistShareRate] = useState(0);
-  const [officeShareRate, setOfficeShareRate] = useState(0);
+  const [saleValue, setSaleValue] = useState("0");
+  const [totalCommissionRate, setTotalCommissionRate] = useState("10");
+  const [specialistShareRate, setSpecialistShareRate] = useState("0");
+  const [officeShareRate, setOfficeShareRate] = useState("0");
 
   const [specialists, setSpecialists] = useState<Specialist[]>([]);
   const [companies, setCompanies] = useState<Company[]>([]);
@@ -57,22 +59,35 @@ export default function CommissionCalculatorPage() {
   useEffect(() => {
     if (!category) {
       setProducts([]);
+      setIsLoadingProducts(false);
       return;
     }
+
+    let isCurrentRequest = true;
     setIsLoadingProducts(true);
     fetchProductsByCategory(category)
-      .then(setProducts)
-      .catch(() => setProducts([]))
-      .finally(() => setIsLoadingProducts(false));
+      .then((nextProducts) => {
+        if (isCurrentRequest) setProducts(nextProducts);
+      })
+      .catch(() => {
+        if (isCurrentRequest) setProducts([]);
+      })
+      .finally(() => {
+        if (isCurrentRequest) setIsLoadingProducts(false);
+      });
+
+    return () => {
+      isCurrentRequest = false;
+    };
   }, [category]);
 
   const split = useMemo(
     () =>
       computeNestedCommissionSplit({
-        proposalValue: saleValue,
-        totalCommissionRate,
-        specialistShareRate,
-        officeShareRate,
+        proposalValue: numericValue(saleValue),
+        totalCommissionRate: numericValue(totalCommissionRate),
+        specialistShareRate: numericValue(specialistShareRate),
+        officeShareRate: numericValue(officeShareRate),
       }),
     [saleValue, totalCommissionRate, specialistShareRate, officeShareRate],
   );
@@ -88,10 +103,11 @@ export default function CommissionCalculatorPage() {
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <label className={labelClass}>
+                <label htmlFor="calculator-category" className={labelClass}>
                   Categoria do produto (opcional)
                 </label>
                 <select
+                  id="calculator-category"
                   value={category}
                   onChange={(e) =>
                     setCategory(e.target.value as ProductCategory | "")
@@ -106,16 +122,17 @@ export default function CommissionCalculatorPage() {
               </div>
 
               <div>
-                <label className={labelClass}>
+                <label htmlFor="calculator-product" className={labelClass}>
                   Produto {category && `(${CATEGORY_LABEL[category]})`}
                 </label>
                 <select
+                  id="calculator-product"
                   disabled={!category || isLoadingProducts}
                   onChange={(e) => {
                     const product = products.find(
                       (p) => String(p.id) === e.target.value,
                     );
-                    if (product) setSaleValue(product.valor);
+                    if (product) setSaleValue(String(product.valor));
                   }}
                   className={selectClass}
                 >
@@ -132,27 +149,34 @@ export default function CommissionCalculatorPage() {
             </div>
 
             <div>
-              <label className={labelClass}>Valor de venda (R$)</label>
+              <label htmlFor="calculator-sale-value" className={labelClass}>
+                Valor de venda (R$)
+              </label>
               <Input
+                id="calculator-sale-value"
                 type="number"
                 min={0}
                 step="0.01"
                 value={saleValue}
-                onChange={(e) => setSaleValue(Number(e.target.value) || 0)}
+                onChange={(e) => setSaleValue(e.target.value)}
               />
             </div>
 
             <div>
-              <label className={labelClass}>Comissão total da venda (%)</label>
+              <label
+                htmlFor="calculator-total-commission-rate"
+                className={labelClass}
+              >
+                Comissão total da venda (%)
+              </label>
               <Input
+                id="calculator-total-commission-rate"
                 type="number"
                 min={0}
                 max={100}
                 step="0.01"
                 value={totalCommissionRate}
-                onChange={(e) =>
-                  setTotalCommissionRate(Number(e.target.value) || 0)
-                }
+                onChange={(e) => setTotalCommissionRate(e.target.value)}
               />
             </div>
           </Card>
@@ -164,13 +188,20 @@ export default function CommissionCalculatorPage() {
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <label className={labelClass}>Especialista (opcional)</label>
+                <label htmlFor="calculator-specialist" className={labelClass}>
+                  Especialista (opcional)
+                </label>
                 <select
+                  id="calculator-specialist"
                   onChange={(e) => {
                     const specialist = specialists.find(
                       (s) => s.id === e.target.value,
                     );
-                    setSpecialistShareRate(specialist?.commission_rate ?? 0);
+                    if (specialist) {
+                      setSpecialistShareRate(
+                        String(specialist.commission_rate ?? 0),
+                      );
+                    }
                   }}
                   className={selectClass}
                 >
@@ -184,29 +215,36 @@ export default function CommissionCalculatorPage() {
               </div>
 
               <div>
-                <label className={labelClass}>
+                <label
+                  htmlFor="calculator-specialist-share-rate"
+                  className={labelClass}
+                >
                   Fatia do especialista sobre o bolo (%)
                 </label>
                 <Input
+                  id="calculator-specialist-share-rate"
                   type="number"
                   min={0}
                   max={100}
                   step="0.01"
                   value={specialistShareRate}
-                  onChange={(e) =>
-                    setSpecialistShareRate(Number(e.target.value) || 0)
-                  }
+                  onChange={(e) => setSpecialistShareRate(e.target.value)}
                 />
               </div>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <label className={labelClass}>Escritório (opcional)</label>
+                <label htmlFor="calculator-office" className={labelClass}>
+                  Escritório (opcional)
+                </label>
                 <select
+                  id="calculator-office"
                   onChange={(e) => {
                     const company = companies.find((c) => c.id === e.target.value);
-                    setOfficeShareRate(company?.commission_rate ?? 0);
+                    if (company) {
+                      setOfficeShareRate(String(company.commission_rate ?? 0));
+                    }
                   }}
                   className={selectClass}
                 >
@@ -220,18 +258,20 @@ export default function CommissionCalculatorPage() {
               </div>
 
               <div>
-                <label className={labelClass}>
+                <label
+                  htmlFor="calculator-office-share-rate"
+                  className={labelClass}
+                >
                   Fatia do escritório sobre o restante (%)
                 </label>
                 <Input
+                  id="calculator-office-share-rate"
                   type="number"
                   min={0}
                   max={100}
                   step="0.01"
                   value={officeShareRate}
-                  onChange={(e) =>
-                    setOfficeShareRate(Number(e.target.value) || 0)
-                  }
+                  onChange={(e) => setOfficeShareRate(e.target.value)}
                 />
               </div>
             </div>
@@ -241,7 +281,10 @@ export default function CommissionCalculatorPage() {
         <div className="lg:sticky lg:top-6 h-fit">
           <Card>
             <h2 className="text-lg font-semibold text-ink mb-4">Resultado</h2>
-            <CommissionSplitResult saleValue={saleValue} split={split} />
+            <CommissionSplitResult
+              saleValue={numericValue(saleValue)}
+              split={split}
+            />
           </Card>
         </div>
       </div>

--- a/frontend/src/pages/admin/CommissionCalculatorPage.tsx
+++ b/frontend/src/pages/admin/CommissionCalculatorPage.tsx
@@ -4,6 +4,7 @@ import { Card } from "../../components/ui/card";
 import { Input } from "../../components/ui/input";
 import { CommissionSplitResult } from "../../components/commission/CommissionSplitResult";
 import { computeNestedCommissionSplit } from "../../lib/commission-split";
+import { normalizeCommissionCalculatorInput } from "../../lib/commission-calculator-input";
 import {
   getSpecialists,
   type Specialist,
@@ -24,8 +25,6 @@ const CATEGORY_LABEL: Record<ProductCategory, string> = {
 
 const brl = (n: number) =>
   n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
-
-const numericValue = (value: string) => Number(value) || 0;
 
 async function fetchProductsByCategory(
   category: ProductCategory,
@@ -49,6 +48,7 @@ export default function CommissionCalculatorPage() {
   const [companies, setCompanies] = useState<Company[]>([]);
   const [category, setCategory] = useState<ProductCategory | "">("");
   const [products, setProducts] = useState<Product[]>([]);
+  const [selectedProductId, setSelectedProductId] = useState("");
   const [isLoadingProducts, setIsLoadingProducts] = useState(false);
 
   useEffect(() => {
@@ -81,15 +81,26 @@ export default function CommissionCalculatorPage() {
     };
   }, [category]);
 
+  const calculationInput = useMemo(
+    () =>
+      normalizeCommissionCalculatorInput({
+        saleValue,
+        totalCommissionRate,
+        specialistShareRate,
+        officeShareRate,
+      }),
+    [saleValue, totalCommissionRate, specialistShareRate, officeShareRate],
+  );
+
   const split = useMemo(
     () =>
       computeNestedCommissionSplit({
-        proposalValue: numericValue(saleValue),
-        totalCommissionRate: numericValue(totalCommissionRate),
-        specialistShareRate: numericValue(specialistShareRate),
-        officeShareRate: numericValue(officeShareRate),
+        proposalValue: calculationInput.saleValue,
+        totalCommissionRate: calculationInput.totalCommissionRate,
+        specialistShareRate: calculationInput.specialistShareRate,
+        officeShareRate: calculationInput.officeShareRate,
       }),
-    [saleValue, totalCommissionRate, specialistShareRate, officeShareRate],
+    [calculationInput],
   );
 
   return (
@@ -109,9 +120,12 @@ export default function CommissionCalculatorPage() {
                 <select
                   id="calculator-category"
                   value={category}
-                  onChange={(e) =>
-                    setCategory(e.target.value as ProductCategory | "")
-                  }
+                  onChange={(e) => {
+                    setCategory(e.target.value as ProductCategory | "");
+                    setSelectedProductId("");
+                    setProducts([]);
+                    setSaleValue("0");
+                  }}
                   className={selectClass}
                 >
                   <option value="">Nenhuma — valor manual</option>
@@ -128,7 +142,9 @@ export default function CommissionCalculatorPage() {
                 <select
                   id="calculator-product"
                   disabled={!category || isLoadingProducts}
+                  value={selectedProductId}
                   onChange={(e) => {
+                    setSelectedProductId(e.target.value);
                     const product = products.find(
                       (p) => String(p.id) === e.target.value,
                     );
@@ -282,7 +298,7 @@ export default function CommissionCalculatorPage() {
           <Card>
             <h2 className="text-lg font-semibold text-ink mb-4">Resultado</h2>
             <CommissionSplitResult
-              saleValue={numericValue(saleValue)}
+              saleValue={calculationInput.saleValue}
               split={split}
             />
           </Card>

--- a/frontend/src/pages/admin/DashboardPage.tsx
+++ b/frontend/src/pages/admin/DashboardPage.tsx
@@ -32,6 +32,7 @@ import {
 import { AppContext } from "../../contexts/AppContext";
 import { Card } from "../../components/ui/card";
 import { PageHeader } from "../../components/patterns/PageHeader";
+import { CommissionMiniCalculator } from "../../components/commission/CommissionMiniCalculator";
 
 const brl = (n: number) =>
   n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
@@ -334,6 +335,17 @@ export default function DashboardPage() {
               </div>
             )}
           </Card>
+        </motion.div>
+      </div>
+
+      {/* Calculadora rápida de comissões */}
+      <div className="mb-8">
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: cardDuration, delay: 0.19 }}
+        >
+          <CommissionMiniCalculator />
         </motion.div>
       </div>
 

--- a/frontend/src/pages/catalog/ProductPage.tsx
+++ b/frontend/src/pages/catalog/ProductPage.tsx
@@ -147,13 +147,13 @@ export default function ProductPage() {
 
         switch (productType) {
           case "car":
-            rawProduct = await getCarById(Number(id));
+            rawProduct = await getCarById(id);
             break;
           case "boat":
-            rawProduct = await getBoatById(Number(id));
+            rawProduct = await getBoatById(id);
             break;
           case "aircraft":
-            rawProduct = await getAircraftById(Number(id));
+            rawProduct = await getAircraftById(id);
             break;
           default:
             throw new Error("Tipo de produto desconhecido");
@@ -295,7 +295,7 @@ export default function ProductPage() {
               user.id,
               specialist.id,
               productType.toUpperCase() as "CAR" | "BOAT" | "AIRCRAFT",
-              Number(product.id),
+              product.id,
             );
             if (existing) {
               setLockedAppointment(existing);
@@ -365,7 +365,7 @@ export default function ProductPage() {
               user.id,
               specialist.id,
               productType.toUpperCase() as "CAR" | "BOAT" | "AIRCRAFT",
-              Number(product.id),
+              product.id,
             );
             if (existing) {
               setLockedAppointment(existing);
@@ -667,7 +667,7 @@ export default function ProductPage() {
                       ? "AIRCRAFT"
                       : (productType.toUpperCase() as "CAR" | "BOAT" | "AIRCRAFT"))
               }
-              productId={Number(id)}
+              productId={id}
               specialistId={specialist.id}
               productLabel={`${product.marca} ${product.modelo}`.trim()}
               onClose={() => setIsStartProcessModalOpen(false)}

--- a/frontend/src/pages/consultant/StartProcessForClientModal.tsx
+++ b/frontend/src/pages/consultant/StartProcessForClientModal.tsx
@@ -12,7 +12,7 @@ import { Loader2, Search } from "lucide-react";
 
 interface Props {
   productType: "CAR" | "BOAT" | "AIRCRAFT";
-  productId: number;
+  productId: string;
   specialistId: string;
   productLabel?: string;
   onClose: () => void;

--- a/frontend/src/pages/customer/CustomerProcessesPage.tsx
+++ b/frontend/src/pages/customer/CustomerProcessesPage.tsx
@@ -35,7 +35,7 @@ interface ProcessClient {
     name?: string;
   };
   product?: {
-    id: number | string;
+    id: string;
     marca?: string;
     modelo?: string;
   };

--- a/frontend/src/pages/specialist/ProductFormPage.tsx
+++ b/frontend/src/pages/specialist/ProductFormPage.tsx
@@ -28,7 +28,7 @@ export default function ProductFormPage() {
 
     setLoading(true);
     try {
-      const productId = Number(id);
+      const productId = id;
 
       if (productType === "cars") {
         const data = await getCarById(productId);
@@ -84,7 +84,7 @@ export default function ProductFormPage() {
             mode={mode}
             productType={mode === "edit" ? getProductTypeEnum() : undefined}
             productData={productData}
-            productId={id ? Number(id) : undefined}
+            productId={id}
             processId={mode === "create" ? processId : undefined}
           />
         )}
@@ -92,4 +92,3 @@ export default function ProductFormPage() {
     </div>
   );
 }
-

--- a/frontend/src/pages/specialist/ProductsPage.tsx
+++ b/frontend/src/pages/specialist/ProductsPage.tsx
@@ -15,7 +15,7 @@ import { PageHeader } from "../../components/patterns/PageHeader";
 type ProductType = "cars" | "boats" | "aircrafts";
 
 interface Product {
-  id: number;
+  id: string;
   marca: string;
   modelo: string;
   ano?: number;
@@ -85,7 +85,7 @@ export default function ProductsPage() {
     }
   };
 
-  const handleDelete = async (id: number) => {
+  const handleDelete = async (id: string) => {
     if (!window.confirm("Tem certeza que deseja excluir este produto?")) {
       return;
     }
@@ -106,7 +106,7 @@ export default function ProductsPage() {
     }
   };
 
-  const handleEdit = (id: number) => {
+  const handleEdit = (id: string) => {
     navigate(`/specialist/products/edit/${productType}/${id}`);
   };
 

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -19,6 +19,7 @@ import SettingsPage from "../pages/admin/SettingsPage";
 import MyCompanyPage from "../pages/admin/MyCompanyPage";
 import CommissionsPage from "../pages/admin/CommissionsPage";
 import DatabasePage from "../pages/admin/DatabasePage";
+import CommissionCalculatorPage from "../pages/admin/CommissionCalculatorPage";
 import ProductsPage from "../pages/specialist/ProductsPage";
 import ProductFormPage from "../pages/specialist/ProductFormPage";
 import SpecialistDashboard from "../pages/specialist/SpecialistDashboard";
@@ -260,6 +261,16 @@ export default function RouterApp() {
         <MainLayout>
           <ProtectedRoute allowedRoles={["ADMIN"]}>
             <CommissionsPage />
+          </ProtectedRoute>
+        </MainLayout>
+      ),
+    },
+    {
+      path: "/admin/calculator",
+      element: (
+        <MainLayout>
+          <ProtectedRoute allowedRoles={["ADMIN"]}>
+            <CommissionCalculatorPage />
           </ProtectedRoute>
         </MainLayout>
       ),

--- a/frontend/src/services/aircrafts.service.ts
+++ b/frontend/src/services/aircrafts.service.ts
@@ -16,6 +16,7 @@ export interface RawAircraft {
   id: string;
   marca: string;
   modelo: string;
+  identificador: string;
   valor: number;
   estado: string;
   ano: number;

--- a/frontend/src/services/aircrafts.service.ts
+++ b/frontend/src/services/aircrafts.service.ts
@@ -13,7 +13,7 @@ import {
 } from "./product-import-jobs.service";
 
 export interface RawAircraft {
-  id: number;
+  id: string;
   marca: string;
   modelo: string;
   valor: number;
@@ -114,7 +114,7 @@ export async function getAircrafts(
 }
 
 // Get /aircrafts/:id
-export async function getAircraftById(id: number): Promise<RawAircraft> {
+export async function getAircraftById(id: string): Promise<RawAircraft> {
   try {
     const response = await api.get<RawAircraft>(`/aircrafts/${id}`);
     return response.data;
@@ -139,7 +139,7 @@ export async function createAircraft(
 
 // Patch /aircrafts/:id
 export async function updateAircraft(
-  id: number,
+  id: string,
   data: UpdateAircraftDto,
 ): Promise<RawAircraft> {
   try {
@@ -152,7 +152,7 @@ export async function updateAircraft(
 }
 
 // Delete /aircrafts/:id
-export async function deleteAircraft(id: number): Promise<void> {
+export async function deleteAircraft(id: string): Promise<void> {
   try {
     await api.delete(`/aircrafts/${id}`);
   } catch (error) {

--- a/frontend/src/services/aircrafts.service.ts
+++ b/frontend/src/services/aircrafts.service.ts
@@ -48,6 +48,7 @@ export interface ImageDto {
 export interface CreateAircraftDto {
   marca: string;
   modelo: string;
+  identificador: string;
   valor: number;
   estado: string;
   ano: number;

--- a/frontend/src/services/appointments.service.ts
+++ b/frontend/src/services/appointments.service.ts
@@ -5,7 +5,7 @@ export interface Appointment {
   client_id: string;
   specialist_id: string;
   product_type?: "CAR" | "BOAT" | "AIRCRAFT" | null;
-  product_id?: number | null;
+  product_id?: string | null;
   appointment_datetime?: string | null;
   status: "PENDING" | "SCHEDULED" | "COMPLETED" | "CANCELLED";
   notes?: string;
@@ -33,7 +33,7 @@ export interface Appointment {
     calendly_url?: string;
   };
   product?: {
-    id: number;
+    id: string;
     product_type: string;
     marca: string;
     modelo: string;
@@ -82,7 +82,7 @@ export async function checkExistingAppointment(
   clientId: string,
   specialistId: string,
   productType: "CAR" | "BOAT" | "AIRCRAFT",
-  productId: number,
+  productId: string,
 ): Promise<Appointment | null> {
   try {
     const response = await api.get<ApiResponse<Appointment | null>>(
@@ -113,7 +113,7 @@ export async function createPendingAppointment(data: {
   client_id: string;
   specialist_id: string;
   product_type: "CAR" | "BOAT" | "AIRCRAFT";
-  product_id: number;
+  product_id: string;
   notes?: string;
 }): Promise<Appointment> {
   const response = await api.post<ApiResponse<Appointment>>(

--- a/frontend/src/services/boats.service.ts
+++ b/frontend/src/services/boats.service.ts
@@ -13,7 +13,7 @@ import {
 } from "./product-import-jobs.service";
 
 export interface RawBoat {
-  id: number;
+  id: string;
   marca: string;
   modelo: string;
   valor: number;
@@ -130,7 +130,7 @@ export async function getBoats(
 }
 
 // Get /boats/:id
-export async function getBoatById(id: number): Promise<RawBoat> {
+export async function getBoatById(id: string): Promise<RawBoat> {
   try {
     const response = await api.get<RawBoat>(`/boats/${id}`);
     return response.data;
@@ -153,7 +153,7 @@ export async function createBoat(data: CreateBoatDto): Promise<RawBoat> {
 
 // Patch /boats/:id
 export async function updateBoat(
-  id: number,
+  id: string,
   data: UpdateBoatDto,
 ): Promise<RawBoat> {
   try {
@@ -166,7 +166,7 @@ export async function updateBoat(
 }
 
 // Delete /boats/:id
-export async function deleteBoat(id: number): Promise<void> {
+export async function deleteBoat(id: string): Promise<void> {
   try {
     await api.delete(`/boats/${id}`);
   } catch (error) {

--- a/frontend/src/services/boats.service.ts
+++ b/frontend/src/services/boats.service.ts
@@ -53,6 +53,7 @@ export interface ImageDto {
 export interface CreateBoatDto {
   marca: string;
   modelo: string;
+  identificador: string;
   valor: number;
   estado: string;
   ano: number;

--- a/frontend/src/services/boats.service.ts
+++ b/frontend/src/services/boats.service.ts
@@ -16,6 +16,7 @@ export interface RawBoat {
   id: string;
   marca: string;
   modelo: string;
+  identificador: string;
   valor: number;
   estado: string;
   ano: number;

--- a/frontend/src/services/cars.service.ts
+++ b/frontend/src/services/cars.service.ts
@@ -16,6 +16,7 @@ export interface RawCar {
   id: string;
   marca: string;
   modelo: string;
+  identificador: string;
   valor: number;
   estado: string;
   ano: number;

--- a/frontend/src/services/cars.service.ts
+++ b/frontend/src/services/cars.service.ts
@@ -13,7 +13,7 @@ import {
 } from "./product-import-jobs.service";
 
 export interface RawCar {
-  id: number;
+  id: string;
   marca: string;
   modelo: string;
   valor: number;
@@ -119,7 +119,7 @@ export async function getCars(
 }
 
 // Get /cars/:id
-export async function getCarById(id: number): Promise<RawCar> {
+export async function getCarById(id: string): Promise<RawCar> {
   try {
     const response = await api.get<RawCar>(`/cars/${id}`);
     return response.data;
@@ -142,7 +142,7 @@ export async function createCar(data: CreateCarDto): Promise<RawCar> {
 
 // Patch /cars/:id
 export async function updateCar(
-  id: number,
+  id: string,
   data: UpdateCarDto,
 ): Promise<RawCar> {
   try {
@@ -155,7 +155,7 @@ export async function updateCar(
 }
 
 // Delete /cars/:id
-export async function deleteCar(id: number): Promise<void> {
+export async function deleteCar(id: string): Promise<void> {
   try {
     await api.delete(`/cars/${id}`);
   } catch (error) {

--- a/frontend/src/services/cars.service.ts
+++ b/frontend/src/services/cars.service.ts
@@ -50,6 +50,7 @@ export interface ImageDto {
 export interface CreateCarDto {
   marca: string;
   modelo: string;
+  identificador: string;
   valor: number;
   estado: string;
   ano: number;

--- a/frontend/src/services/consultant.service.ts
+++ b/frontend/src/services/consultant.service.ts
@@ -122,7 +122,7 @@ export type CreateConsultantProcessData = {
   client_id: string;
   specialist_id: string;
   product_type: 'CAR' | 'BOAT' | 'AIRCRAFT';
-  product_id?: number;
+  product_id?: string;
 };
 
 export type ConsultantProcessResult = {
@@ -212,4 +212,3 @@ export async function registerConsultant(data: {
   const response = await api.post('/auth/register-consultant', data);
   return response.data;
 }
-

--- a/frontend/src/services/processes.service.ts
+++ b/frontend/src/services/processes.service.ts
@@ -19,7 +19,7 @@ export interface Process {
   product_type?: "CAR" | "BOAT" | "AIRCRAFT" | null;
   client_id: string;
   specialist_id: string;
-  product_id?: number | string | null;
+  product_id?: string | null;
   notes?: string;
   created_at: string;
   updated_at: string;
@@ -138,7 +138,7 @@ export interface CreateProcessRequest {
   client_id: string;
   specialist_id: string | undefined;
   product_type: "CAR" | "BOAT" | "AIRCRAFT";
-  product_id: string | number;
+  product_id: string;
 }
 
 /**
@@ -185,7 +185,7 @@ export async function updateProcessStatus(
 export async function assignProductToProcess(
   processId: string,
   productType: "CAR" | "BOAT" | "AIRCRAFT",
-  productId: number,
+  productId: string,
 ): Promise<Process> {
   const response = await api.patch<ApiResponse<Process>>(
     `/processes/${processId}/assign-product`,
@@ -306,7 +306,7 @@ export interface CreateAppointmentRequest {
   specialist_id: string;
   client_id: string;
   product_type: "CAR" | "BOAT" | "AIRCRAFT";
-  product_id: string | number;
+  product_id: string;
   appointment_datetime?: string;
   notes?: string;
 }

--- a/frontend/src/services/processes.service.ts
+++ b/frontend/src/services/processes.service.ts
@@ -30,7 +30,7 @@ export interface Process {
     name?: string;
   };
   product?: {
-    id: number | string;
+    id: string;
     marca?: string;
     modelo?: string;
     descricao?: string;

--- a/frontend/src/services/select-options.service.ts
+++ b/frontend/src/services/select-options.service.ts
@@ -13,7 +13,8 @@ export interface ClientOption extends SelectOption {
   role: UserRole;
 }
 
-export interface ProductOption extends SelectOption {
+export interface ProductOption extends Omit<SelectOption, "id"> {
+  id: string;
   marca: string;
   modelo: string;
   ano: number;

--- a/frontend/src/services/select-options.service.ts
+++ b/frontend/src/services/select-options.service.ts
@@ -89,7 +89,7 @@ export async function fetchAvailableProducts(
 
     return products.map(
       (product: {
-        id: number | string;
+        id: string;
         marca: string;
         modelo: string;
         ano: number;
@@ -127,7 +127,7 @@ export async function fetchAvailableProducts(
  * @param productType - Type of product (CAR, BOAT, AIRCRAFT)
  */
 export async function fetchProductDetails(
-  productId: string | number,
+  productId: string,
   productType: "CAR" | "BOAT" | "AIRCRAFT"
 ): Promise<Product> {
   try {

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -91,7 +91,7 @@ export interface PaginationMeta {
 
 // Informações essenciais dos produtos
 export interface Product {
-  id: number;
+  id: string;
   marca: string;
   modelo: string;
   descricao?: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
@@ -17,5 +17,8 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    environment: 'node',
   },
 })


### PR DESCRIPTION
## Summary
- Adiciona o campo `identificador` (obrigatório) ao formulário manual de criação/edição de produtos (carro/barco/aeronave), fechando o gap que só existia no fluxo de import CSV.
- Propaga `identificador` pro payload da API e sincroniza os tipos TS (`Raw*` e `Create*Dto`) nos 3 services de produto.
- Corrige o modal de import CSV: `identificador` aparece como coluna obrigatória para os 3 tipos, e a dica de dedup deixa de citar "marca + modelo" (incorreto) e passa a citar `identificador` (correto).
- Fix adicional descoberto na revisão final: `identificador` duplicado retornava 500 genérico em vez do 409 amigável do `PrismaExceptionFilter`, porque `cars/boats/aircrafts.service.ts` engoliam o erro do Prisma antes do filtro global conseguir tratá-lo. Corrigido com rethrow do `PrismaClientKnownRequestError` nos 6 catch blocks de create/update.
- `identificador` agora é trimado no formulário manual, consistente com o import CSV.

## Test plan
- [x] `frontend: npx tsc -b --noEmit` — sem erros
- [x] `backend: npx tsc --noEmit -p tsconfig.build.json` — sem erros
- [x] `backend: npm test -- --maxWorkers=2` — 80/85 passando (5 falhas pré-existentes não relacionadas em `contracts.service.spec.ts`, modelo nested vs mocks antigos — não é regressão desta branch)
- [x] `frontend: npx vitest run` — 10/10 passando
- [ ] Verificação manual em browser com backend real (não executável neste ambiente — dev server do backend não é seguro de rodar nesta máquina): criar produto com identificador novo (sucesso), repetir com o mesmo identificador (esperado: 409 amigável "Já existe um registro..."), abrir produto criado em modo edição (esperado: campo identificador pré-preenchido)

🤖 Generated with [Claude Code](https://claude.com/claude-code)