### PR TITLE
feat: gerente de escritorio ve processos dos clientes vinculados

### DIFF
--- a/backend/src/features/processes/processes.controller.ts
+++ b/backend/src/features/processes/processes.controller.ts
@@ -26,6 +26,7 @@ import { RejectProcessDto } from './dto/reject-process.dto';
 import { ProcessWithHistory } from './entity/process-history.response';
 import { AuthGuard } from 'src/auth/auth.guard';
 import { GetProcessesFilterDto } from './dto/get-processes-filter.dto';
+import { UserEntity } from 'src/auth/entities/user.entity';
 
 @Controller('processes')
 export class ProcessesController {
@@ -54,19 +55,32 @@ export class ProcessesController {
 
   /**
    * GET /api/processes
-   * Retorna os processos de maneira paginada com filtros opcionais
+   * Retorna os processos de maneira paginada com filtros opcionais.
+   *
+   * O resultado é escopado pelo papel de quem pede (ver
+   * ProcessesService.buildVisibilityFilter): ADMIN vê tudo, gerente de
+   * escritório vê os processos dos clientes da própria empresa, e os demais
+   * papéis veem apenas os processos de que participam.
    *
    * @param {QueryDto} - Parâmetros de paginação
    * @param {GetProcessesFilterDto} - Parâmetros de filtro (status, search, etc)
    * @returns {Promise<ApiResponseDto<ProcessResponse[], unknown, ProcessSummary>>} - Listagem de processos de maneira paginada e sumário
+   * @throws {UnauthorizedException} - Usuário autenticado não identificado
+   * @throws {ForbiddenException} - Papel sem regra de visibilidade definida
    */
   @Get()
   async getAll(
     @Query() queryDto: QueryDto & GetProcessesFilterDto,
+    @Req() req: { user?: UserEntity },
   ): Promise<ApiResponseDto<ProcessResponse[], unknown, ProcessSummary>> {
     // Tratamento de variáveis do front
     const page = Number(queryDto.page);
     const perPage = Number(queryDto.perPage);
+
+    const user = req.user;
+    if (!user) {
+      throw new UnauthorizedException('Usuário autenticado não identificado');
+    }
 
     const { count, processes, byStatus } = await this.processesService.getAll({
       perPage,
@@ -75,6 +89,11 @@ export class ProcessesController {
       search: queryDto.search,
       sortBy: queryDto.sortBy,
       order: queryDto.order,
+      requester: {
+        id: user.id,
+        role: user.role,
+        companyId: user.company_id,
+      },
     });
 
     // Criação do objeto de pagination

--- a/backend/src/features/processes/processes.service.spec.ts
+++ b/backend/src/features/processes/processes.service.spec.ts
@@ -1,3 +1,4 @@
+import { ForbiddenException } from '@nestjs/common';
 import { validate } from 'class-validator';
 import { CreateProcessDTO } from './dto/create-process.dto';
 import { AssignProductToProcessDto } from './dto/assign-product.dto';
@@ -77,5 +78,148 @@ describe('ProcessesService — produto UUID', () => {
 
     expect((await validate(createDto)).some((error) => error.property === 'product_id')).toBe(true);
     expect((await validate(assignDto)).some((error) => error.property === 'product_id')).toBe(true);
+  });
+});
+
+describe('ProcessesService.getAll — escopo de visibilidade', () => {
+  const companyId = '55555555-5555-4555-8555-555555555555';
+
+  /**
+   * Monta o service com um Prisma falso e devolve os mocks das três queries que
+   * o getAll dispara, para inspecionar o `where` que cada uma recebeu.
+   */
+  function mkService() {
+    const findMany = jest.fn().mockReturnValue([]);
+    const count = jest.fn().mockReturnValue(0);
+    const groupBy = jest.fn().mockReturnValue([]);
+    const prisma = {
+      process: { findMany, count, groupBy },
+      // getAll passa um array de queries; devolvemos o resultado de cada mock
+      // na mesma ordem em que são montadas.
+      $transaction: jest.fn(async () => [[], 0, []]),
+    } as any;
+
+    return {
+      service: new ProcessesService(prisma, {} as any),
+      findMany,
+      groupBy,
+    };
+  }
+
+  const baseQuery = { page: 1, perPage: 20 } as any;
+
+  it('ADMIN não recebe filtro de visibilidade', async () => {
+    const { service, findMany } = mkService();
+
+    await service.getAll({
+      ...baseQuery,
+      requester: { id: 'admin1', role: 'ADMIN' as any },
+    });
+
+    expect(findMany.mock.calls[0][0].where.AND).toBeUndefined();
+  });
+
+  it('OFFICE só enxerga clientes da própria empresa', async () => {
+    const { service, findMany } = mkService();
+
+    await service.getAll({
+      ...baseQuery,
+      requester: { id: 'office1', role: 'OFFICE' as any, companyId },
+    });
+
+    expect(findMany.mock.calls[0][0].where.AND).toEqual([
+      {
+        client: {
+          role: 'CUSTOMER',
+          OR: [
+            { consultant: { company_id: companyId } },
+            { company_id: companyId },
+          ],
+        },
+      },
+    ]);
+  });
+
+  it('OFFICE sem company_id é barrado em vez de ver tudo', async () => {
+    const { service } = mkService();
+
+    await expect(
+      service.getAll({
+        ...baseQuery,
+        requester: { id: 'office1', role: 'OFFICE' as any, companyId: null },
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it.each([
+    ['CUSTOMER', 'cliente1', { client_id: 'cliente1' }],
+    ['SPECIALIST', 'esp1', { specialist_id: 'esp1' }],
+    ['CONSULTANT', 'cons1', { client: { consultant_id: 'cons1' } }],
+  ])('%s enxerga apenas os próprios processos', async (role, id, expected) => {
+    const { service, findMany } = mkService();
+
+    await service.getAll({
+      ...baseQuery,
+      requester: { id, role: role as any },
+    });
+
+    expect(findMany.mock.calls[0][0].where.AND).toEqual([expected]);
+  });
+
+  it('papel desconhecido é barrado (fail closed)', async () => {
+    const { service } = mkService();
+
+    await expect(
+      service.getAll({
+        ...baseQuery,
+        requester: { id: 'x', role: 'ALGO_NOVO' as any },
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  // Regressão: a busca textual escreve em `where.OR`. Se o escopo morasse no
+  // mesmo nível, a busca o sobrescreveria e um escritório veria processos de
+  // outro ao digitar na busca.
+  it('busca textual não desfaz o escopo do escritório', async () => {
+    const { service, findMany } = mkService();
+
+    await service.getAll({
+      ...baseQuery,
+      search: 'porsche',
+      requester: { id: 'office1', role: 'OFFICE' as any, companyId },
+    });
+
+    const where = findMany.mock.calls[0][0].where;
+    expect(where.AND).toHaveLength(1);
+    expect(where.AND[0].client.OR).toBeDefined();
+    expect(where.OR).toBeDefined();
+  });
+
+  // Regressão: o groupBy do sumário rodava sem `where` nenhum e devolvia a
+  // contagem da plataforma inteira para qualquer usuário.
+  it('sumário por status respeita o escopo', async () => {
+    const { service, groupBy } = mkService();
+
+    await service.getAll({
+      ...baseQuery,
+      requester: { id: 'office1', role: 'OFFICE' as any, companyId },
+    });
+
+    expect(groupBy.mock.calls[0][0].where.AND).toBeDefined();
+  });
+
+  // O sumário conta quantos processos há em CADA status, então não pode herdar
+  // o filtro de status — senão selecionar uma aba zera o contador das outras.
+  it('sumário ignora o filtro de status, a listagem aplica', async () => {
+    const { service, findMany, groupBy } = mkService();
+
+    await service.getAll({
+      ...baseQuery,
+      status: 'NEGOTIATION' as any,
+      requester: { id: 'admin1', role: 'ADMIN' as any },
+    });
+
+    expect(findMany.mock.calls[0][0].where.status).toBe('NEGOTIATION');
+    expect(groupBy.mock.calls[0][0].where.status).toBeUndefined();
   });
 });

--- a/backend/src/features/processes/processes.service.ts
+++ b/backend/src/features/processes/processes.service.ts
@@ -22,6 +22,15 @@ import { UpdateProcessDto } from './dto/update-process.dto';
 import { ProcessWithHistory } from './entity/process-history.response';
 import { NotificationService } from 'src/features/notifications/notification.service';
 
+/**
+ * Quem está pedindo a listagem de processos. `companyId` só é usado por OFFICE.
+ */
+export type ProcessesRequester = {
+  id: string;
+  role: UserRole;
+  companyId?: string | null;
+};
+
 @Injectable()
 export class ProcessesService {
   private readonly logger = new Logger(ProcessesService.name);
@@ -332,6 +341,78 @@ export class ProcessesService {
    *  byStatus: Record<ProcessStatus, number>
    * }>} - Objeto com numero total de elementos, array de processos e contagem de processos por status
    */
+  /**
+   * Monta o filtro de visibilidade da listagem de processos.
+   *
+   * ADMIN enxerga tudo. Os demais papéis enxergam só o que lhes diz respeito,
+   * usando a mesma noção de "participante" já aplicada em getById (cliente,
+   * especialista ou consultor do cliente), somada ao gerente de escritório —
+   * que vê os processos dos clientes da própria empresa.
+   *
+   * Papel desconhecido cai no default e é barrado: sem regra explícita de
+   * visibilidade, negar é o único padrão seguro.
+   *
+   * @returns filtro Prisma, ou null quando não há restrição (ADMIN)
+   */
+  private buildVisibilityFilter(requester: ProcessesRequester): any | null {
+    switch (requester.role) {
+      case UserRole.ADMIN:
+        return null;
+
+      case UserRole.OFFICE: {
+        if (!requester.companyId) {
+          this.logger.error(
+            `[getAll] OFFICE user=${requester.id} sem company_id — config inválida`,
+          );
+          throw new ForbiddenException({
+            success: false,
+            error: {
+              code: 403,
+              message: 'Escritório sem empresa vinculada',
+              details: { user_id: requester.id },
+            },
+          });
+        }
+
+        // Mesma definição de "cliente do escritório" usada em
+        // OfficeService.listClients: cliente ligado a um consultor da empresa
+        // OU vinculado direto à empresa (sem consultor). Se as duas regras
+        // divergirem, a aba Clientes e a aba Processos passam a discordar.
+        return {
+          client: {
+            role: UserRole.CUSTOMER,
+            OR: [
+              { consultant: { company_id: requester.companyId } },
+              { company_id: requester.companyId },
+            ],
+          },
+        };
+      }
+
+      case UserRole.SPECIALIST:
+        return { specialist_id: requester.id };
+
+      case UserRole.CONSULTANT:
+        return { client: { consultant_id: requester.id } };
+
+      case UserRole.CUSTOMER:
+        return { client_id: requester.id };
+
+      default:
+        this.logger.warn(
+          `[getAll] acesso negado role=${requester.role} user=${requester.id}`,
+        );
+        throw new ForbiddenException({
+          success: false,
+          error: {
+            code: 403,
+            message: 'Acesso negado',
+            details: { user_id: requester.id },
+          },
+        });
+    }
+  }
+
   async getAll({
     page,
     perPage,
@@ -339,11 +420,13 @@ export class ProcessesService {
     search,
     sortBy = 'created_at',
     order = 'desc',
+    requester,
   }: QueryDto & {
     status?: ProcessStatus;
     search?: string;
     sortBy?: 'created_at' | 'updated_at' | 'status';
     order?: 'asc' | 'desc';
+    requester: ProcessesRequester;
   }): Promise<{
     count: number;
     processes: ProcessResponse[];
@@ -353,17 +436,23 @@ export class ProcessesService {
     const take = perPage;
     const skip = page && take ? (page - 1) * take : 0;
 
-    // Construir filtros WHERE
-    const where: any = {};
+    // Filtros compartilhados entre a listagem e o sumário por status.
+    // O status fica de fora daqui de propósito: o sumário existe para mostrar
+    // quantos processos há em CADA status, então filtrar por um deles zeraria
+    // os demais e o contador das abas iria a zero ao selecionar uma.
+    const scopedWhere: any = {};
 
-    // Filtro de status
-    if (status) {
-      where.status = status;
+    // Filtro de visibilidade por papel. Vai em AND porque a busca textual
+    // abaixo ocupa o OR do nível raiz — se o escopo fosse escrito ali, a busca
+    // sobrescreveria o filtro e vazaria processos de outros escritórios.
+    const visibilityFilter = this.buildVisibilityFilter(requester);
+    if (visibilityFilter) {
+      scopedWhere.AND = [visibilityFilter];
     }
 
     // Filtro de busca textual (nome cliente, email, marca/modelo produto)
     if (search && search.trim()) {
-      where.OR = [
+      scopedWhere.OR = [
         {
           client: {
             OR: [
@@ -399,6 +488,9 @@ export class ProcessesService {
       ];
     }
 
+    // Escopo + status: usado pela listagem e pela contagem total, não pelo sumário.
+    const where: any = status ? { ...scopedWhere, status } : scopedWhere;
+
     // Construir ordenação
     const orderBy: any = {};
     orderBy[sortBy] = order;
@@ -423,8 +515,12 @@ export class ProcessesService {
           },
         }),
         this.prismaService.process.count({ where }),
+        // Escopo sem o filtro de status: sem o `where` o sumário contava os
+        // processos da plataforma inteira, entregando números de fora do
+        // escopo de quem pede.
         this.prismaService.process.groupBy({
           by: ['status'],
+          where: scopedWhere,
           orderBy: {
             status: 'asc',
           },

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -15,6 +15,7 @@ import {
   Database,
   Calculator,
   PanelLeft,
+  ClipboardList,
 } from "lucide-react";
 import { useContext } from "react";
 import { AppContext } from "../contexts/AppContext";
@@ -195,6 +196,11 @@ export default function Sidebar() {
             to: "/office/clients",
             label: "Clientes",
             icon: <UserCog size={20} />,
+          },
+          {
+            to: "/office/processes",
+            label: "Processos",
+            icon: <ClipboardList size={20} />,
           },
           {
             to: "/office/company",

--- a/frontend/src/pages/office/OfficeProcessesPage.tsx
+++ b/frontend/src/pages/office/OfficeProcessesPage.tsx
@@ -1,0 +1,213 @@
+import { useCallback, useEffect, useState } from "react";
+import { ClipboardList } from "lucide-react";
+import {
+  getProcesses,
+  type Process,
+  type ProcessFilters,
+} from "../../services/processes.service";
+import { PageHeader } from "../../components/patterns/PageHeader";
+import { EmptyState } from "../../components/patterns/EmptyState";
+import {
+  StatusBadge,
+  PROCESS_STATUS_META,
+} from "../../components/patterns/StatusBadge";
+
+const PER_PAGE = 20;
+
+const PRODUCT_TYPE_LABEL: Record<string, string> = {
+  CAR: "Carro",
+  BOAT: "Embarcação",
+  AIRCRAFT: "Aeronave",
+};
+
+/**
+ * Processos dos clientes vinculados ao escritório.
+ *
+ * A tela não envia nenhum identificador de empresa: o escopo é aplicado no
+ * backend a partir do papel de quem está autenticado (ver getAll em
+ * processes.service.ts). Enviar company_id daqui seria um filtro que o cliente
+ * poderia trocar.
+ */
+export default function OfficeProcessesPage() {
+  const [processes, setProcesses] = useState<Process[]>([]);
+  const [byStatus, setByStatus] = useState<Record<string, number>>({});
+  const [total, setTotal] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<string>("");
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    const filters: ProcessFilters = {
+      ...(status && { status }),
+      ...(search && { search }),
+    };
+
+    getProcesses(page, PER_PAGE, filters)
+      .then((result) => {
+        setProcesses(result.processes);
+        setByStatus(result.byStatus);
+        setTotal(result.total);
+        setTotalPages(result.totalPages);
+      })
+      .catch((e) =>
+        setError(
+          (e as { friendlyMessage?: string }).friendlyMessage ||
+            "Erro ao carregar processos",
+        ),
+      )
+      .finally(() => setLoading(false));
+  }, [page, status, search]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  // Trocar de filtro volta para a primeira página: manter a página atual pode
+  // cair num intervalo vazio e a tela parecer sem resultados.
+  const applyStatus = (value: string) => {
+    setStatus(value);
+    setPage(1);
+  };
+
+  const applySearch = () => {
+    setSearch(searchInput);
+    setPage(1);
+  };
+
+  return (
+    <div className="p-8">
+      <PageHeader title="Processos do escritório" />
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        <input
+          type="text"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && applySearch()}
+          placeholder="Buscar por cliente, e-mail ou produto..."
+          className="flex-1 min-w-[240px] px-3 py-2 border border-border rounded-md"
+        />
+        <select
+          value={status}
+          onChange={(e) => applyStatus(e.target.value)}
+          className="px-3 py-2 border border-border rounded-md"
+        >
+          <option value="">Todos os status</option>
+          {PROCESS_STATUS_META.map((meta) => (
+            <option key={meta.value} value={meta.value}>
+              {meta.label}
+              {byStatus[meta.value] ? ` (${byStatus[meta.value]})` : ""}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {loading && <p className="text-muted">Carregando...</p>}
+      {error && <p className="text-status-bad">{error}</p>}
+
+      {!loading && !error && processes.length === 0 && (
+        <EmptyState
+          icon={ClipboardList}
+          title={
+            status || search
+              ? "Nenhum processo para esse filtro."
+              : "Nenhum processo ainda."
+          }
+        />
+      )}
+
+      {!loading && !error && processes.length > 0 && (
+        <>
+          <div className="bg-surface rounded-lg shadow overflow-x-auto">
+            <table className="w-full min-w-[720px]">
+              <thead className="bg-border-soft border-b border-border">
+                <tr>
+                  <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">
+                    Cliente
+                  </th>
+                  <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">
+                    Especialista
+                  </th>
+                  <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">
+                    Tipo
+                  </th>
+                  <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">
+                    Status
+                  </th>
+                  <th className="text-left text-xs font-medium text-muted uppercase px-4 py-3">
+                    Aberto em
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {processes.map((process) => (
+                  <tr key={process.id} className="border-b border-border-soft">
+                    <td className="px-4 py-3 text-sm">
+                      {process.client?.name ?? "—"}
+                      {process.client?.email && (
+                        <span className="block text-xs text-muted">
+                          {process.client.email}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {process.specialist?.name ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {process.product_type
+                        ? (PRODUCT_TYPE_LABEL[process.product_type] ??
+                          process.product_type)
+                        : "Consultoria"}
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <StatusBadge status={process.status} />
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      {new Date(process.created_at).toLocaleDateString("pt-BR")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="flex items-center justify-between mt-4">
+            <p className="text-sm text-muted">
+              {total} processo{total === 1 ? "" : "s"}
+            </p>
+            {totalPages > 1 && (
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1}
+                  className="px-3 py-2 text-sm border border-border rounded-md disabled:opacity-50"
+                >
+                  Anterior
+                </button>
+                <span className="text-sm text-muted">
+                  {page} de {totalPages}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={page >= totalPages}
+                  className="px-3 py-2 text-sm border border-border rounded-md disabled:opacity-50"
+                >
+                  Próxima
+                </button>
+              </div>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/routes.tsx
+++ b/frontend/src/routes/routes.tsx
@@ -40,6 +40,7 @@ import RegisterOfficePage from "../pages/auth/RegisterOfficePage";
 import OfficeDashboardPage from "../pages/office/OfficeDashboardPage";
 import OfficeConsultantsPage from "../pages/office/OfficeConsultantsPage";
 import OfficeClientsPage from "../pages/office/OfficeClientsPage";
+import OfficeProcessesPage from "../pages/office/OfficeProcessesPage";
 import OfficeCompanySettingsPage from "../pages/office/OfficeCompanySettingsPage";
 import WhitelabelPage from "../pages/whitelabel/WhitelabelPage";
 
@@ -110,6 +111,16 @@ export default function RouterApp() {
         <MainLayout>
           <ProtectedRoute allowedRoles={["OFFICE", "ADMIN"]}>
             <OfficeClientsPage />
+          </ProtectedRoute>
+        </MainLayout>
+      ),
+    },
+    {
+      path: "/office/processes",
+      element: (
+        <MainLayout>
+          <ProtectedRoute allowedRoles={["OFFICE", "ADMIN"]}>
+            <OfficeProcessesPage />
           </ProtectedRoute>
         </MainLayout>
       ),

--- a/frontend/src/services/processes.service.ts
+++ b/frontend/src/services/processes.service.ts
@@ -80,16 +80,49 @@ export interface ProcessFilters {
   order?: "asc" | "desc";
 }
 
+export interface ProcessesPage {
+  processes: Process[];
+  total: number;
+  totalPages: number;
+  byStatus: Record<string, number>;
+}
+
 /**
- * Get all processes
- * Filters based on user role and permissions
+ * Lista processos. O backend escopa o resultado pelo papel de quem pede:
+ * ADMIN vê tudo, gerente de escritório vê os processos dos clientes da própria
+ * empresa, e os demais papéis veem apenas os processos de que participam —
+ * não há parâmetro de cliente/empresa a enviar daqui.
  */
-export async function getProcesses(page = 1, perPage = 20): Promise<Process[]> {
-  const response = await api.get<ApiResponse<Process[]>>("/processes", {
+export async function getProcesses(
+  page = 1,
+  perPage = 20,
+  filters?: ProcessFilters,
+): Promise<ProcessesPage> {
+  const response = await api.get<
+    ApiResponse<Process[]> & {
+      meta?: {
+        pagination?: { total?: number; total_pages?: number };
+        summary?: { by_status?: Record<string, number> };
+      };
+    }
+  >("/processes", {
     withCredentials: true,
-    params: { page, perPage },
+    params: {
+      page,
+      perPage,
+      ...(filters?.status && { status: filters.status }),
+      ...(filters?.search && { search: filters.search }),
+      ...(filters?.sortBy && { sortBy: filters.sortBy }),
+      ...(filters?.order && { order: filters.order }),
+    },
   });
-  return response.data.data;
+
+  return {
+    processes: response.data.data,
+    total: response.data.meta?.pagination?.total ?? 0,
+    totalPages: response.data.meta?.pagination?.total_pages ?? 0,
+    byStatus: response.data.meta?.summary?.by_status ?? {},
+  };
 }
 
 /**


### PR DESCRIPTION
# Changelog

- Escopa `GET /processes` pelo papel de quem pede: gerente de escritório passa a ver os processos dos clientes da própria empresa;
- Corrige acesso indevido no mesmo endpoint — qualquer usuário autenticado listava todos os processos da plataforma;
- Corrige o sumário `by_status`, que contava os processos da plataforma inteira ignorando os filtros;
- Adiciona a tela `/office/processes` com busca, filtro por status e paginação;
- Adiciona entrada "Processos" na sidebar do escritório;
- Adiciona 10 testes de escopo de visibilidade em `processes.service.spec.ts`.

closes: [TASK 3.2 — Escritório: gerente vê processos dos clientes vinculados](https://github.com/orgs/InteliJR/projects/23)

---

## Como o escopo foi definido

`Process` não tem `company_id` — o vínculo com o escritório é indireto, via cliente. Reusei a definição que já existia em `OfficeService.listClients`:

```
role = CUSTOMER  AND  (consultant.company_id = X  OR  company_id = X)
```

Ou seja: cliente ligado a um consultor da empresa, **ou** vinculado direto à empresa. Se as duas telas usassem regras diferentes, a aba Clientes e a aba Processos passariam a discordar sobre quem é cliente do escritório.

A tabela completa que `buildVisibilityFilter` aplica:

| Papel | Enxerga |
|---|---|
| `ADMIN` | tudo |
| `OFFICE` | processos dos clientes da própria empresa |
| `SPECIALIST` | processos em que é o especialista |
| `CONSULTANT` | processos dos próprios clientes |
| `CUSTOMER` | os próprios processos |
| desconhecido | nada (403) |

Para os papéis que já existiam, essa é a mesma noção de "participante" que o `getById` já aplicava — a listagem só estava sem ela.

## Sobre o acesso indevido incluído aqui

`GET /processes` não tinha `@Roles()`, e o `RolesGuard` libera quando não encontra metadata (`roles.guard.ts:27`). Com apenas o `AuthGuard` global, **qualquer usuário autenticado — inclusive um CUSTOMER — listava todos os processos da plataforma**, com nome e e-mail dos clientes.

Não separei em outro PR porque escopar o `getAll` por papel *é* a correção: adicionar só o ramo do `OFFICE` e deixar os demais papéis vendo tudo seria deixar o buraco aberto na função sendo editada.

Vale destacar que `getProcesses()` no frontend não tinha nenhum consumidor, então o endpoint não estava sendo exercitado por nenhuma tela — o que reduz bastante o risco de regressão.

## Dois detalhes de implementação

**O escopo vai em `where.AND`, não no nível raiz.** A busca textual ocupa `where.OR`; se o escopo morasse lá, uma busca sobrescreveria o filtro e vazaria processos de outro escritório. Tem teste de regressão para isso.

**O sumário não herda o filtro de status.** O `groupBy` recebe escopo + busca, mas não o status — ele existe justamente para dizer quantos processos há em *cada* status, e filtrar por um deles zeraria o contador dos outros.

## Testes

- 10 testes novos cobrindo cada papel, escritório sem `company_id`, papel desconhecido (fail closed), busca que não desfaz o escopo, e o sumário;
- `npx jest processes.service` → 12 passando;
- Suíte completa do backend: 197 passando. As 5 falhas em `contracts.service.spec.ts` (arredondamento de comissão) e os 4 erros de typecheck em specs de produto **já existem na develop** — confirmado rodando na branch limpa;
- Frontend: `tsc -b` limpo, `vitest` 37 passando, eslint sem problema novo.

## O que não foi verificado

Não consegui exercitar a tela com dados reais: renderizar `/office/processes` exige sessão de gerente de escritório, e validar o escopo de verdade exigiria um banco com **duas empresas** e processos em cada uma — a única prova que realmente importa aqui. Confirmei que a rota resolve e o `ProtectedRoute` redireciona corretamente, mas a validação do escopo neste PR é a dos testes unitários, não de ponta a ponta.

Sugiro que a revisão inclua esse teste manual com dois escritórios antes do merge.
