### PR TITLE
feat(contracts): torna preenchimento de campos do contrato flexivel

### DIFF
--- a/backend/src/features/contracts/contracts.service.ts
+++ b/backend/src/features/contracts/contracts.service.ts
@@ -559,6 +559,15 @@ export class ContractsService {
       );
     }
 
+    // Os demais campos do contrato são opcionais, mas a taxa não pode ser:
+    // undefined/NaN aqui propaga NaN para platform/office/specialist value e
+    // esses valores são gravados no banco. Falhar aqui é o mal menor.
+    if (!Number.isFinite(totalCommissionRate)) {
+      throw new BadRequestException(
+        'total_commission_rate ausente ou inválido — não é possível calcular a comissão.',
+      );
+    }
+
     // Split aninhado — ver commission-split.ts. Soma exata por construção.
     const split = computeNestedCommissionSplit({
       proposalValue,
@@ -799,24 +808,24 @@ export class ContractsService {
               seller_name: dto.seller_name,
               seller_cpf: cleanDocs.seller_cpf,
               seller_rg: cleanDocs.seller_rg,
-              seller_address: dto.seller_address,
+              seller_address: dto.seller_address ?? '',
               seller_cep: cleanDocs.seller_cep,
-              seller_bank: dto.seller_bank,
-              seller_agency: dto.seller_agency,
-              seller_checking_account: dto.seller_checking_account,
+              seller_bank: dto.seller_bank ?? '',
+              seller_agency: dto.seller_agency ?? '',
+              seller_checking_account: dto.seller_checking_account ?? '',
 
               // Dados do comprador
               buyer_name: dto.buyer_name,
               buyer_cpf: cleanDocs.buyer_cpf,
               buyer_rg: cleanDocs.buyer_rg,
-              buyer_address: dto.buyer_address,
+              buyer_address: dto.buyer_address ?? '',
               buyer_cep: cleanDocs.buyer_cep,
 
               // Dados do veículo
-              vehicle_model: dto.vehicle_model,
-              vehicle_year: dto.vehicle_year,
-              vehicle_registration_id: dto.vehicle_registration_id,
-              vehicle_serial_number: dto.vehicle_serial_number,
+              vehicle_model: dto.vehicle_model ?? '',
+              vehicle_year: dto.vehicle_year ?? '',
+              vehicle_registration_id: dto.vehicle_registration_id ?? '',
+              vehicle_serial_number: dto.vehicle_serial_number ?? '',
               vehicle_technical_information: dto.vehicle_technical_info,
               vehicle_price: dto.vehicle_price,
               vehicle_price_written: numberToWords(dto.vehicle_price),
@@ -866,7 +875,7 @@ export class ContractsService {
               testimonial2_email: dto.testimonial2_email || null,
 
               // Cidade
-              city: dto.city,
+              city: dto.city ?? '',
 
               // Template usado
               template_id: templateId,
@@ -1007,24 +1016,24 @@ export class ContractsService {
       seller_name: dto.seller_name,
       seller_cpf: formatCpf(dto.seller_cpf),
       seller_rg: dto.seller_rg ? formatRg(dto.seller_rg) : '',
-      seller_address: dto.seller_address,
+      seller_address: dto.seller_address ?? '',
       seller_cep: formatCep(dto.seller_cep),
-      seller_bank: dto.seller_bank,
-      seller_agency: dto.seller_agency,
-      seller_checking_account: dto.seller_checking_account,
+      seller_bank: dto.seller_bank ?? '',
+      seller_agency: dto.seller_agency ?? '',
+      seller_checking_account: dto.seller_checking_account ?? '',
 
       // Comprador
       buyer_name: dto.buyer_name,
       buyer_cpf: formatCpf(dto.buyer_cpf),
       buyer_rg: dto.buyer_rg ? formatRg(dto.buyer_rg) : '',
-      buyer_address: dto.buyer_address,
+      buyer_address: dto.buyer_address ?? '',
       buyer_cep: formatCep(dto.buyer_cep),
 
       // Veículo
-      vehicle_model: dto.vehicle_model,
-      vehicle_year: dto.vehicle_year,
-      vehicle_registration_id: dto.vehicle_registration_id,
-      vehicle_serial_number: dto.vehicle_serial_number,
+      vehicle_model: dto.vehicle_model ?? '',
+      vehicle_year: dto.vehicle_year ?? '',
+      vehicle_registration_id: dto.vehicle_registration_id ?? '',
+      vehicle_serial_number: dto.vehicle_serial_number ?? '',
       // ATENÇÃO: typo no template - "techinical" com 'i' antes de 'n'
       vehicle_techinical_information: dto.vehicle_technical_info || '',
       vehicle_price: formatBRL(dto.vehicle_price),
@@ -1087,7 +1096,7 @@ export class ContractsService {
         : '',
 
       // Cidade
-      city: dto.city,
+      city: dto.city ?? '',
     };
 
     this.logger.debug(
@@ -1208,21 +1217,21 @@ export class ContractsService {
         seller_email: dto.seller_email,
         seller_cpf: dto.seller_cpf,
         seller_rg: dto.seller_rg,
-        seller_address: dto.seller_address,
+        seller_address: dto.seller_address ?? '',
         seller_cep: dto.seller_cep,
-        seller_bank: dto.seller_bank,
-        seller_agency: dto.seller_agency,
-        seller_checking_account: dto.seller_checking_account,
+        seller_bank: dto.seller_bank ?? '',
+        seller_agency: dto.seller_agency ?? '',
+        seller_checking_account: dto.seller_checking_account ?? '',
         buyer_name: dto.buyer_name,
         buyer_email: dto.buyer_email,
         buyer_cpf: dto.buyer_cpf,
         buyer_rg: dto.buyer_rg,
-        buyer_address: dto.buyer_address,
+        buyer_address: dto.buyer_address ?? '',
         buyer_cep: dto.buyer_cep,
-        vehicle_model: dto.vehicle_model,
-        vehicle_year: dto.vehicle_year,
-        vehicle_registration_id: dto.vehicle_registration_id,
-        vehicle_serial_number: dto.vehicle_serial_number,
+        vehicle_model: dto.vehicle_model ?? '',
+        vehicle_year: dto.vehicle_year ?? '',
+        vehicle_registration_id: dto.vehicle_registration_id ?? '',
+        vehicle_serial_number: dto.vehicle_serial_number ?? '',
         vehicle_technical_info: dto.vehicle_technical_info,
         vehicle_price: dto.vehicle_price,
         payment_seller_value: dto.payment_seller_value,
@@ -1250,7 +1259,7 @@ export class ContractsService {
         testimonial1_email: dto.testimonial1_email,
         testimonial2_cpf: dto.testimonial2_cpf,
         testimonial2_email: dto.testimonial2_email,
-        city: dto.city,
+        city: dto.city ?? '',
         description: dto.description,
       };
 
@@ -1455,24 +1464,24 @@ export class ContractsService {
               seller_name: dto.seller_name,
               seller_cpf: cleanDocs.seller_cpf,
               seller_rg: cleanDocs.seller_rg,
-              seller_address: dto.seller_address,
+              seller_address: dto.seller_address ?? '',
               seller_cep: cleanDocs.seller_cep,
-              seller_bank: dto.seller_bank,
-              seller_agency: dto.seller_agency,
-              seller_checking_account: dto.seller_checking_account,
+              seller_bank: dto.seller_bank ?? '',
+              seller_agency: dto.seller_agency ?? '',
+              seller_checking_account: dto.seller_checking_account ?? '',
 
               // Dados do comprador
               buyer_name: dto.buyer_name,
               buyer_cpf: cleanDocs.buyer_cpf,
               buyer_rg: cleanDocs.buyer_rg,
-              buyer_address: dto.buyer_address,
+              buyer_address: dto.buyer_address ?? '',
               buyer_cep: cleanDocs.buyer_cep,
 
               // Dados do veículo
-              vehicle_model: dto.vehicle_model,
-              vehicle_year: dto.vehicle_year,
-              vehicle_registration_id: dto.vehicle_registration_id,
-              vehicle_serial_number: dto.vehicle_serial_number,
+              vehicle_model: dto.vehicle_model ?? '',
+              vehicle_year: dto.vehicle_year ?? '',
+              vehicle_registration_id: dto.vehicle_registration_id ?? '',
+              vehicle_serial_number: dto.vehicle_serial_number ?? '',
               vehicle_technical_information: dto.vehicle_technical_info,
               vehicle_price: dto.vehicle_price,
               vehicle_price_written: numberToWords(dto.vehicle_price),
@@ -1522,7 +1531,7 @@ export class ContractsService {
               testimonial2_email: dto.testimonial2_email || null,
 
               // Cidade
-              city: dto.city,
+              city: dto.city ?? '',
 
               // Template usado
               template_id: templateId,

--- a/backend/src/features/contracts/dto/generate-contract.dto.ts
+++ b/backend/src/features/contracts/dto/generate-contract.dto.ts
@@ -48,32 +48,32 @@ export class GenerateContractDto {
   seller_email: string;
 
   @IsString({ message: 'seller_cpf deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_cpf é obrigatório' })
-  seller_cpf: string;
+  @IsOptional()
+  seller_cpf?: string;
 
   @IsString({ message: 'seller_rg deve ser uma string' })
   @IsOptional()
   seller_rg?: string;
 
   @IsString({ message: 'seller_address deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_address é obrigatório' })
-  seller_address: string;
+  @IsOptional()
+  seller_address?: string;
 
   @IsString({ message: 'seller_cep deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_cep é obrigatório' })
-  seller_cep: string;
+  @IsOptional()
+  seller_cep?: string;
 
   @IsString({ message: 'seller_bank deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_bank é obrigatório' })
-  seller_bank: string;
+  @IsOptional()
+  seller_bank?: string;
 
   @IsString({ message: 'seller_agency deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_agency é obrigatório' })
-  seller_agency: string;
+  @IsOptional()
+  seller_agency?: string;
 
   @IsString({ message: 'seller_checking_account deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_checking_account é obrigatório' })
-  seller_checking_account: string;
+  @IsOptional()
+  seller_checking_account?: string;
 
   // === COMPRADOR (BUYER) ===
 
@@ -87,54 +87,54 @@ export class GenerateContractDto {
   buyer_email: string;
 
   @IsString({ message: 'buyer_cpf deve ser uma string' })
-  @IsNotEmpty({ message: 'buyer_cpf é obrigatório' })
-  buyer_cpf: string;
+  @IsOptional()
+  buyer_cpf?: string;
 
   @IsString({ message: 'buyer_rg deve ser uma string' })
   @IsOptional()
   buyer_rg?: string;
 
   @IsString({ message: 'buyer_address deve ser uma string' })
-  @IsNotEmpty({ message: 'buyer_address é obrigatório' })
-  buyer_address: string;
+  @IsOptional()
+  buyer_address?: string;
 
   @IsString({ message: 'buyer_cep deve ser uma string' })
-  @IsNotEmpty({ message: 'buyer_cep é obrigatório' })
-  buyer_cep: string;
+  @IsOptional()
+  buyer_cep?: string;
 
   // === VEÍCULO/PRODUTO ===
 
   @IsString({ message: 'vehicle_model deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_model é obrigatório' })
-  vehicle_model: string;
+  @IsOptional()
+  vehicle_model?: string;
 
   @IsString({ message: 'vehicle_year deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_year é obrigatório' })
-  vehicle_year: string;
+  @IsOptional()
+  vehicle_year?: string;
 
   @IsString({ message: 'vehicle_registration_id deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_registration_id é obrigatório' })
-  vehicle_registration_id: string;
+  @IsOptional()
+  vehicle_registration_id?: string;
 
   @IsString({ message: 'vehicle_serial_number deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_serial_number é obrigatório' })
-  vehicle_serial_number: string;
+  @IsOptional()
+  vehicle_serial_number?: string;
 
   @IsString({ message: 'vehicle_technical_info deve ser uma string' })
   @IsOptional()
   vehicle_technical_info?: string;
 
   @IsNumber({}, { message: 'vehicle_price deve ser um número' })
-  @IsNotEmpty({ message: 'vehicle_price é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'vehicle_price deve ser maior ou igual a zero' })
-  vehicle_price: number;
+  vehicle_price?: number;
 
   // === PAGAMENTO AO VENDEDOR ===
 
   @IsNumber({}, { message: 'payment_seller_value deve ser um número' })
-  @IsNotEmpty({ message: 'payment_seller_value é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'payment_seller_value deve ser maior ou igual a zero' })
-  payment_seller_value: number;
+  payment_seller_value?: number;
 
   // === COMISSÃO TOTAL DA VENDA ===
   // ATENÇÃO: rota legada (POST /contracts/generate não é usada pelo frontend
@@ -153,14 +153,14 @@ export class GenerateContractDto {
   // === DADOS DA PLATAFORMA (SPLIT 1) ===
 
   @IsNumber({}, { message: 'platform_value deve ser um número' })
-  @IsNotEmpty({ message: 'platform_value é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'platform_value deve ser maior ou igual a zero' })
-  platform_value: number;
+  platform_value?: number;
 
   @IsNumber({}, { message: 'platform_percentage deve ser um número' })
-  @IsNotEmpty({ message: 'platform_percentage é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'platform_percentage deve ser maior ou igual a zero' })
-  platform_percentage: number;
+  platform_percentage?: number;
 
   @IsString({ message: 'platform_name deve ser uma string' })
   @IsOptional()
@@ -185,9 +185,9 @@ export class GenerateContractDto {
   // === DADOS DO ESCRITÓRIO/EMPRESA PARCEIRA (SPLIT 2) ===
 
   @IsNumber({}, { message: 'office_value deve ser um número' })
-  @IsNotEmpty({ message: 'office_value é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'office_value deve ser maior ou igual a zero' })
-  office_value: number;
+  office_value?: number;
 
   @IsString({ message: 'office_name deve ser uma string' })
   @IsOptional()
@@ -212,9 +212,9 @@ export class GenerateContractDto {
   // === DADOS DO ESPECIALISTA (SPLIT 3) ===
 
   @IsNumber({}, { message: 'specialist_value deve ser um número' })
-  @IsNotEmpty({ message: 'specialist_value é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'specialist_value deve ser maior ou igual a zero' })
-  specialist_value: number;
+  specialist_value?: number;
 
   @IsString({ message: 'specialist_name deve ser uma string' })
   @IsOptional()
@@ -269,8 +269,8 @@ export class GenerateContractDto {
   // === CIDADE DE ASSINATURA ===
 
   @IsString({ message: 'city deve ser uma string' })
-  @IsNotEmpty({ message: 'city é obrigatório' })
-  city: string;
+  @IsOptional()
+  city?: string;
 
   // === DESCRIÇÃO OPCIONAL ===
 

--- a/backend/src/features/contracts/dto/preview-contract.dto.spec.ts
+++ b/backend/src/features/contracts/dto/preview-contract.dto.spec.ts
@@ -1,0 +1,112 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { PreviewContractDto } from './preview-contract.dto';
+import { GenerateContractDto } from './generate-contract.dto';
+
+const processId = '550e8400-e29b-41d4-a716-446655440000';
+
+/** Só o que continua estruturalmente obrigatório. */
+const minimoPreview = {
+  return_url: 'https://app.example.com/callback',
+  process_id: processId,
+  seller_name: 'Vendedor',
+  seller_email: 'vendedor@example.com',
+  buyer_name: 'Comprador',
+  buyer_email: 'comprador@example.com',
+  total_commission_rate: 10,
+};
+
+const minimoGenerate = {
+  process_id: processId,
+  seller_name: 'Vendedor',
+  seller_email: 'vendedor@example.com',
+  buyer_name: 'Comprador',
+  buyer_email: 'comprador@example.com',
+  total_commission_rate: 10,
+};
+
+async function erros(cls: any, payload: Record<string, unknown>) {
+  return validate(plainToInstance(cls, payload));
+}
+
+describe('PreviewContractDto — preenchimento flexível', () => {
+  // Critério de aceite da task: dá para gerar contrato com parte dos campos.
+  it('aceita payload sem os campos de conteúdo do contrato', async () => {
+    expect(await erros(PreviewContractDto, minimoPreview)).toHaveLength(0);
+  });
+
+  it.each([
+    'seller_cpf',
+    'seller_address',
+    'seller_cep',
+    'seller_bank',
+    'seller_agency',
+    'seller_checking_account',
+    'buyer_cpf',
+    'buyer_address',
+    'buyer_cep',
+    'vehicle_model',
+    'vehicle_year',
+    'vehicle_registration_id',
+    'vehicle_serial_number',
+    'vehicle_price',
+    'payment_seller_value',
+    'city',
+  ])('%s deixou de ser obrigatório', async (campo) => {
+    const errs = await erros(PreviewContractDto, minimoPreview);
+    expect(errs.find((e) => e.property === campo)).toBeUndefined();
+  });
+
+  // Os que continuam obrigatórios não podem ter sido afrouxados junto.
+  it.each([
+    'return_url',
+    'process_id',
+    'seller_name',
+    'seller_email',
+    'buyer_name',
+    'buyer_email',
+    'total_commission_rate',
+  ])('%s continua obrigatório', async (campo) => {
+    const payload = { ...minimoPreview };
+    delete (payload as Record<string, unknown>)[campo];
+
+    const errs = await erros(PreviewContractDto, payload);
+    expect(errs.some((e) => e.property === campo)).toBe(true);
+  });
+
+  // Opcional não significa "aceita lixo": o tipo ainda é validado quando vem.
+  it('valida o tipo dos campos opcionais quando preenchidos', async () => {
+    const errs = await erros(PreviewContractDto, {
+      ...minimoPreview,
+      vehicle_price: 'caro',
+    });
+    expect(errs.some((e) => e.property === 'vehicle_price')).toBe(true);
+  });
+});
+
+describe('GenerateContractDto — preenchimento flexível', () => {
+  // /contracts/generate é chamado pelo mesmo formulário; afrouxar só o preview
+  // deixaria o fluxo travado no passo seguinte.
+  it('aceita payload sem os campos de conteúdo do contrato', async () => {
+    expect(await erros(GenerateContractDto, minimoGenerate)).toHaveLength(0);
+  });
+
+  // O backend recalcula a comissão e ignora estes valores do cliente.
+  it.each([
+    'platform_value',
+    'platform_percentage',
+    'office_value',
+    'specialist_value',
+  ])('%s deixou de ser obrigatório', async (campo) => {
+    const errs = await erros(GenerateContractDto, minimoGenerate);
+    expect(errs.find((e) => e.property === campo)).toBeUndefined();
+  });
+
+  it('total_commission_rate continua obrigatório', async () => {
+    const payload = { ...minimoGenerate };
+    delete (payload as Record<string, unknown>).total_commission_rate;
+
+    const errs = await erros(GenerateContractDto, payload);
+    expect(errs.some((e) => e.property === 'total_commission_rate')).toBe(true);
+  });
+});

--- a/backend/src/features/contracts/dto/preview-contract.dto.ts
+++ b/backend/src/features/contracts/dto/preview-contract.dto.ts
@@ -19,6 +19,26 @@ import {
  *
  * O preview cria um envelope em modo DRAFT que pode ser visualizado
  * e editado antes do envio definitivo.
+ *
+ * ## Campos obrigatórios
+ *
+ * Os dados do contrato (CPF, endereço, CEP, banco, dados do veículo, valores,
+ * cidade) são OPCIONAIS de propósito: nem sempre estão todos disponíveis na
+ * hora de montar o contrato, e travar o preenchimento impedia gerar o
+ * documento. Campos ausentes chegam vazios no template do DocuSign.
+ *
+ * Continuam obrigatórios apenas os que quebram o fluxo se faltarem:
+ *
+ * - `return_url`, `process_id` — encanamento, não são conteúdo do contrato.
+ * - `seller_name`/`seller_email`, `buyer_name`/`buyer_email` — viram
+ *   destinatários do envelope; o DocuSign recusa criar envelope sem eles, e
+ *   `buyer_email` ainda é usado para localizar o usuário signatário.
+ * - `total_commission_rate` — base do cálculo de comissão. Sem ele o split
+ *   vira NaN e é persistido assim; um erro de validação é preferível a um
+ *   contrato com valores corrompidos.
+ *
+ * Se o PO decidir afrouxar `total_commission_rate` também, trate a ausência
+ * como zero em resolveCommissionFromTotal antes de remover a validação daqui.
  */
 export class PreviewContractDto {
   /**
@@ -60,32 +80,32 @@ export class PreviewContractDto {
   seller_email: string;
 
   @IsString({ message: 'seller_cpf deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_cpf é obrigatório' })
-  seller_cpf: string;
+  @IsOptional()
+  seller_cpf?: string;
 
   @IsString({ message: 'seller_rg deve ser uma string' })
   @IsOptional()
   seller_rg?: string;
 
   @IsString({ message: 'seller_address deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_address é obrigatório' })
-  seller_address: string;
+  @IsOptional()
+  seller_address?: string;
 
   @IsString({ message: 'seller_cep deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_cep é obrigatório' })
-  seller_cep: string;
+  @IsOptional()
+  seller_cep?: string;
 
   @IsString({ message: 'seller_bank deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_bank é obrigatório' })
-  seller_bank: string;
+  @IsOptional()
+  seller_bank?: string;
 
   @IsString({ message: 'seller_agency deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_agency é obrigatório' })
-  seller_agency: string;
+  @IsOptional()
+  seller_agency?: string;
 
   @IsString({ message: 'seller_checking_account deve ser uma string' })
-  @IsNotEmpty({ message: 'seller_checking_account é obrigatório' })
-  seller_checking_account: string;
+  @IsOptional()
+  seller_checking_account?: string;
 
   // === COMPRADOR (BUYER) ===
 
@@ -99,54 +119,54 @@ export class PreviewContractDto {
   buyer_email: string;
 
   @IsString({ message: 'buyer_cpf deve ser uma string' })
-  @IsNotEmpty({ message: 'buyer_cpf é obrigatório' })
-  buyer_cpf: string;
+  @IsOptional()
+  buyer_cpf?: string;
 
   @IsString({ message: 'buyer_rg deve ser uma string' })
   @IsOptional()
   buyer_rg?: string;
 
   @IsString({ message: 'buyer_address deve ser uma string' })
-  @IsNotEmpty({ message: 'buyer_address é obrigatório' })
-  buyer_address: string;
+  @IsOptional()
+  buyer_address?: string;
 
   @IsString({ message: 'buyer_cep deve ser uma string' })
-  @IsNotEmpty({ message: 'buyer_cep é obrigatório' })
-  buyer_cep: string;
+  @IsOptional()
+  buyer_cep?: string;
 
   // === VEÍCULO/PRODUTO ===
 
   @IsString({ message: 'vehicle_model deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_model é obrigatório' })
-  vehicle_model: string;
+  @IsOptional()
+  vehicle_model?: string;
 
   @IsString({ message: 'vehicle_year deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_year é obrigatório' })
-  vehicle_year: string;
+  @IsOptional()
+  vehicle_year?: string;
 
   @IsString({ message: 'vehicle_registration_id deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_registration_id é obrigatório' })
-  vehicle_registration_id: string;
+  @IsOptional()
+  vehicle_registration_id?: string;
 
   @IsString({ message: 'vehicle_serial_number deve ser uma string' })
-  @IsNotEmpty({ message: 'vehicle_serial_number é obrigatório' })
-  vehicle_serial_number: string;
+  @IsOptional()
+  vehicle_serial_number?: string;
 
   @IsString({ message: 'vehicle_technical_info deve ser uma string' })
   @IsOptional()
   vehicle_technical_info?: string;
 
   @IsNumber({}, { message: 'vehicle_price deve ser um número' })
-  @IsNotEmpty({ message: 'vehicle_price é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'vehicle_price deve ser maior ou igual a zero' })
-  vehicle_price: number;
+  vehicle_price?: number;
 
   // === PAGAMENTO AO VENDEDOR ===
 
   @IsNumber({}, { message: 'payment_seller_value deve ser um número' })
-  @IsNotEmpty({ message: 'payment_seller_value é obrigatório' })
+  @IsOptional()
   @Min(0, { message: 'payment_seller_value deve ser maior ou igual a zero' })
-  payment_seller_value: number;
+  payment_seller_value?: number;
 
   // === COMISSÃO TOTAL DA VENDA ===
   // Único valor de comissão editável pelo especialista. O backend trava as taxas
@@ -257,8 +277,8 @@ export class PreviewContractDto {
   // === CIDADE DE ASSINATURA ===
 
   @IsString({ message: 'city deve ser uma string' })
-  @IsNotEmpty({ message: 'city é obrigatório' })
-  city: string;
+  @IsOptional()
+  city?: string;
 
   // === DESCRIÇÃO OPCIONAL ===
 

--- a/backend/src/shared/utils/format.utils.ts
+++ b/backend/src/shared/utils/format.utils.ts
@@ -16,7 +16,7 @@
  * @returns CPF formatado
  * @example formatCpf('12345678901') => '123.456.789-01'
  */
-export function formatCpf(value: string): string {
+export function formatCpf(value?: string | null): string {
   if (!value) return '';
   const digits = value.replace(/\D/g, '');
   if (digits.length !== 11) return value;
@@ -59,7 +59,7 @@ export function formatDocument(value: string): string {
  * @returns CEP formatado
  * @example formatCep('01234567') => '01234-567'
  */
-export function formatCep(value: string): string {
+export function formatCep(value?: string | null): string {
   if (!value) return '';
   const digits = value.replace(/\D/g, '');
   if (digits.length !== 8) return value;
@@ -72,7 +72,7 @@ export function formatCep(value: string): string {
  * @returns RG formatado
  * @example formatRg('123456789') => '12.345.678-9'
  */
-export function formatRg(value: string): string {
+export function formatRg(value?: string | null): string {
   if (!value) return '';
   const digits = value.replace(/\D/g, '');
   // Unificação RG/CPF: 10-11 dígitos é um CPF sendo usado como documento de RG.
@@ -96,7 +96,7 @@ export function formatRg(value: string): string {
  * @returns Valor formatado em reais
  * @example formatBRL(1234567.89) => 'R$ 1.234.567,89'
  */
-export function formatBRL(value: number): string {
+export function formatBRL(value?: number | null): string {
   if (value === null || value === undefined || isNaN(value)) return '';
   return new Intl.NumberFormat('pt-BR', {
     style: 'currency',
@@ -110,7 +110,7 @@ export function formatBRL(value: number): string {
  * @returns Valor por extenso
  * @example numberToWords(1234567.89) => 'um milhão, duzentos e trinta e quatro mil, quinhentos e sessenta e sete reais e oitenta e nove centavos'
  */
-export function numberToWords(value: number): string {
+export function numberToWords(value?: number | null): string {
   if (value === null || value === undefined || isNaN(value)) return '';
   if (value === 0) return 'zero reais';
 

--- a/frontend/src/pages/specialist/CreateContractPage.tsx
+++ b/frontend/src/pages/specialist/CreateContractPage.tsx
@@ -897,7 +897,6 @@ export default function CreateContractPage() {
                 <Controller
                   name="seller_cpf"
                   control={control}
-                  rules={{ required: "CPF é obrigatório" }}
                   render={({ field }) => (
                     <input
                       type="text"
@@ -945,7 +944,6 @@ export default function CreateContractPage() {
                 <Controller
                   name="seller_cep"
                   control={control}
-                  rules={{ required: "CEP é obrigatório" }}
                   render={({ field }) => (
                     <input
                       type="text"
@@ -973,7 +971,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("seller_address", {
-                    required: "Endereço é obrigatório",
                   })}
                   placeholder="Rua, número, complemento, bairro, cidade - UF"
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
@@ -998,7 +995,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("seller_bank", {
-                    required: "Banco é obrigatório",
                   })}
                   placeholder="Ex: Itaú, Bradesco, Nubank"
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
@@ -1017,7 +1013,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("seller_agency", {
-                    required: "Agência é obrigatória",
                   })}
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
@@ -1035,7 +1030,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("seller_checking_account", {
-                    required: "Conta é obrigatória",
                   })}
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
@@ -1099,7 +1093,6 @@ export default function CreateContractPage() {
                 <Controller
                   name="buyer_cpf"
                   control={control}
-                  rules={{ required: "CPF é obrigatório" }}
                   render={({ field }) => (
                     <input
                       type="text"
@@ -1146,7 +1139,7 @@ export default function CreateContractPage() {
                 </label>
                 <input
                   type="text"
-                  {...register("buyer_cep", { required: "CEP é obrigatório" })}
+                  {...register("buyer_cep")}
                   placeholder="00000-000"
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
@@ -1163,7 +1156,7 @@ export default function CreateContractPage() {
                 </label>
                 <input
                   type="text"
-                  {...register("buyer_address", { required: "Endereço é obrigatório" })}
+                  {...register("buyer_address")}
                   placeholder="Rua, número, bairro, cidade — UF"
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
@@ -1202,7 +1195,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("vehicle_model", {
-                    required: "Modelo é obrigatório",
                   })}
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
@@ -1220,7 +1212,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("vehicle_year", {
-                    required: "Ano é obrigatório",
                   })}
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
@@ -1238,7 +1229,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("vehicle_registration_id", {
-                    required: "Identificação é obrigatória",
                   })}
                   placeholder={
                     prefillData?.product_type === "CAR"
@@ -1263,7 +1253,6 @@ export default function CreateContractPage() {
                 <input
                   type="text"
                   {...register("vehicle_serial_number", {
-                    required: "Número serial é obrigatório",
                   })}
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />
@@ -1305,7 +1294,7 @@ export default function CreateContractPage() {
                 Calculado automaticamente
               </span>
             </div>
-            <input type="hidden" {...register("vehicle_price", { required: "Valor é obrigatório", valueAsNumber: true, min: { value: 0, message: "Valor deve ser positivo" } })} />
+            <input type="hidden" {...register("vehicle_price", { valueAsNumber: true, min: { value: 0, message: "Valor deve ser positivo" } })} />
             <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
               <div>
                 <label className="block text-sm font-medium text-muted mb-1">
@@ -1330,6 +1319,7 @@ export default function CreateContractPage() {
                   type="number"
                   step="0.01"
                   {...register("total_commission_rate", {
+                    required: "Taxa de comissão é obrigatória",
                     valueAsNumber: true,
                     min: { value: 0, message: "Valor deve ser positivo" },
                   })}
@@ -1868,7 +1858,7 @@ export default function CreateContractPage() {
                 </label>
                 <input
                   type="text"
-                  {...register("city", { required: "Cidade é obrigatória" })}
+                  {...register("city")}
                   placeholder="Ex: São Paulo"
                   className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
                 />


### PR DESCRIPTION
# Changelog

- Torna opcionais os campos de conteúdo do contrato em `PreviewContractDto` (16 campos) e `GenerateContractDto` (20 campos);
- Remove as mesmas obrigatoriedades do formulário em `CreateContractPage.tsx`;
- Adiciona `required` em `total_commission_rate` no formulário, que o backend sempre exigiu;
- Mantém obrigatórios só os campos que quebram o fluxo se faltarem;
- Alinha as assinaturas de `formatCpf`/`formatCep`/`formatRg`/`formatBRL`/`numberToWords` ao comportamento que já tinham em runtime;
- Adiciona guarda contra `total_commission_rate` inválido em `resolveCommissionFromTotal`;
- Adiciona 31 testes de validação dos dois DTOs.

closes: [TASK 3.5 — Contrato: tornar preenchimento de campos flexível](https://github.com/orgs/InteliJR/projects/23)

---

## O que continua obrigatório, e por quê

A task pede para definir o conjunto obrigatório com o PO. Como isso não estava definido, mantive apenas os campos cuja ausência **quebra o fluxo**, não os que são só desejáveis:

| Campo | Por que não dá para afrouxar |
|---|---|
| `return_url`, `process_id` | Encanamento do endpoint, não são conteúdo do contrato |
| `seller_name`, `seller_email` | Viram destinatário do envelope; o DocuSign recusa criar envelope sem nome/e-mail |
| `buyer_name`, `buyer_email` | Idem, e `buyer_email` ainda localiza o usuário signatário (`SignerNotFoundException`) |
| `total_commission_rate` | Entra direto em `computeNestedCommissionSplit`; ausente vira `NaN` em platform/office/specialist value — e esses valores são **persistidos** |

Todo o resto (CPF, endereço, CEP, banco, agência, conta, dados do veículo, preço, valor de pagamento, cidade) virou opcional e chega vazio no template.

**Backend e formulário exigem exatamente a mesma lista** — é a única forma de o especialista não descobrir a regra por um 400 depois do submit.

`total_commission_rate` é o único caso em que fui conservador de propósito: um erro de validação é recuperável, um contrato gravado com comissão `NaN` não é. **Se o PO quiser afrouxar esse também, o caminho está documentado no DTO** — tratar ausência como zero em `resolveCommissionFromTotal` antes de tirar a validação. Deixei a guarda de `Number.isFinite` lá para que essa mudança falhe de forma clara em vez de silenciosa.

## Por que os dois DTOs

A task cita só `preview-contract.dto.ts`, mas o mesmo formulário chama `/contracts/preview` **e** `/contracts/generate`, e o segundo tinha 27 `@IsNotEmpty` próprios. Afrouxar só o preview deixaria o fluxo travado um passo adiante.

Em `GenerateContractDto` também soltei `platform_value`, `platform_percentage`, `office_value` e `specialist_value`: o backend recalcula tudo a partir do total e explicitamente ignora o que vem do cliente ("nunca confia nos campos de comissão vindos do DTO", `contracts.service.ts`).

## Uma inconsistência corrigida de passagem

`total_commission_rate` **nunca teve** `required` no formulário, embora o backend sempre tenha exigido. Deixar assim significava trocar uma mensagem de campo por um erro 400 depois do envio — e com este PR ele passa a ser um dos poucos obrigatórios, o que tornaria a lacuna mais visível. Adicionei a regra.

## O efeito colateral útil

Tornar os campos opcionais fez o TypeScript apontar **22 pontos** em `contracts.service.ts` que assumiam presença. Nenhum deles quebraria em runtime por sorte — os formatadores já retornavam string vazia para valor ausente, só que suas assinaturas diziam `string`. Alinhei os tipos ao comportamento real e completei os pontos que montam `Record<string, string>` com `?? ''`.

Vale notar o que isso significa: campo ausente imprime **em branco** no contrato, não "R$ 0,00" nem "undefined".

## Testes

- 31 testes novos cobrindo os dois DTOs: payload mínimo passa, cada campo liberado não aparece nos erros, cada campo mantido continua falhando quando ausente, e tipo de campo opcional segue validado quando preenchido;
- Backend: 230 passando. As 5 falhas em `contracts.service.spec.ts` **já existem na develop** (mesmas de antes deste PR);
- `nest build` passa;
- Frontend: `tsc -b` limpo, `vitest` 37 passando, sem lint novo.

## O que não foi verificado

Não gerei um contrato real. Provar que o DocuSign aceita um template com tabs vazias exige credenciais e um envelope de verdade — a validação aqui é de DTO e de formulário. **Sugiro que a revisão inclua um preview real com campos em branco antes do merge**, principalmente para confirmar que o documento sai legível com lacunas em vez de quebrado.
