### PR TITLE
feat: botao Comece a Explorar abre selecao de tipo de produto

### DIFF
--- a/frontend/src/components/landing-page/HeroSection.tsx
+++ b/frontend/src/components/landing-page/HeroSection.tsx
@@ -1,8 +1,17 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, useReducedMotion, type Variants, easeOut } from 'framer-motion';
+import ProductTypePreferenceModal, {
+  type PreferredProductType,
+} from '../product/ProductTypePreferenceModal';
 
 const HERO_POSTER = '/hero/hero-poster.webp';
+
+const catalogRouteMap: Record<PreferredProductType, string> = {
+  CAR: '/catalog/cars',
+  BOAT: '/catalog/boats',
+  AIRCRAFT: '/catalog/aircrafts',
+};
 
 type NetworkInformation = { saveData?: boolean; effectiveType?: string };
 
@@ -53,6 +62,12 @@ export function HeroBackdrop() {
 
 export function HeroSection() {
   const navigate = useNavigate();
+  const [isProductTypeModalOpen, setIsProductTypeModalOpen] = useState(false);
+
+  const handleSelectProductType = (type: PreferredProductType) => {
+    setIsProductTypeModalOpen(false);
+    navigate(catalogRouteMap[type]);
+  };
 
   const containerVariants: Variants = {
     hidden: { opacity: 0 },
@@ -113,7 +128,7 @@ export function HeroSection() {
         </motion.div>
 
         <motion.button
-          onClick={() => navigate('/login')}
+          onClick={() => setIsProductTypeModalOpen(true)}
           variants={itemVariants}
           whileHover={{ scale: 1.02, backgroundColor: '#f3f4f6' }}
           whileTap={{ scale: 0.98 }}
@@ -122,6 +137,14 @@ export function HeroSection() {
           Comece a Explorar
         </motion.button>
       </motion.div>
+
+      <ProductTypePreferenceModal
+        isOpen={isProductTypeModalOpen}
+        title="O que você quer explorar?"
+        description="Escolha uma categoria para ver o catálogo correspondente."
+        onClose={() => setIsProductTypeModalOpen(false)}
+        onSelect={handleSelectProductType}
+      />
     </section>
   );
 }


### PR DESCRIPTION
# Changelog

- Botão "Comece a Explorar" do hero da landing page passa a abrir a seleção de tipo de produto em vez de navegar direto para `/login`;
- Reaproveita o `ProductTypePreferenceModal` existente, sem criar componente novo;
- A escolha leva ao catálogo correspondente (Carro, Embarcação ou Aeronave).

closes: [TASK 3.1 — Botão "Comece a Explorar" deve abrir seleção de tipo de produto](https://github.com/orgs/InteliJR/projects/23)

---

## Decisão que vale revisar

`/catalog/:category` é rota **pública** (fora do `ProtectedRoute`, `routes.tsx:51`), então a seleção leva o visitante direto ao catálogo, sem passar pelo login.

Se a intenção do time for exigir login antes, dá pra mudar — mas aí o `ProtectedRoute` precisaria passar `state.from` no redirect para `/login`, coisa que hoje ele não faz, e a escolha do usuário se perderia no caminho.

## Testes

- `tsc` e `eslint` limpos no arquivo alterado;
- Testado no navegador em desktop (1280px) e mobile (375px): o modal abre nos dois, e a seleção navega para `/catalog/boats` e `/catalog/aircrafts` corretamente.
