### PR TITLE
feat: gerente de escritorio inicia processo em nome de cliente da empresa

### DIFF
--- a/backend/src/features/consultant/consultant.module.ts
+++ b/backend/src/features/consultant/consultant.module.ts
@@ -6,10 +6,12 @@ import { ConsultantService } from './consultant.service';
 import { ClientInviteJobsService } from './client-invite-jobs.service';
 import { AwsModule } from 'src/aws/aws.module';
 import { XlsxImportService } from 'src/shared/services/xlsx-import.service';
+import { ProcessesModule } from 'src/features/processes/processes.module';
 
 @Module({
   imports: [
     AwsModule,
+    ProcessesModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/features/consultant/consultant.service.ts
+++ b/backend/src/features/consultant/consultant.service.ts
@@ -11,6 +11,7 @@ import { UpdateClientDto } from './dto/update-client.dto';
 import { SendInvitationDto } from './dto/send-invitation.dto';
 import { CreateConsultantProcessDto } from './dto/create-consultant-process.dto';
 import { SesService } from 'src/aws/ses.service';
+import { ProcessesService } from 'src/features/processes/processes.service';
 
 @Injectable()
 export class ConsultantService {
@@ -18,6 +19,7 @@ export class ConsultantService {
     private prismaService: PrismaService,
     private sesService: SesService,
     private jwtService: JwtService,
+    private processesService: ProcessesService,
   ) {}
 
   /**
@@ -213,117 +215,17 @@ export class ConsultantService {
       );
     }
 
-    const specialist = await this.prismaService.user.findFirst({
-      where: { id: dto.specialist_id, role: 'SPECIALIST' },
+    // A criação em si (Appointment + Process + histórico) vive em
+    // ProcessesService.createOnBehalfOfClient, compartilhada com o fluxo do
+    // escritório. Aqui fica só a autorização: o cliente é deste consultor.
+    return this.processesService.createOnBehalfOfClient({
+      client_id: dto.client_id,
+      specialist_id: dto.specialist_id,
+      product_type: dto.product_type,
+      product_id: dto.product_id,
+      createdBy: consultantId,
+      actorLabel: 'consultor',
     });
-
-    if (!specialist) {
-      throw new NotFoundException('Especialista não encontrado');
-    }
-
-    const productFieldMap = {
-      CAR: 'car_id',
-      BOAT: 'boat_id',
-      AIRCRAFT: 'aircraft_id',
-    } as const;
-    const productField = dto.product_id
-      ? productFieldMap[dto.product_type]
-      : undefined;
-
-    const activeStatuses = [
-      'SCHEDULING',
-      'NEGOTIATION',
-      'PROCESSING_CONTRACT',
-      'DOCUMENTATION',
-    ] as const;
-
-    if (productField && dto.product_id) {
-      // Só bloqueia se houver processo ATIVO; processos encerrados
-      // (COMPLETED/REJECTED) permitem novo processo para o mesmo produto.
-      const existing = await this.prismaService.process.findFirst({
-        where: {
-          client_id: dto.client_id,
-          specialist_id: dto.specialist_id,
-          [productField]: dto.product_id,
-          status: { in: [...activeStatuses] as any },
-        },
-      });
-      if (existing) {
-        throw new ConflictException(
-          'Já existe processo ativo para este cliente com este produto.',
-        );
-      }
-    } else {
-      const activeConsultancy = await this.prismaService.process.findFirst({
-        where: {
-          client_id: dto.client_id,
-          specialist_id: dto.specialist_id,
-          product_type: null,
-          status: { in: [...activeStatuses] as any },
-        },
-      });
-      if (activeConsultancy) {
-        throw new ConflictException(
-          'Já existe consultoria ativa entre este cliente e este especialista.',
-        );
-      }
-    }
-
-    const pendingExpiresAt = new Date();
-    pendingExpiresAt.setDate(pendingExpiresAt.getDate() + 7);
-
-    const isConsultancy = !productField || !dto.product_id;
-
-    const [, process] = await this.prismaService.$transaction(async (tx) => {
-      const appointmentData: any = {
-        client_id: dto.client_id,
-        specialist_id: dto.specialist_id,
-        appointment_datetime: null,
-        status: 'PENDING',
-        notes: isConsultancy
-          ? `Consultoria criada pelo consultor em nome do cliente (${new Date().toISOString()})`
-          : `Processo criado pelo consultor em nome do cliente (${new Date().toISOString()})`,
-        user_clicked_at: new Date(),
-        pending_expires_at: pendingExpiresAt,
-      };
-      if (!isConsultancy) {
-        appointmentData.product_type = dto.product_type;
-        appointmentData.product_id = dto.product_id;
-      }
-
-      const createdAppointment = await tx.appointment.create({
-        data: appointmentData,
-      });
-
-      const processData: any = {
-        client_id: dto.client_id,
-        specialist_id: dto.specialist_id,
-        appointment_id: createdAppointment.id,
-        product_type: isConsultancy ? null : dto.product_type,
-        status: 'SCHEDULING',
-        notes: isConsultancy
-          ? `Consultoria iniciada pelo consultor (${new Date().toISOString()})`
-          : `Processo iniciado pelo consultor (${new Date().toISOString()})`,
-      };
-      if (!isConsultancy && productField && dto.product_id) {
-        processData[productField] = dto.product_id;
-      }
-
-      const createdProcess = await tx.process.create({ data: processData });
-
-      await tx.processStatusHistory.create({
-        data: {
-          processId: createdProcess.id,
-          status: 'SCHEDULING',
-          changed_by: consultantId,
-          changed_at: new Date(),
-        },
-      });
-
-      return [createdAppointment, createdProcess];
-    });
-
-    return process;
   }
 
   /**

--- a/backend/src/features/office/dto/create-process.dto.ts
+++ b/backend/src/features/office/dto/create-process.dto.ts
@@ -1,0 +1,30 @@
+import { IsEnum, IsOptional, IsUUID } from 'class-validator';
+
+export enum OfficeProductTypeEnum {
+  CAR = 'CAR',
+  BOAT = 'BOAT',
+  AIRCRAFT = 'AIRCRAFT',
+}
+
+export class OfficeCreateProcessDto {
+  @IsUUID('4', { message: 'client_id deve ser um UUID válido' })
+  client_id: string;
+
+  @IsUUID('4', { message: 'specialist_id deve ser um UUID válido' })
+  specialist_id: string;
+
+  @IsEnum(OfficeProductTypeEnum, {
+    message: 'product_type deve ser CAR, BOAT ou AIRCRAFT',
+  })
+  product_type: OfficeProductTypeEnum;
+
+  @IsUUID('4', { message: 'product_id deve ser um UUID válido' })
+  @IsOptional()
+  product_id?: string;
+
+  // Só ADMIN usa: OFFICE tem a empresa resolvida a partir do próprio escopo,
+  // e resolveCompanyId ignora este campo para quem não é ADMIN.
+  @IsUUID('4', { message: 'company_id deve ser um UUID válido' })
+  @IsOptional()
+  company_id?: string;
+}

--- a/backend/src/features/office/office.controller.ts
+++ b/backend/src/features/office/office.controller.ts
@@ -25,6 +25,7 @@ import { ConsultantInviteJobsService } from './consultant-invite-jobs.service';
 import { InviteConsultantDto } from './dto/invite-consultant.dto';
 import { OfficeUpdateCompanyDto } from './dto/update-company.dto';
 import { OfficeUpdateConsultantDto } from './dto/update-consultant.dto';
+import { OfficeCreateProcessDto } from './dto/create-process.dto';
 import { OfficeService } from './office.service';
 
 const UUID_RE =
@@ -186,6 +187,33 @@ export class OfficeController {
     if (consultantId) assertUuid(consultantId, 'consultantId');
     if (companyId) assertUuid(companyId, 'companyId');
     return this.office.listClients(scope, { consultantId, q, companyId });
+  }
+
+  // ─── Processos ─────────────────────────────────────────────────────────
+  /**
+   * POST /api/office/processes
+   * Abre um processo em nome de um cliente do escritório, com o Appointment
+   * pendente que permite marcar o horário depois — equivalente ao fluxo que o
+   * consultor já tem em POST /api/consultant/processes.
+   */
+  @Post('processes')
+  @HttpCode(HttpStatus.CREATED)
+  async createProcess(
+    @OfficeScope() scope: OfficeScopeData,
+    @Request() req: RequestWithUser,
+    @Body() dto: OfficeCreateProcessDto,
+  ) {
+    const process = await this.office.createProcessForCompanyClient(
+      scope,
+      req.user.id,
+      dto,
+    );
+
+    return {
+      success: true,
+      message: 'Processo criado com sucesso',
+      data: process,
+    };
   }
 
   // ─── Batch invite jobs ─────────────────────────────────────────────────

--- a/backend/src/features/office/office.module.ts
+++ b/backend/src/features/office/office.module.ts
@@ -8,11 +8,13 @@ import { XlsxImportService } from 'src/shared/services/xlsx-import.service';
 import { ConsultantInviteJobsService } from './consultant-invite-jobs.service';
 import { OfficeController } from './office.controller';
 import { OfficeService } from './office.service';
+import { ProcessesModule } from 'src/features/processes/processes.module';
 
 @Module({
   imports: [
     PrismaModule,
     AwsModule,
+    ProcessesModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/src/features/office/office.service.spec.ts
+++ b/backend/src/features/office/office.service.spec.ts
@@ -61,8 +61,9 @@ function mkSvc(
   jwt: any = mkJwt(),
   s3: any = {},
   logoSanitizer: any = {},
+  processes: any = { createOnBehalfOfClient: jest.fn() },
 ) {
-  return new OfficeService(prisma, jwt, ses, s3, logoSanitizer);
+  return new OfficeService(prisma, jwt, ses, s3, logoSanitizer, processes);
 }
 
 describe('OfficeService — tenant isolation', () => {

--- a/backend/src/features/office/office.service.ts
+++ b/backend/src/features/office/office.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
   Logger,
   NotFoundException,
@@ -16,6 +17,8 @@ import { resolveCompanyLogoUrl } from 'src/auth/utils/company-logo.util';
 import { InviteConsultantDto } from './dto/invite-consultant.dto';
 import { OfficeUpdateCompanyDto } from './dto/update-company.dto';
 import { OfficeUpdateConsultantDto } from './dto/update-consultant.dto';
+import { OfficeCreateProcessDto } from './dto/create-process.dto';
+import { ProcessesService } from 'src/features/processes/processes.service';
 
 interface Scope {
   companyId: string | null;
@@ -32,7 +35,57 @@ export class OfficeService {
     private readonly ses: SesService,
     private readonly s3: S3Service,
     private readonly logoSanitizer: LogoSanitizerService,
+    private readonly processes: ProcessesService,
   ) {}
+
+  /**
+   * Abre um processo em nome de um cliente do escritório.
+   *
+   * A autorização é o ponto da operação: só passa cliente que pertence à
+   * mesma Company de quem pede, pela mesma regra de listClients (ligado a um
+   * consultor da empresa OU vinculado direto a ela). ADMIN não tem atalho
+   * aqui — precisa de uma empresa alvo, senão "cliente do escritório" perde
+   * sentido e a checagem vira decorativa.
+   *
+   * @throws {ForbiddenException} - Cliente não pertence à empresa
+   */
+  async createProcessForCompanyClient(
+    scope: Scope,
+    actorId: string,
+    dto: OfficeCreateProcessDto,
+  ) {
+    const companyId = this.resolveCompanyId(scope, dto.company_id);
+
+    const client = await this.prisma.user.findFirst({
+      where: {
+        id: dto.client_id,
+        role: UserRole.CUSTOMER,
+        OR: [
+          { consultant: { company_id: companyId } },
+          { company_id: companyId },
+        ],
+      },
+      select: { id: true },
+    });
+
+    if (!client) {
+      this.logger.warn(
+        `[createProcessForCompanyClient] acesso negado actor=${actorId} client=${dto.client_id} company=${companyId}`,
+      );
+      throw new ForbiddenException(
+        'Cliente não encontrado ou não pertence a este escritório',
+      );
+    }
+
+    return this.processes.createOnBehalfOfClient({
+      client_id: dto.client_id,
+      specialist_id: dto.specialist_id,
+      product_type: dto.product_type,
+      product_id: dto.product_id,
+      createdBy: actorId,
+      actorLabel: 'gerente do escritório',
+    });
+  }
 
   /** ADMIN vê todas Companies; OFFICE só a própria. */
   private resolveCompanyId(scope: Scope, requestedCompanyId?: string): string {

--- a/backend/src/features/processes/processes.controller.ts
+++ b/backend/src/features/processes/processes.controller.ts
@@ -43,8 +43,18 @@ export class ProcessesController {
   @Post()
   async create(
     @Body() createProcessDto: CreateProcessDTO,
+    @Req() req: { user?: UserEntity },
   ): Promise<ApiResponseDto<ProcessResponse>> {
-    const process = await this.processesService.create(createProcessDto);
+    const user = req.user;
+    if (!user) {
+      throw new UnauthorizedException('Usuário autenticado não identificado');
+    }
+
+    const process = await this.processesService.create(createProcessDto, {
+      id: user.id,
+      role: user.role,
+      companyId: user.company_id,
+    });
 
     return {
       success: true,

--- a/backend/src/features/processes/processes.module.ts
+++ b/backend/src/features/processes/processes.module.ts
@@ -7,5 +7,8 @@ import { NotificationModule } from 'src/features/notifications/notification.modu
   imports: [NotificationModule],
   controllers: [ProcessesController],
   providers: [ProcessesService],
+  // Consultor e escritório abrem processos em nome do cliente reaproveitando
+  // createOnBehalfOfClient em vez de duplicar a transação de criação.
+  exports: [ProcessesService],
 })
 export class ProcessesModule {}

--- a/backend/src/features/processes/processes.service.spec.ts
+++ b/backend/src/features/processes/processes.service.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { validate } from 'class-validator';
 import { CreateProcessDTO } from './dto/create-process.dto';
 import { AssignProductToProcessDto } from './dto/assign-product.dto';
@@ -41,12 +41,16 @@ describe('ProcessesService — produto UUID', () => {
     } as any;
     const service = new ProcessesService(prisma, {} as any);
 
-    await service.create({
-      client_id: clientId,
-      specialist_id: specialistId,
-      product_type: 'CAR',
-      product_id: productId,
-    } as unknown as CreateProcessDTO);
+    await service.create(
+      {
+        client_id: clientId,
+        specialist_id: specialistId,
+        product_type: 'CAR',
+        product_id: productId,
+      } as unknown as CreateProcessDTO,
+      // ADMIN: passa direto pela autorização, o foco deste teste é o UUID
+      { id: 'admin1', role: 'ADMIN' as any },
+    );
 
     expect(findFirst).toHaveBeenCalledWith({
       where: expect.objectContaining({ car_id: productId }),
@@ -78,6 +82,183 @@ describe('ProcessesService — produto UUID', () => {
 
     expect((await validate(createDto)).some((error) => error.property === 'product_id')).toBe(true);
     expect((await validate(assignDto)).some((error) => error.property === 'product_id')).toBe(true);
+  });
+});
+
+describe('ProcessesService.create — autorização por cliente', () => {
+  const companyId = '66666666-6666-4666-8666-666666666666';
+
+  function mkService(clientLookup: any = null) {
+    const findFirst = jest.fn().mockResolvedValue(clientLookup);
+    const prisma = {
+      user: { findFirst },
+      process: { findFirst: jest.fn().mockResolvedValue(null) },
+      $transaction: jest.fn(),
+    } as any;
+    return { service: new ProcessesService(prisma, {} as any), findFirst };
+  }
+
+  const dto = {
+    client_id: clientId,
+    specialist_id: specialistId,
+    product_type: 'CAR',
+    product_id: productId,
+  } as unknown as CreateProcessDTO;
+
+  it('SPECIALIST não cria processo com outro especialista no lugar dele', async () => {
+    const { service } = mkService();
+
+    await expect(
+      service.create(dto, { id: 'outro-esp', role: 'SPECIALIST' as any }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('CUSTOMER não cria processo em nome de outro cliente', async () => {
+    const { service } = mkService();
+
+    await expect(
+      service.create(dto, { id: 'outro-cliente', role: 'CUSTOMER' as any }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('CONSULTANT não cria processo para cliente que não é dele', async () => {
+    const { service } = mkService(null); // lookup não encontra vínculo
+
+    await expect(
+      service.create(dto, { id: 'cons1', role: 'CONSULTANT' as any }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  // Critério de aceite da task: cliente de outra empresa é bloqueado.
+  it('OFFICE não cria processo para cliente de outra empresa', async () => {
+    const { service, findFirst } = mkService(null);
+
+    await expect(
+      service.create(dto, {
+        id: 'office1',
+        role: 'OFFICE' as any,
+        companyId,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+
+    // Confirma que a checagem usou a regra de cliente do escritório
+    expect(findFirst.mock.calls[0][0].where.OR).toEqual([
+      { consultant: { company_id: companyId } },
+      { company_id: companyId },
+    ]);
+  });
+
+  it('OFFICE sem company_id é barrado', async () => {
+    const { service } = mkService();
+
+    await expect(
+      service.create(dto, {
+        id: 'office1',
+        role: 'OFFICE' as any,
+        companyId: null,
+      }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  it('papel desconhecido é barrado (fail closed)', async () => {
+    const { service } = mkService();
+
+    await expect(
+      service.create(dto, { id: 'x', role: 'ALGO_NOVO' as any }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});
+
+describe('ProcessesService.createOnBehalfOfClient', () => {
+  function mkService(specialist: any = { id: specialistId }) {
+    const appointmentCreate = jest
+      .fn()
+      .mockResolvedValue({ id: 'appointment-1' });
+    const processCreate = jest.fn().mockResolvedValue({ id: 'process-1' });
+    const prisma = {
+      user: { findFirst: jest.fn().mockResolvedValue(specialist) },
+      process: { findFirst: jest.fn().mockResolvedValue(null) },
+      $transaction: jest.fn(async (cb) =>
+        cb({
+          appointment: { create: appointmentCreate },
+          process: { create: processCreate },
+          processStatusHistory: { create: jest.fn().mockResolvedValue({}) },
+        }),
+      ),
+    } as any;
+    return {
+      service: new ProcessesService(prisma, {} as any),
+      appointmentCreate,
+      processCreate,
+    };
+  }
+
+  const base = {
+    client_id: clientId,
+    specialist_id: specialistId,
+    product_type: 'CAR' as const,
+    product_id: productId,
+    createdBy: 'ator1',
+  };
+
+  // O Appointment é a razão de existir deste método: sem ele o especialista
+  // não consegue confirmar o agendamento e o processo fica sem saída natural.
+  it('cria o Appointment pendente junto com o processo', async () => {
+    const { service, appointmentCreate, processCreate } = mkService();
+
+    await service.createOnBehalfOfClient({
+      ...base,
+      actorLabel: 'gerente do escritório',
+    });
+
+    expect(appointmentCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'PENDING' }),
+      }),
+    );
+    expect(processCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'SCHEDULING',
+          appointment_id: 'appointment-1',
+        }),
+      }),
+    );
+  });
+
+  it('registra nas notas quem abriu o processo', async () => {
+    const { service, processCreate } = mkService();
+
+    await service.createOnBehalfOfClient({
+      ...base,
+      actorLabel: 'gerente do escritório',
+    });
+
+    expect(processCreate.mock.calls[0][0].data.notes).toContain(
+      'gerente do escritório',
+    );
+  });
+
+  it('sem produto cria consultoria (product_type null)', async () => {
+    const { service, processCreate } = mkService();
+
+    await service.createOnBehalfOfClient({
+      ...base,
+      product_id: undefined,
+      actorLabel: 'consultor',
+    });
+
+    const data = processCreate.mock.calls[0][0].data;
+    expect(data.product_type).toBeNull();
+    expect(data.notes).toContain('Consultoria');
+  });
+
+  it('especialista inexistente é rejeitado', async () => {
+    const { service } = mkService(null);
+
+    await expect(
+      service.createOnBehalfOfClient({ ...base, actorLabel: 'consultor' }),
+    ).rejects.toThrow(NotFoundException);
   });
 });
 

--- a/backend/src/features/processes/processes.service.ts
+++ b/backend/src/features/processes/processes.service.ts
@@ -23,12 +23,28 @@ import { ProcessWithHistory } from './entity/process-history.response';
 import { NotificationService } from 'src/features/notifications/notification.service';
 
 /**
- * Quem está pedindo a listagem de processos. `companyId` só é usado por OFFICE.
+ * Quem está pedindo a operação. `companyId` só é usado por OFFICE.
  */
 export type ProcessesRequester = {
   id: string;
   role: UserRole;
   companyId?: string | null;
+};
+
+/**
+ * Dados para abrir um processo em nome de um cliente.
+ *
+ * `actorLabel` entra nas notas do Appointment e do Process ("consultor",
+ * "gerente do escritório") — é o que permite saber depois quem abriu o
+ * processo em nome de quem.
+ */
+export type CreateOnBehalfInput = {
+  client_id: string;
+  specialist_id: string;
+  product_type: 'CAR' | 'BOAT' | 'AIRCRAFT';
+  product_id?: string;
+  createdBy: string;
+  actorLabel: string;
 };
 
 @Injectable()
@@ -174,15 +190,105 @@ export class ProcessesService {
   }
 
   /**
+   * Autoriza a criação de um processo para um `client_id`.
+   *
+   * Antes disso o endpoint aceitava qualquer `client_id` de qualquer usuário
+   * autenticado: dava para abrir processo em nome de um cliente alheio.
+   *
+   * O especialista não é restringido a clientes com quem já tem relação —
+   * abrir o primeiro processo de um cliente novo é justamente o caso de uso
+   * da tela dele. O que se exige é que ele seja o especialista do processo.
+   *
+   * @throws {ForbiddenException} - Sem vínculo com o cliente informado
+   */
+  private async assertCanCreateFor(
+    requester: ProcessesRequester,
+    dto: CreateProcessDTO,
+  ): Promise<void> {
+    const deny = (motivo: string): never => {
+      this.logger.warn(
+        `[create] acesso negado role=${requester.role} user=${requester.id} client=${dto.client_id}: ${motivo}`,
+      );
+      throw new ForbiddenException({
+        success: false,
+        error: {
+          code: 403,
+          message: 'Você não pode criar processo para este cliente',
+          details: { user_id: requester.id, client_id: dto.client_id },
+        },
+      });
+    };
+
+    switch (requester.role) {
+      case UserRole.ADMIN:
+        return;
+
+      case UserRole.SPECIALIST:
+        if (dto.specialist_id !== requester.id) {
+          deny('especialista só cria processo para si mesmo');
+        }
+        return;
+
+      case UserRole.CUSTOMER:
+        if (dto.client_id !== requester.id) {
+          deny('cliente só cria processo para si mesmo');
+        }
+        return;
+
+      case UserRole.CONSULTANT: {
+        const client = await this.prismaService.user.findFirst({
+          where: {
+            id: dto.client_id,
+            role: UserRole.CUSTOMER,
+            consultant_id: requester.id,
+          },
+          select: { id: true },
+        });
+        if (!client) deny('cliente não pertence a este consultor');
+        return;
+      }
+
+      case UserRole.OFFICE: {
+        if (!requester.companyId) deny('escritório sem empresa vinculada');
+
+        // Mesma regra de "cliente do escritório" de OfficeService.listClients.
+        const client = await this.prismaService.user.findFirst({
+          where: {
+            id: dto.client_id,
+            role: UserRole.CUSTOMER,
+            OR: [
+              { consultant: { company_id: requester.companyId } },
+              { company_id: requester.companyId },
+            ],
+          },
+          select: { id: true },
+        });
+        if (!client) deny('cliente não pertence a este escritório');
+        return;
+      }
+
+      default:
+        deny('papel sem regra de criação definida');
+    }
+  }
+
+  /**
    * Cria um processo, normalmente no status de agendamento
    *
    * @param {CreateProcessDTO} createProcessDto - Dto para criar o processo
+   * @param {ProcessesRequester} requester - Quem está criando (autorização)
    * @returns {Promise<ProcessResponse>} - Entidade do processo
    */
-  async create(createProcessDto: CreateProcessDTO): Promise<ProcessResponse> {
+  async create(
+    createProcessDto: CreateProcessDTO,
+    requester: ProcessesRequester,
+  ): Promise<ProcessResponse> {
     this.logger.log(
       `[create] Iniciando criação de processo para cliente ${createProcessDto.client_id}`,
     );
+
+    await this.assertCanCreateFor(requester, createProcessDto);
+
     const { product_id, client_id, specialist_id, ...dataToSave } =
       createProcessDto;
 
@@ -329,6 +435,134 @@ export class ProcessesService {
       created_at: processCreated.created_at,
       notes: processCreated.notes,
     };
+  }
+
+  /**
+   * Abre um processo em nome de um cliente, junto com o Appointment pendente
+   * que permite marcar o horário depois (Calendly).
+   *
+   * Diferente de `create`, que só grava o Process: sem Appointment o
+   * especialista não consegue confirmar o agendamento
+   * (`confirmAppointment` exige um) e o processo fica sem caminho natural.
+   *
+   * Quem chama é responsável por autorizar o vínculo com o cliente ANTES —
+   * este método não sabe se o cliente pertence ao consultor ou ao escritório.
+   *
+   * @throws {NotFoundException} - Especialista inexistente
+   * @throws {ConflictException} - Já existe processo/consultoria ativa equivalente
+   */
+  async createOnBehalfOfClient(input: CreateOnBehalfInput) {
+    const specialist = await this.prismaService.user.findFirst({
+      where: { id: input.specialist_id, role: UserRole.SPECIALIST },
+    });
+
+    if (!specialist) {
+      throw new NotFoundException('Especialista não encontrado');
+    }
+
+    const productFieldMap = {
+      CAR: 'car_id',
+      BOAT: 'boat_id',
+      AIRCRAFT: 'aircraft_id',
+    } as const;
+    const productField = input.product_id
+      ? productFieldMap[input.product_type]
+      : undefined;
+
+    const activeStatuses = [
+      'SCHEDULING',
+      'NEGOTIATION',
+      'PROCESSING_CONTRACT',
+      'DOCUMENTATION',
+    ] as const;
+
+    if (productField && input.product_id) {
+      // Só bloqueia se houver processo ATIVO; processos encerrados
+      // (COMPLETED/REJECTED) permitem novo processo para o mesmo produto.
+      const existing = await this.prismaService.process.findFirst({
+        where: {
+          client_id: input.client_id,
+          specialist_id: input.specialist_id,
+          [productField]: input.product_id,
+          status: { in: [...activeStatuses] as any },
+        },
+      });
+      if (existing) {
+        throw new ConflictException(
+          'Já existe processo ativo para este cliente com este produto.',
+        );
+      }
+    } else {
+      const activeConsultancy = await this.prismaService.process.findFirst({
+        where: {
+          client_id: input.client_id,
+          specialist_id: input.specialist_id,
+          product_type: null,
+          status: { in: [...activeStatuses] as any },
+        },
+      });
+      if (activeConsultancy) {
+        throw new ConflictException(
+          'Já existe consultoria ativa entre este cliente e este especialista.',
+        );
+      }
+    }
+
+    const pendingExpiresAt = new Date();
+    pendingExpiresAt.setDate(pendingExpiresAt.getDate() + 7);
+
+    const isConsultancy = !productField || !input.product_id;
+
+    const [, process] = await this.prismaService.$transaction(async (tx) => {
+      const appointmentData: any = {
+        client_id: input.client_id,
+        specialist_id: input.specialist_id,
+        appointment_datetime: null,
+        status: 'PENDING',
+        notes: isConsultancy
+          ? `Consultoria criada pelo ${input.actorLabel} em nome do cliente (${new Date().toISOString()})`
+          : `Processo criado pelo ${input.actorLabel} em nome do cliente (${new Date().toISOString()})`,
+        user_clicked_at: new Date(),
+        pending_expires_at: pendingExpiresAt,
+      };
+      if (!isConsultancy) {
+        appointmentData.product_type = input.product_type;
+        appointmentData.product_id = input.product_id;
+      }
+
+      const createdAppointment = await tx.appointment.create({
+        data: appointmentData,
+      });
+
+      const processData: any = {
+        client_id: input.client_id,
+        specialist_id: input.specialist_id,
+        appointment_id: createdAppointment.id,
+        product_type: isConsultancy ? null : input.product_type,
+        status: 'SCHEDULING',
+        notes: isConsultancy
+          ? `Consultoria iniciada pelo ${input.actorLabel} (${new Date().toISOString()})`
+          : `Processo iniciado pelo ${input.actorLabel} (${new Date().toISOString()})`,
+      };
+      if (!isConsultancy && productField && input.product_id) {
+        processData[productField] = input.product_id;
+      }
+
+      const createdProcess = await tx.process.create({ data: processData });
+
+      await tx.processStatusHistory.create({
+        data: {
+          processId: createdProcess.id,
+          status: 'SCHEDULING',
+          changed_by: input.createdBy,
+          changed_at: new Date(),
+        },
+      });
+
+      return [createdAppointment, createdProcess];
+    });
+
+    return process;
   }
 
   /**

--- a/frontend/src/components/processes/StartProcessForClientModal.tsx
+++ b/frontend/src/components/processes/StartProcessForClientModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { PopupModal, useCalendlyEventListener } from "react-calendly";
 import { getClients, createConsultantProcess, type Client } from "../../services/consultant.service";
+import { officeService } from "../../services/office";
 import { getUserById } from "../../services/users.service";
 import {
   registerCalendlyScheduledEvent,
@@ -10,11 +11,34 @@ import {
 import Button from "../../components/ui/button";
 import { Loader2, Search } from "lucide-react";
 
+/**
+ * Consultor e gerente de escritório abrem processo em nome de um cliente pelo
+ * mesmo fluxo; o que muda é de onde vem a lista de clientes, qual endpoint
+ * cria o processo e para onde o usuário volta depois.
+ */
+const MODES = {
+  CONSULTANT: {
+    listClients: () => getClients(),
+    createProcess: createConsultantProcess,
+    redirectTo: "/consultant/processes",
+    emptyMessage:
+      'Você ainda não tem clientes. Convide um cliente primeiro em "Meus Clientes".',
+  },
+  OFFICE: {
+    listClients: () => officeService.listClients(),
+    createProcess: officeService.createProcess,
+    redirectTo: "/office/processes",
+    emptyMessage:
+      "Nenhum cliente vinculado ao escritório ainda.",
+  },
+} as const;
+
 interface Props {
   productType: "CAR" | "BOAT" | "AIRCRAFT";
   productId: string;
   specialistId: string;
   productLabel?: string;
+  mode?: keyof typeof MODES;
   onClose: () => void;
 }
 
@@ -23,8 +47,10 @@ export default function StartProcessForClientModal({
   productId,
   specialistId,
   productLabel,
+  mode = "CONSULTANT",
   onClose,
 }: Props) {
+  const config = MODES[mode];
   const navigate = useNavigate();
   const [clients, setClients] = useState<Client[]>([]);
   const [isLoadingClients, setIsLoadingClients] = useState(true);
@@ -46,12 +72,15 @@ export default function StartProcessForClientModal({
   const [calendlyMessage, setCalendlyMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    getClients()
-      .then(setClients)
+    config
+      .listClients()
+      .then((list) => setClients(list as Client[]))
       .catch(() => setClients([]))
       .finally(() => setIsLoadingClients(false));
     searchRef.current?.focus();
-  }, []);
+    // MODES é constante de módulo, então `config` só muda se `mode` mudar —
+    // não recarrega a lista a cada render.
+  }, [config]);
 
   // Carrega o link do Calendly do especialista para permitir agendar a reunião
   useEffect(() => {
@@ -92,7 +121,7 @@ export default function StartProcessForClientModal({
         console.error("Erro ao sincronizar evento do Calendly:", err);
       } finally {
         setIsCalendlyOpen(false);
-        navigate("/consultant/processes");
+        navigate(config.redirectTo);
       }
     },
   });
@@ -105,7 +134,7 @@ export default function StartProcessForClientModal({
     setError(null);
     setIsSubmitting(true);
     try {
-      const process = await createConsultantProcess({
+      const process = await config.createProcess({
         client_id: selectedClient.id,
         specialist_id: specialistId,
         product_type: productType,
@@ -126,7 +155,7 @@ export default function StartProcessForClientModal({
           "Conclua o agendamento no Calendly para marcar o horário da reunião.",
         );
       } else {
-        navigate("/consultant/processes");
+        navigate(config.redirectTo);
       }
     } catch (err) {
       setError((err as Error).message || "Erro ao criar processo. Tente novamente.");
@@ -168,7 +197,7 @@ export default function StartProcessForClientModal({
           </div>
         ) : clients.length === 0 ? (
           <p className="text-sm text-gray-500 text-center py-8">
-            Você ainda não tem clientes. Convide um cliente primeiro em "Meus Clientes".
+            {config.emptyMessage}
           </p>
         ) : (
           <div className="max-h-64 overflow-y-auto border border-gray-200 rounded-md divide-y divide-gray-100">
@@ -219,7 +248,7 @@ export default function StartProcessForClientModal({
           open={isCalendlyOpen}
           onModalClose={() => {
             setIsCalendlyOpen(false);
-            navigate("/consultant/processes");
+            navigate(config.redirectTo);
           }}
           rootElement={document.getElementById("root") ?? document.body}
           prefill={{

--- a/frontend/src/pages/catalog/ProductPage.tsx
+++ b/frontend/src/pages/catalog/ProductPage.tsx
@@ -22,7 +22,7 @@ import { Card } from "../../components/ui/card";
 import { Alert } from "../../components/ui/alert";
 import { Dialog, DialogContent } from "../../components/ui/dialog";
 import { PageHeader } from "../../components/patterns/PageHeader";
-import StartProcessForClientModal from "../consultant/StartProcessForClientModal";
+import StartProcessForClientModal from "../../components/processes/StartProcessForClientModal";
 import { useAuth } from "../../store/authStateManager";
 import { useCheckAppointment } from "../../hooks/useCheckAppointment";
 import { useCalendlyScheduling } from "../../hooks/useCalendlyScheduling";
@@ -504,6 +504,22 @@ export default function ProductPage() {
                 Iniciar processo para cliente
               </Button>
             </div>
+          ) : user.role === "OFFICE" ? (
+            /* Gerente de escritório — inicia processo para cliente da empresa */
+            <div className="space-y-4">
+              <Alert variant="info">
+                <p className="text-sm">
+                  <strong>Modo Escritório:</strong> Você não pode agendar uma reunião em seu próprio nome. Selecione qual cliente do escritório terá o processo criado para este produto.
+                </p>
+              </Alert>
+
+              <Button
+                onClick={() => setIsStartProcessModalOpen(true)}
+                className="w-full"
+              >
+                Iniciar processo para cliente
+              </Button>
+            </div>
           ) : user.role !== "CUSTOMER" ? (
             /* SPECIALIST / ADMIN — apenas clientes podem agendar */
             <div className="bg-border-soft border border-border rounded-lg p-4">
@@ -670,6 +686,7 @@ export default function ProductPage() {
               productId={id}
               specialistId={specialist.id}
               productLabel={`${product.marca} ${product.modelo}`.trim()}
+              mode={user?.role === "OFFICE" ? "OFFICE" : "CONSULTANT"}
               onClose={() => setIsStartProcessModalOpen(false)}
             />
           </DialogContent>

--- a/frontend/src/services/office.ts
+++ b/frontend/src/services/office.ts
@@ -132,6 +132,24 @@ export const officeService = {
     params: { consultantId?: string; q?: string; companyId?: string } = {},
   ) => api.get<OfficeClient[]>('office/clients', { params }).then((r) => r.data),
 
+  /**
+   * Abre um processo em nome de um cliente do escritório.
+   * A empresa não vai no payload: o backend resolve pelo escopo de quem está
+   * autenticado, então não há como pedir processo para cliente de outra.
+   */
+  createProcess: (payload: {
+    client_id: string;
+    specialist_id: string;
+    product_type: 'CAR' | 'BOAT' | 'AIRCRAFT';
+    product_id?: string;
+  }) =>
+    api
+      .post<{ data: { id: string; appointment_id?: string } }>(
+        'office/processes',
+        payload,
+      )
+      .then((r) => r.data.data),
+
   // Company
   getCompany: () => api.get<OfficeCompany>('office/company').then((r) => r.data),
   updateCompany: (payload: Partial<OfficeCompany>) =>


### PR DESCRIPTION
# Changelog

- Adiciona `POST /office/processes`: gerente de escritório abre processo em nome de um cliente da própria empresa, com agendamento;
- Bloqueia cliente de outra empresa nesse fluxo;
- Corrige `POST /processes`, que não validava nenhum vínculo entre quem cria e o `client_id` informado;
- Extrai a transação de criação (Appointment + Process + histórico) de `ConsultantService` para `ProcessesService.createOnBehalfOfClient`, usada pelos dois fluxos;
- Generaliza `StartProcessForClientModal` para os dois papéis via prop `mode` e move de `pages/consultant/` para `components/processes/`;
- Adiciona 10 testes: autorização por papel na criação e o método extraído.

closes: [TASK 3.3 — Escritório: gerente inicia processo em nome de cliente da empresa](https://github.com/orgs/InteliJR/projects/23)

> [!IMPORTANT]
> **PR empilhada:** sai de `feat/office-processes-scope` (#205), não de `develop`. O tipo `ProcessesRequester` nasce lá e é reusado aqui; separar significaria duplicá-lo e conflitar no merge. **Revisar e mergear o #205 primeiro** — depois disso o diff aqui fica só com o que é da 3.3.

---

## Por que com agendamento

A task pede "equivalente ao Modo Consultor". O fluxo do consultor (`POST /consultant/processes`) cria um `Appointment` pendente junto com o processo, e é isso que abre o popup do Calendly em seguida. O `POST /processes` genérico **não** cria `Appointment`.

Isso não é um detalhe cosmético: `confirmAppointment` lança `NotFoundException` se o processo não tiver agendamento, então um processo criado sem ele deixa o especialista sem o passo seguinte natural — ele só sairia de `SCHEDULING` por um `PATCH` de status direto.

Somando a isso o fato de "agendamento integrado" aparecer como certeza em `docs/docs/visao-produto.md`, implementei o fluxo completo. **Se o time preferir o caminho curto (processo sem agendamento), essa é a parte a revisar primeiro.**

## Por que extrair em vez de duplicar

O `createProcessForCompanyClient` precisava da mesma transação de ~60 linhas do consultor. Copiar significaria duas cópias divergindo com o tempo, então extraí para `ProcessesService.createOnBehalfOfClient`, parametrizada por `actorLabel` ("consultor" / "gerente do escritório") — que é o que fica registrado nas notas do processo.

O risco disso é mexer num fluxo que funciona: `consultant.service.ts` **não tinha nenhum spec**. Por isso o método extraído já nasce com testes cobrindo Appointment pendente, notas do ator, consultoria sem produto e especialista inexistente — o fluxo do consultor termina este PR com mais cobertura do que tinha.

## A correção de acesso no POST /processes

O endpoint aceitava qualquer `client_id` de qualquer usuário autenticado — dava para abrir processo em nome de cliente alheio. A task pede essa validação explicitamente ("não apenas abrir mais um caminho sem checagem").

| Papel | Pode criar para |
|---|---|
| `ADMIN` | qualquer cliente |
| `SPECIALIST` | qualquer cliente, mas só com `specialist_id` igual ao próprio |
| `CONSULTANT` | clientes próprios |
| `OFFICE` | clientes da própria empresa |
| `CUSTOMER` | apenas para si |
| desconhecido | ninguém (403) |

O especialista **não** foi restringido a clientes com quem já tem relação: abrir o primeiro processo de um cliente novo é o caso de uso da tela dele. O `CreateProcessModal` já envia `specialist_id: user.id`, então a regra não muda o comportamento da tela existente.

## Testes

- 10 testes novos; `processes.service` + `office.service` → 41 passando;
- Suíte completa do backend: 207 passando. As 5 falhas em `contracts.service.spec.ts` **já existem na develop** (confirmado na branch limpa);
- `nest build` passa — o que exercita a fiação nova de módulos (`ProcessesModule` exportado e importado por consultant/office; sem ciclo);
- Frontend: `tsc -b` limpo, `vitest` 37 passando, sem lint novo.

## O que não foi verificado

Mesma limitação do #205: não exercitei o fluxo com dados reais. A prova que importa aqui — gerente do escritório A tentando abrir processo para cliente do escritório B — exige banco com duas empresas, e o caminho feliz ainda passa por Calendly. A validação neste PR é unitária.

Sugiro que a revisão inclua os dois casos manualmente antes do merge.
