### PR TITLE
fix(backend): exclui scripts/ do build — dist/main.js estava faltando

### DIFF
--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "prisma", "**/*spec.ts"]
+  "exclude": ["node_modules", "test", "dist", "prisma", "scripts", "**/*spec.ts"]
 }


### PR DESCRIPTION
## O que
Hotfix de deploy: o build de produção não gerava `dist/main.js`, causando `Error: Cannot find module '/app/dist/main.js'` no container.

## Causa raiz
`backend/tsconfig.build.json` não excluía `backend/scripts/`. Sem `rootDir` explícito, o `tsc` inferia o rootDir como a raiz do backend (ancestral comum de `src/` + `scripts/`), gerando `dist/src/main.js` em vez de `dist/main.js`. `Dockerfile`, `railway.toml` e `package.json#start:prod` esperam `dist/main.js` na raiz.

Reproduzido localmente inclusive na `main` anterior ao PR #197 — ou seja, já estava quebrado antes desse merge. Railway provavelmente vinha mantendo o último container saudável no ar enquanto deploys recentes falhavam silenciosamente no build/start.

## Fix
Adiciona `"scripts"` ao `exclude` de `tsconfig.build.json`. `scripts/export-produtos-para-csv.ts` é standalone, roda via `ts-node` manual, não faz parte do runtime do app.

## Verificação
Rebuild limpo (`npm ci && prisma generate && npm run build`, igual ao Dockerfile) em worktree isolado, antes e depois do fix:
- Antes: `dist/src/main.js` (sem `dist/main.js`) → `node dist/main.js` falha com `Cannot find module`
- Depois: `dist/main.js` na raiz → app sobe (Nest bootstrap chega a inicializar módulos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)