### PR TITLE
feat(admin): administrar cargos e especialidades

### DIFF
--- a/backend/src/features/admin-database/admin-database.controller.spec.ts
+++ b/backend/src/features/admin-database/admin-database.controller.spec.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import { BadRequestException, ValidationPipe } from '@nestjs/common';
 import { ProductType, UserRole } from '@prisma/client';
 import { ROLES_KEY } from 'src/shared/decorators/roles.decorator';
 import { AdminDatabaseController } from './admin-database.controller';
@@ -6,6 +7,7 @@ import { AdminDatabaseService } from './admin-database.service';
 import { AdminUserManagementService } from './admin-user-management.service';
 import { ChangeRoleDto } from './dto/change-role.dto';
 import { ChangeSpecialityDto } from './dto/change-speciality.dto';
+import { localizedValidationExceptionFactory } from '../../shared/validation/localized-validation-exception';
 
 describe('AdminDatabaseController — gestão de usuários', () => {
   const userId = 'a3e72de0-41b0-4468-a866-c5aac1a7a55e';
@@ -80,4 +82,56 @@ describe('AdminDatabaseController — gestão de usuários', () => {
       [UserRole.ADMIN],
     );
   });
+
+  it.each([
+    {
+      metatype: ChangeRoleDto,
+      payload: { role: 'SUPERUSER' },
+      expected:
+        'O cargo deve ser Cliente, Consultor, Especialista, Gerente de escritório ou Administrador.',
+    },
+    {
+      metatype: ChangeRoleDto,
+      payload: { role: UserRole.CONSULTANT, company_id: 'escritorio-1' },
+      expected: 'O escritório deve ter um identificador válido.',
+    },
+    {
+      metatype: ChangeRoleDto,
+      payload: {
+        role: UserRole.OFFICE,
+        replacement: { role: 'SUPERUSER' },
+      },
+      expected:
+        'O novo cargo do gerente atual deve ser Cliente, Consultor, Especialista ou Administrador.',
+    },
+    {
+      metatype: ChangeSpecialityDto,
+      payload: { speciality: 'MOTORCYCLE' },
+      expected: 'A especialidade deve ser Carros, Embarcações ou Aeronaves.',
+    },
+  ])(
+    'devolve validação de payload em português sem enum cru: $expected',
+    async ({ metatype, payload, expected }) => {
+      const pipe = new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        exceptionFactory: localizedValidationExceptionFactory,
+      });
+
+      const caught = await pipe
+        .transform(payload, { type: 'body', metatype })
+        .catch((error: unknown) => error);
+
+      expect(caught).toBeInstanceOf(BadRequestException);
+      expect((caught as BadRequestException).getResponse()).toMatchObject({
+        message: expect.arrayContaining([expected]),
+      });
+      expect(
+        JSON.stringify((caught as BadRequestException).getResponse()),
+      ).not.toMatch(
+        /SUPERUSER|MOTORCYCLE|CUSTOMER|CONSULTANT|SPECIALIST|OFFICE|ADMIN|CAR|BOAT|AIRCRAFT/,
+      );
+    },
+  );
 });

--- a/backend/src/features/admin-database/admin-database.controller.spec.ts
+++ b/backend/src/features/admin-database/admin-database.controller.spec.ts
@@ -134,4 +134,35 @@ describe('AdminDatabaseController — gestão de usuários', () => {
       );
     },
   );
+
+  it('omite detalhes de validação em produção', async () => {
+    const previousNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      const pipe = new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+        disableErrorMessages: true,
+        exceptionFactory: localizedValidationExceptionFactory,
+      });
+
+      const caught = await pipe
+        .transform(
+          { role: 'SUPERUSER' },
+          { type: 'body', metatype: ChangeRoleDto },
+        )
+        .catch((error: unknown) => error);
+
+      expect(caught).toBeInstanceOf(BadRequestException);
+      expect((caught as BadRequestException).getResponse()).toEqual({
+        statusCode: 400,
+        message: 'Os dados informados não são válidos.',
+        error: 'Requisição inválida',
+      });
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+  });
 });

--- a/backend/src/features/admin-database/admin-database.controller.spec.ts
+++ b/backend/src/features/admin-database/admin-database.controller.spec.ts
@@ -1,0 +1,83 @@
+import 'reflect-metadata';
+import { ProductType, UserRole } from '@prisma/client';
+import { ROLES_KEY } from 'src/shared/decorators/roles.decorator';
+import { AdminDatabaseController } from './admin-database.controller';
+import { AdminDatabaseService } from './admin-database.service';
+import { AdminUserManagementService } from './admin-user-management.service';
+import { ChangeRoleDto } from './dto/change-role.dto';
+import { ChangeSpecialityDto } from './dto/change-speciality.dto';
+
+describe('AdminDatabaseController — gestão de usuários', () => {
+  const userId = 'a3e72de0-41b0-4468-a866-c5aac1a7a55e';
+  const roleDto: ChangeRoleDto = { role: UserRole.SPECIALIST };
+  const specialityDto: ChangeSpecialityDto = { speciality: ProductType.CAR };
+  const management = {
+    validateRoleChange: jest.fn(),
+    changeRole: jest.fn(),
+    validateSpecialityChange: jest.fn(),
+    changeSpeciality: jest.fn(),
+  } as unknown as AdminUserManagementService;
+  const controller = new AdminDatabaseController(
+    {} as AdminDatabaseService,
+    management,
+  );
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('delega pré-validação de cargo', async () => {
+    const result = { allowed: true, blockers: [] };
+    management.validateRoleChange = jest.fn().mockResolvedValue(result);
+
+    await expect(
+      (controller as any).validateRoleChange(userId, roleDto),
+    ).resolves.toBe(result);
+    expect(management.validateRoleChange).toHaveBeenCalledWith(userId, roleDto);
+  });
+
+  it('delega correção de cargo', async () => {
+    const result = { id: userId, role: UserRole.SPECIALIST };
+    management.changeRole = jest.fn().mockResolvedValue(result);
+
+    await expect((controller as any).changeRole(userId, roleDto)).resolves.toBe(
+      result,
+    );
+    expect(management.changeRole).toHaveBeenCalledWith(userId, roleDto);
+  });
+
+  it('delega pré-validação de especialidade', async () => {
+    const result = { allowed: true, blockers: [] };
+    management.validateSpecialityChange = jest.fn().mockResolvedValue(result);
+
+    await expect(
+      (controller as any).validateSpecialityChange(userId, specialityDto),
+    ).resolves.toBe(result);
+    expect(management.validateSpecialityChange).toHaveBeenCalledWith(
+      userId,
+      specialityDto,
+    );
+  });
+
+  it('delega correção de especialidade', async () => {
+    const result = { id: userId, speciality: ProductType.CAR };
+    management.changeSpeciality = jest.fn().mockResolvedValue(result);
+
+    await expect(
+      (controller as any).changeSpeciality(userId, specialityDto),
+    ).resolves.toBe(result);
+    expect(management.changeSpeciality).toHaveBeenCalledWith(
+      userId,
+      specialityDto,
+    );
+  });
+
+  it.each([
+    'validateRoleChange',
+    'changeRole',
+    'validateSpecialityChange',
+    'changeSpeciality',
+  ])('protege %s somente para ADMIN', (method) => {
+    expect(Reflect.getMetadata(ROLES_KEY, (controller as any)[method])).toEqual(
+      [UserRole.ADMIN],
+    );
+  });
+});

--- a/backend/src/features/admin-database/admin-database.controller.ts
+++ b/backend/src/features/admin-database/admin-database.controller.ts
@@ -1,12 +1,26 @@
-import { Controller, Get, Param, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
 import { UserRole } from '@prisma/client';
 import { Roles } from 'src/shared/decorators/roles.decorator';
 import { AdminDatabaseService } from './admin-database.service';
+import { AdminUserManagementService } from './admin-user-management.service';
+import { ChangeRoleDto } from './dto/change-role.dto';
+import { ChangeSpecialityDto } from './dto/change-speciality.dto';
 
 // Navegador read-only da base de dados — só ADMIN.
 @Controller('admin/database')
 export class AdminDatabaseController {
-  constructor(private readonly service: AdminDatabaseService) {}
+  constructor(
+    private readonly service: AdminDatabaseService,
+    private readonly management: AdminUserManagementService,
+  ) {}
 
   @Get('entities')
   @Roles(UserRole.ADMIN)
@@ -22,5 +36,32 @@ export class AdminDatabaseController {
     @Query('pageSize') pageSize = '20',
   ) {
     return this.service.list(entity, Number(page) || 1, Number(pageSize) || 20);
+  }
+
+  @Post('users/:id/role-change/validate')
+  @Roles(UserRole.ADMIN)
+  validateRoleChange(@Param('id') id: string, @Body() dto: ChangeRoleDto) {
+    return this.management.validateRoleChange(id, dto);
+  }
+
+  @Patch('users/:id/role-change')
+  @Roles(UserRole.ADMIN)
+  changeRole(@Param('id') id: string, @Body() dto: ChangeRoleDto) {
+    return this.management.changeRole(id, dto);
+  }
+
+  @Post('users/:id/speciality-change/validate')
+  @Roles(UserRole.ADMIN)
+  validateSpecialityChange(
+    @Param('id') id: string,
+    @Body() dto: ChangeSpecialityDto,
+  ) {
+    return this.management.validateSpecialityChange(id, dto);
+  }
+
+  @Patch('users/:id/speciality-change')
+  @Roles(UserRole.ADMIN)
+  changeSpeciality(@Param('id') id: string, @Body() dto: ChangeSpecialityDto) {
+    return this.management.changeSpeciality(id, dto);
   }
 }

--- a/backend/src/features/admin-database/admin-database.labels.spec.ts
+++ b/backend/src/features/admin-database/admin-database.labels.spec.ts
@@ -11,7 +11,7 @@ describe('admin-database.labels', () => {
   it('traduz papel de usuário', () => {
     const fn = enumLabel(USER_ROLE);
     expect(fn('CONSULTANT')).toBe('Consultor');
-    expect(fn('OFFICE')).toBe('Escritório');
+    expect(fn('OFFICE')).toBe('Gerente de escritório');
   });
 
   it('traduz status de processo', () => {

--- a/backend/src/features/admin-database/admin-database.labels.ts
+++ b/backend/src/features/admin-database/admin-database.labels.ts
@@ -25,7 +25,7 @@ export const USER_ROLE: Record<string, string> = {
   CONSULTANT: 'Consultor',
   SPECIALIST: 'Especialista',
   ADMIN: 'Administrador',
-  OFFICE: 'Escritório',
+  OFFICE: 'Gerente de escritório',
 };
 
 export const PRODUCT_TYPE: Record<string, string> = {

--- a/backend/src/features/admin-database/admin-database.module.ts
+++ b/backend/src/features/admin-database/admin-database.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AdminDatabaseService } from './admin-database.service';
 import { AdminDatabaseController } from './admin-database.controller';
+import { AdminUserManagementService } from './admin-user-management.service';
 
 @Module({
   controllers: [AdminDatabaseController],
-  providers: [AdminDatabaseService],
+  providers: [AdminDatabaseService, AdminUserManagementService],
   exports: [AdminDatabaseService],
 })
 export class AdminDatabaseModule {}

--- a/backend/src/features/admin-database/admin-database.service.spec.ts
+++ b/backend/src/features/admin-database/admin-database.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException } from '@nestjs/common';
+import { UserRole } from '@prisma/client';
 import { AdminDatabaseService } from './admin-database.service';
 
 function mkPrisma(overrides: Record<string, any> = {}) {
@@ -156,6 +157,19 @@ describe('AdminDatabaseService — usuários', () => {
     expect(args.select).toBeDefined();
     expect(args.select.password_hash).toBeUndefined();
     expect(JSON.stringify(args.select)).not.toContain('password_hash');
+  });
+
+  it('retorna metadados não visuais de usuário', async () => {
+    const userId = 'a3e72de0-41b0-4468-a866-c5aac1a7a55e';
+    const { prisma, result } = await listarUsuarios({
+      ...usuario,
+      id: userId,
+      role: UserRole.SPECIALIST,
+    });
+
+    expect(result.rowMeta).toEqual([{ id: userId, role: UserRole.SPECIALIST }]);
+    expect(result.columns.map((column) => column.label)).not.toContain('ID');
+    expect(prisma.user.findMany.mock.calls[0][0].select.id).toBe(true);
   });
 
   it('devolve travessão para relação e campos ausentes', async () => {

--- a/backend/src/features/admin-database/admin-database.service.ts
+++ b/backend/src/features/admin-database/admin-database.service.ts
@@ -41,6 +41,7 @@ export class AdminDatabaseService {
   ): Promise<{
     columns: ColumnMeta[];
     data: Cell[][];
+    rowMeta: ({ id: string; role: string } | { id: string })[];
     total: number;
     page: number;
     pageSize: number;
@@ -63,7 +64,7 @@ export class AdminDatabaseService {
         skip,
         take,
         orderBy: { id: 'desc' },
-        select: cfg.select,
+        select: { ...cfg.select, id: true },
       }),
       model.count(),
     ]);
@@ -78,8 +79,11 @@ export class AdminDatabaseService {
       label: c.label,
       ...(c.wide ? { wide: true } : {}),
     }));
+    const rowMeta = rows.map((row: any) =>
+      entity === 'users' ? { id: row.id, role: row.role } : { id: row.id },
+    );
 
-    return { columns, data, total, page: currentPage, pageSize: take };
+    return { columns, data, rowMeta, total, page: currentPage, pageSize: take };
   }
 
   /** Projeta uma linha do Prisma na matriz de células já formatadas. */

--- a/backend/src/features/admin-database/admin-user-management.labels.spec.ts
+++ b/backend/src/features/admin-database/admin-user-management.labels.spec.ts
@@ -1,0 +1,25 @@
+import { ProductType, UserRole } from '@prisma/client';
+import {
+  roleLabel,
+  specialityLabel,
+} from './admin-user-management.labels';
+
+describe('admin-user-management.labels', () => {
+  it.each([
+    [UserRole.CUSTOMER, 'Cliente'],
+    [UserRole.CONSULTANT, 'Consultor'],
+    [UserRole.SPECIALIST, 'Especialista'],
+    [UserRole.OFFICE, 'Gerente de escritório'],
+    [UserRole.ADMIN, 'Administrador'],
+  ])('traduz %s', (role, expected) => {
+    expect(roleLabel(role)).toBe(expected);
+  });
+
+  it.each([
+    [ProductType.CAR, 'Carros'],
+    [ProductType.BOAT, 'Embarcações'],
+    [ProductType.AIRCRAFT, 'Aeronaves'],
+  ])('traduz %s', (value, expected) => {
+    expect(specialityLabel(value)).toBe(expected);
+  });
+});

--- a/backend/src/features/admin-database/admin-user-management.labels.spec.ts
+++ b/backend/src/features/admin-database/admin-user-management.labels.spec.ts
@@ -1,5 +1,6 @@
 import { ProductType, UserRole } from '@prisma/client';
 import {
+  blockerMessage,
   roleLabel,
   specialityLabel,
 } from './admin-user-management.labels';
@@ -21,5 +22,36 @@ describe('admin-user-management.labels', () => {
     [ProductType.AIRCRAFT, 'Aeronaves'],
   ])('traduz %s', (value, expected) => {
     expect(specialityLabel(value)).toBe(expected);
+  });
+
+  it.each([
+    [
+      'CONSULTANT_HAS_CLIENTS' as const,
+      'O consultor ainda possui 1 cliente vinculado.',
+      'O consultor ainda possui 2 clientes vinculados.',
+    ],
+    [
+      'CONSULTANT_HAS_ADVISEES' as const,
+      'O consultor ainda possui 1 assessoria sob sua responsabilidade.',
+      'O consultor ainda possui 2 assessorias sob sua responsabilidade.',
+    ],
+    [
+      'SPECIALIST_HAS_ACTIVE_PRODUCTS' as const,
+      'O especialista ainda possui 1 produto ativo.',
+      'O especialista ainda possui 2 produtos ativos.',
+    ],
+    [
+      'SPECIALIST_HAS_PENDING_APPOINTMENTS' as const,
+      'O especialista ainda possui 1 agendamento pendente.',
+      'O especialista ainda possui 2 agendamentos pendentes.',
+    ],
+    [
+      'SPECIALIST_HAS_OPEN_PROCESSES' as const,
+      'O especialista ainda possui 1 processo em andamento.',
+      'O especialista ainda possui 2 processos em andamento.',
+    ],
+  ])('flexiona bloqueio %s conforme a quantidade', (code, singular, plural) => {
+    expect(blockerMessage({ code, count: 1 })).toBe(singular);
+    expect(blockerMessage({ code, count: 2 })).toBe(plural);
   });
 });

--- a/backend/src/features/admin-database/admin-user-management.labels.ts
+++ b/backend/src/features/admin-database/admin-user-management.labels.ts
@@ -26,25 +26,49 @@ export function specialityLabel(speciality: ProductType): string {
   return specialityLabels[speciality];
 }
 
-export function blockerMessage(blocker: Pick<ChangeBlocker, 'code' | 'count'>): string {
+export function blockerMessage(
+  blocker: Pick<ChangeBlocker, 'code' | 'count'>,
+): string {
   return blockerMessages[blocker.code](blocker.count);
+}
+
+function quantityMessage(
+  count: number | undefined,
+  singular: string,
+  plural: string,
+): string {
+  const quantity = count ?? 0;
+  return `${quantity} ${quantity === 1 ? singular : plural}`;
 }
 
 const blockerMessages: Record<ChangeBlockerCode, (count?: number) => string> = {
   ROLE_UNCHANGED: () => 'O cargo selecionado já está atribuído a este usuário.',
-  SPECIALITY_UNCHANGED: () => 'A especialidade selecionada já está atribuída a este especialista.',
+  SPECIALITY_UNCHANGED: () =>
+    'A especialidade selecionada já está atribuída a este especialista.',
   COMPANY_REQUIRED: () => 'Informe o escritório para o cargo selecionado.',
   COMPANY_NOT_FOUND: () => 'O escritório informado não foi encontrado.',
-  SPECIALITY_REQUIRED: () => 'Informe a especialidade para o cargo de Especialista.',
-  CUSTOMER_HAS_CONSULTANT: () => 'O cliente ainda possui um consultor vinculado.',
+  SPECIALITY_REQUIRED: () =>
+    'Informe a especialidade para o cargo de Especialista.',
+  CUSTOMER_HAS_CONSULTANT: () =>
+    'O cliente ainda possui um consultor vinculado.',
   CUSTOMER_HAS_ADVISOR: () => 'O cliente ainda possui um assessor vinculado.',
-  CONSULTANT_HAS_CLIENTS: (count) => `O consultor ainda possui ${count ?? 0} clientes vinculados.`,
-  CONSULTANT_HAS_ADVISEES: (count) => `O consultor ainda possui ${count ?? 0} assessorias sob sua responsabilidade.`,
-  SPECIALIST_HAS_ACTIVE_PRODUCTS: (count) => `O especialista ainda possui ${count ?? 0} produtos ativos.`,
-  SPECIALIST_HAS_PENDING_APPOINTMENTS: (count) => `O especialista ainda possui ${count ?? 0} agendamentos pendentes.`,
-  SPECIALIST_HAS_OPEN_PROCESSES: (count) => `O especialista ainda possui ${count ?? 0} processos em andamento.`,
-  OFFICE_REPLACEMENT_REQUIRED: () => 'Informe o novo cargo do gerente atual do escritório.',
-  OFFICE_REPLACEMENT_INVALID: () => 'A substituição do gerente de escritório é inválida.',
+  CONSULTANT_HAS_CLIENTS: (count) =>
+    `O consultor ainda possui ${quantityMessage(count, 'cliente vinculado', 'clientes vinculados')}.`,
+  CONSULTANT_HAS_ADVISEES: (count) =>
+    `O consultor ainda possui ${quantityMessage(count, 'assessoria sob sua responsabilidade', 'assessorias sob sua responsabilidade')}.`,
+  SPECIALIST_HAS_ACTIVE_PRODUCTS: (count) =>
+    `O especialista ainda possui ${quantityMessage(count, 'produto ativo', 'produtos ativos')}.`,
+  SPECIALIST_HAS_PENDING_APPOINTMENTS: (count) =>
+    `O especialista ainda possui ${quantityMessage(count, 'agendamento pendente', 'agendamentos pendentes')}.`,
+  SPECIALIST_HAS_OPEN_PROCESSES: (count) =>
+    `O especialista ainda possui ${quantityMessage(count, 'processo em andamento', 'processos em andamento')}.`,
+  OFFICE_REPLACEMENT_REQUIRED: () =>
+    'Informe o novo cargo do gerente atual do escritório.',
+  OFFICE_REPLACEMENT_INVALID: () =>
+    'A substituição do gerente de escritório é inválida.',
   OFFICE_CONFLICT: () => 'O escritório já possui um gerente ativo.',
-  LAST_ACTIVE_ADMIN: () => 'Não é possível remover o último administrador ativo da plataforma.',
+  CONCURRENT_CHANGE: () =>
+    'Outra alteração foi concluída ao mesmo tempo. Verifique os dados e tente novamente.',
+  LAST_ACTIVE_ADMIN: () =>
+    'Não é possível remover o último administrador ativo da plataforma.',
 };

--- a/backend/src/features/admin-database/admin-user-management.labels.ts
+++ b/backend/src/features/admin-database/admin-user-management.labels.ts
@@ -1,0 +1,50 @@
+import { ProductType, UserRole } from '@prisma/client';
+import {
+  ChangeBlocker,
+  ChangeBlockerCode,
+} from './admin-user-management.types';
+
+const roleLabels: Record<UserRole, string> = {
+  [UserRole.CUSTOMER]: 'Cliente',
+  [UserRole.CONSULTANT]: 'Consultor',
+  [UserRole.SPECIALIST]: 'Especialista',
+  [UserRole.OFFICE]: 'Gerente de escritório',
+  [UserRole.ADMIN]: 'Administrador',
+};
+
+const specialityLabels: Record<ProductType, string> = {
+  [ProductType.CAR]: 'Carros',
+  [ProductType.BOAT]: 'Embarcações',
+  [ProductType.AIRCRAFT]: 'Aeronaves',
+};
+
+export function roleLabel(role: UserRole): string {
+  return roleLabels[role];
+}
+
+export function specialityLabel(speciality: ProductType): string {
+  return specialityLabels[speciality];
+}
+
+export function blockerMessage(blocker: Pick<ChangeBlocker, 'code' | 'count'>): string {
+  return blockerMessages[blocker.code](blocker.count);
+}
+
+const blockerMessages: Record<ChangeBlockerCode, (count?: number) => string> = {
+  ROLE_UNCHANGED: () => 'O cargo selecionado já está atribuído a este usuário.',
+  SPECIALITY_UNCHANGED: () => 'A especialidade selecionada já está atribuída a este especialista.',
+  COMPANY_REQUIRED: () => 'Informe o escritório para o cargo selecionado.',
+  COMPANY_NOT_FOUND: () => 'O escritório informado não foi encontrado.',
+  SPECIALITY_REQUIRED: () => 'Informe a especialidade para o cargo de Especialista.',
+  CUSTOMER_HAS_CONSULTANT: () => 'O cliente ainda possui um consultor vinculado.',
+  CUSTOMER_HAS_ADVISOR: () => 'O cliente ainda possui um assessor vinculado.',
+  CONSULTANT_HAS_CLIENTS: (count) => `O consultor ainda possui ${count ?? 0} clientes vinculados.`,
+  CONSULTANT_HAS_ADVISEES: (count) => `O consultor ainda possui ${count ?? 0} assessorias sob sua responsabilidade.`,
+  SPECIALIST_HAS_ACTIVE_PRODUCTS: (count) => `O especialista ainda possui ${count ?? 0} produtos ativos.`,
+  SPECIALIST_HAS_PENDING_APPOINTMENTS: (count) => `O especialista ainda possui ${count ?? 0} agendamentos pendentes.`,
+  SPECIALIST_HAS_OPEN_PROCESSES: (count) => `O especialista ainda possui ${count ?? 0} processos em andamento.`,
+  OFFICE_REPLACEMENT_REQUIRED: () => 'Informe o novo cargo do gerente atual do escritório.',
+  OFFICE_REPLACEMENT_INVALID: () => 'A substituição do gerente de escritório é inválida.',
+  OFFICE_CONFLICT: () => 'O escritório já possui um gerente ativo.',
+  LAST_ACTIVE_ADMIN: () => 'Não é possível remover o último administrador ativo da plataforma.',
+};

--- a/backend/src/features/admin-database/admin-user-management.service.spec.ts
+++ b/backend/src/features/admin-database/admin-user-management.service.spec.ts
@@ -222,7 +222,72 @@ describe('AdminUserManagementService', () => {
     });
   });
 
-  it.each(['car', 'boat', 'aircraft', 'appointment', 'process'] as const)(
+  it.each([
+    {
+      name: 'Cliente',
+      subject: user(customerId, UserRole.CONSULTANT),
+      dto: {
+        role: UserRole.CUSTOMER,
+        company_id: companyId,
+        speciality: ProductType.BOAT,
+      },
+      data: { role: UserRole.CUSTOMER },
+    },
+    {
+      name: 'Administrador',
+      subject: user(customerId, UserRole.CUSTOMER),
+      dto: {
+        role: UserRole.ADMIN,
+        company_id: companyId,
+        speciality: ProductType.BOAT,
+      },
+      data: { role: UserRole.ADMIN },
+    },
+    {
+      name: 'Consultor',
+      subject: user(customerId, UserRole.CUSTOMER),
+      dto: {
+        role: UserRole.CONSULTANT,
+        company_id: companyId,
+        speciality: ProductType.BOAT,
+      },
+      data: { role: UserRole.CONSULTANT, company_id: companyId },
+    },
+    {
+      name: 'Gerente de escritório',
+      subject: user(customerId, UserRole.CUSTOMER),
+      dto: {
+        role: UserRole.OFFICE,
+        company_id: companyId,
+        speciality: ProductType.BOAT,
+      },
+      data: { role: UserRole.OFFICE, company_id: companyId },
+    },
+    {
+      name: 'Especialista',
+      subject: user(customerId, UserRole.CUSTOMER),
+      dto: {
+        role: UserRole.SPECIALIST,
+        company_id: companyId,
+        speciality: ProductType.AIRCRAFT,
+      },
+      data: { role: UserRole.SPECIALIST, speciality: ProductType.AIRCRAFT },
+    },
+  ])(
+    'persiste somente o contexto permitido para $name',
+    async ({ subject, dto, data }) => {
+      const { prisma, service } = makeService([subject]);
+
+      await service.changeRole(subject.id, dto);
+
+      expect(prisma.transactionUser.update).toHaveBeenLastCalledWith({
+        where: { id: subject.id },
+        data,
+      });
+    },
+  );
+
+  it.each(['car', 'boat', 'appointment', 'process'] as const)(
     'bloqueia especialidade com %s incompatível',
     async (resource) => {
       const { prisma, service } = makeService([
@@ -243,6 +308,81 @@ describe('AdminUserManagementService', () => {
     },
   );
 
+  it('permite especialidade com aeronaves ativas compatíveis com o destino', async () => {
+    const { prisma, service } = makeService([
+      user(specialistId, UserRole.SPECIALIST, { speciality: ProductType.CAR }),
+    ]);
+    prisma.aircraft.count.mockResolvedValue(1);
+
+    await expect(
+      service.validateSpecialityChange(specialistId, {
+        speciality: ProductType.AIRCRAFT,
+      }),
+    ).resolves.toMatchObject({ allowed: true, blockers: [] });
+    expect(prisma.aircraft.count).not.toHaveBeenCalled();
+  });
+
+  it('permite especialidade com agendamento PENDING compatível com o destino', async () => {
+    const { prisma, service } = makeService([
+      user(specialistId, UserRole.SPECIALIST, { speciality: ProductType.CAR }),
+    ]);
+    prisma.appointment.count.mockImplementation(({ where }) =>
+      where.OR ? 0 : 1,
+    );
+
+    await expect(
+      service.validateSpecialityChange(specialistId, {
+        speciality: ProductType.AIRCRAFT,
+      }),
+    ).resolves.toMatchObject({ allowed: true, blockers: [] });
+    expect(prisma.appointment.count).toHaveBeenCalledWith({
+      where: {
+        specialist_id: specialistId,
+        status: 'PENDING',
+        OR: [
+          { product_type: { not: ProductType.AIRCRAFT } },
+          { product_type: null },
+        ],
+      },
+    });
+  });
+
+  it('bloqueia especialidade quando há agendamento PENDING sem tipo de produto', async () => {
+    const { prisma, service } = makeService([
+      user(specialistId, UserRole.SPECIALIST, { speciality: ProductType.CAR }),
+    ]);
+    prisma.appointment.count.mockImplementation(({ where }) =>
+      where.OR?.some((condition) => condition.product_type === null) ? 1 : 0,
+    );
+
+    await expect(
+      service.validateSpecialityChange(specialistId, {
+        speciality: ProductType.AIRCRAFT,
+      }),
+    ).resolves.toMatchObject({
+      allowed: false,
+      blockers: [{ code: 'SPECIALIST_HAS_PENDING_APPOINTMENTS' }],
+    });
+  });
+
+  it('bloqueia especialidade quando há processo aberto sem tipo de produto', async () => {
+    const { prisma, service } = makeService([
+      user(specialistId, UserRole.SPECIALIST, { speciality: ProductType.CAR }),
+    ]);
+    prisma.process.count.mockImplementation(({ where }) =>
+      where.OR?.some((condition) => condition.product_type === null) ? 1 : 0,
+    );
+
+    await expect(
+      service.validateSpecialityChange(specialistId, {
+        speciality: ProductType.AIRCRAFT,
+      }),
+    ).resolves.toMatchObject({
+      allowed: false,
+      blockers: [{ code: 'SPECIALIST_HAS_OPEN_PROCESSES' }],
+    });
+  });
+
   it('permite especialidade quando há somente processos concluídos ou rejeitados', async () => {
     const { prisma, service } = makeService([
       user(specialistId, UserRole.SPECIALIST, { speciality: ProductType.CAR }),
@@ -257,7 +397,10 @@ describe('AdminUserManagementService', () => {
       where: {
         specialist_id: specialistId,
         status: { notIn: [ProcessStatus.COMPLETED, ProcessStatus.REJECTED] },
-        product_type: { not: ProductType.AIRCRAFT },
+        OR: [
+          { product_type: { not: ProductType.AIRCRAFT } },
+          { product_type: null },
+        ],
       },
     });
   });

--- a/backend/src/features/admin-database/admin-user-management.service.spec.ts
+++ b/backend/src/features/admin-database/admin-user-management.service.spec.ts
@@ -1,0 +1,302 @@
+import { ConflictException } from '@nestjs/common';
+import { ProcessStatus, ProductType, UserRole } from '@prisma/client';
+import { AdminUserManagementService } from './admin-user-management.service';
+
+const customerId = '11111111-1111-4111-8111-111111111111';
+const specialistId = '22222222-2222-4222-8222-222222222222';
+const officeId = '33333333-3333-4333-8333-333333333333';
+const candidateId = '44444444-4444-4444-8444-444444444444';
+const companyId = '55555555-5555-4555-8555-555555555555';
+
+type User = {
+  id: string;
+  role: UserRole;
+  is_active: boolean;
+  consultant_id?: string | null;
+  company_id?: string | null;
+  speciality?: ProductType | null;
+};
+
+function user(id: string, role: UserRole, overrides: Partial<User> = {}): User {
+  return {
+    id,
+    role,
+    is_active: true,
+    consultant_id: null,
+    company_id: null,
+    speciality: null,
+    ...overrides,
+  };
+}
+
+function makePrisma(users: User[] = [user(customerId, UserRole.CUSTOMER)]) {
+  const transactionUser = {
+    findUnique: jest.fn(
+      async ({ where }) =>
+        users.find((candidate) => candidate.id === where.id) ?? null,
+    ),
+    findFirst: jest.fn().mockResolvedValue(null),
+    count: jest.fn(async ({ where }) =>
+      where?.role === UserRole.ADMIN && where?.is_active === true
+        ? users.filter(
+            (candidate) =>
+              candidate.role === UserRole.ADMIN && candidate.is_active,
+          ).length
+        : 0,
+    ),
+    update: jest.fn().mockResolvedValue({}),
+  };
+  const tx = {
+    user: transactionUser,
+    company: { findUnique: jest.fn().mockResolvedValue({ id: companyId }) },
+    customerAdvisor: { count: jest.fn().mockResolvedValue(0) },
+    car: { count: jest.fn().mockResolvedValue(0) },
+    boat: { count: jest.fn().mockResolvedValue(0) },
+    aircraft: { count: jest.fn().mockResolvedValue(0) },
+    appointment: { count: jest.fn().mockResolvedValue(0) },
+    process: { count: jest.fn().mockResolvedValue(0) },
+  };
+  return {
+    ...tx,
+    $transaction: jest.fn(async (callback) => callback(tx)),
+    transactionUser,
+  } as any;
+}
+
+function makeService(users?: User[]) {
+  const prisma = makePrisma(users);
+  return { prisma, service: new AdminUserManagementService(prisma) };
+}
+
+describe('AdminUserManagementService', () => {
+  it('exige escritório para Consultor', async () => {
+    const { service } = makeService();
+
+    await expect(
+      service.validateRoleChange(customerId, { role: UserRole.CONSULTANT }),
+    ).resolves.toMatchObject({
+      allowed: false,
+      blockers: [{ code: 'COMPANY_REQUIRED' }],
+    });
+  });
+
+  it('exige especialidade para Especialista', async () => {
+    const { service } = makeService();
+
+    await expect(
+      service.validateRoleChange(customerId, { role: UserRole.SPECIALIST }),
+    ).resolves.toMatchObject({
+      allowed: false,
+      blockers: [{ code: 'SPECIALITY_REQUIRED' }],
+    });
+  });
+
+  it('atualiza promoção válida na transação serializável', async () => {
+    const { prisma, service } = makeService();
+
+    await service.changeRole(customerId, {
+      role: UserRole.SPECIALIST,
+      speciality: ProductType.AIRCRAFT,
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: 'Serializable',
+    });
+    expect(prisma.transactionUser.update).toHaveBeenCalledWith({
+      where: { id: customerId },
+      data: { role: UserRole.SPECIALIST, speciality: ProductType.AIRCRAFT },
+    });
+  });
+
+  it.each([
+    [
+      'CUSTOMER_HAS_CONSULTANT',
+      user(customerId, UserRole.CUSTOMER, { consultant_id: officeId }),
+      { role: UserRole.CONSULTANT, company_id: companyId },
+    ],
+    [
+      'CUSTOMER_HAS_ADVISOR',
+      user(customerId, UserRole.CUSTOMER),
+      { role: UserRole.CONSULTANT, company_id: companyId },
+    ],
+    [
+      'CONSULTANT_HAS_CLIENTS',
+      user(customerId, UserRole.CONSULTANT),
+      { role: UserRole.CUSTOMER },
+    ],
+    [
+      'CONSULTANT_HAS_ADVISEES',
+      user(customerId, UserRole.CONSULTANT),
+      { role: UserRole.CUSTOMER },
+    ],
+    [
+      'SPECIALIST_HAS_ACTIVE_PRODUCTS',
+      user(specialistId, UserRole.SPECIALIST),
+      { role: UserRole.CUSTOMER },
+    ],
+    [
+      'SPECIALIST_HAS_PENDING_APPOINTMENTS',
+      user(specialistId, UserRole.SPECIALIST),
+      { role: UserRole.CUSTOMER },
+    ],
+    [
+      'SPECIALIST_HAS_OPEN_PROCESSES',
+      user(specialistId, UserRole.SPECIALIST),
+      { role: UserRole.CUSTOMER },
+    ],
+    [
+      'LAST_ACTIVE_ADMIN',
+      user(customerId, UserRole.ADMIN),
+      { role: UserRole.CUSTOMER },
+    ],
+  ] as const)(
+    'bloqueia %s e devolve mensagem em português',
+    async (code, subject, request) => {
+      const { prisma, service } = makeService([subject]);
+
+      if (
+        code === 'CUSTOMER_HAS_ADVISOR' ||
+        code === 'CONSULTANT_HAS_ADVISEES'
+      ) {
+        prisma.customerAdvisor.count.mockResolvedValue(1);
+      }
+      if (code === 'CONSULTANT_HAS_CLIENTS')
+        prisma.user.count.mockResolvedValue(1);
+      if (code === 'SPECIALIST_HAS_ACTIVE_PRODUCTS')
+        prisma.car.count.mockResolvedValue(1);
+      if (code === 'SPECIALIST_HAS_PENDING_APPOINTMENTS')
+        prisma.appointment.count.mockResolvedValue(1);
+      if (code === 'SPECIALIST_HAS_OPEN_PROCESSES')
+        prisma.process.count.mockResolvedValue(1);
+
+      const result = await service.validateRoleChange(subject.id, request);
+      const blocker = result.blockers.find((item) => item.code === code);
+
+      expect(result.allowed).toBe(false);
+      expect(blocker).toEqual(
+        expect.objectContaining({
+          code,
+          message: expect.stringMatching(/[À-ÿa-z]/i),
+        }),
+      );
+    },
+  );
+
+  it('rejeita cargo sem mudança e informa o motivo em português', async () => {
+    const { service } = makeService();
+
+    await expect(
+      service.validateRoleChange(customerId, { role: UserRole.CUSTOMER }),
+    ).resolves.toMatchObject({
+      allowed: false,
+      blockers: [
+        {
+          code: 'ROLE_UNCHANGED',
+          message: 'O cargo selecionado já está atribuído a este usuário.',
+        },
+      ],
+    });
+  });
+
+  it('troca gerente e substituto na mesma transação', async () => {
+    const currentManager = user(officeId, UserRole.OFFICE, {
+      company_id: companyId,
+    });
+    const candidate = user(candidateId, UserRole.CUSTOMER);
+    const { prisma, service } = makeService([currentManager, candidate]);
+    prisma.transactionUser.findFirst.mockResolvedValue(currentManager);
+
+    await service.changeRole(candidateId, {
+      role: UserRole.OFFICE,
+      company_id: companyId,
+      replacement: { role: UserRole.CONSULTANT, company_id: companyId },
+    });
+
+    expect(prisma.transactionUser.update).toHaveBeenNthCalledWith(1, {
+      where: { id: officeId },
+      data: { role: UserRole.CONSULTANT, company_id: companyId },
+    });
+    expect(prisma.transactionUser.update).toHaveBeenNthCalledWith(2, {
+      where: { id: candidateId },
+      data: { role: UserRole.OFFICE, company_id: companyId },
+    });
+  });
+
+  it.each(['car', 'boat', 'aircraft', 'appointment', 'process'] as const)(
+    'bloqueia especialidade com %s incompatível',
+    async (resource) => {
+      const { prisma, service } = makeService([
+        user(specialistId, UserRole.SPECIALIST, {
+          speciality: ProductType.CAR,
+        }),
+      ]);
+      prisma[resource].count.mockResolvedValue(1);
+
+      await expect(
+        service.validateSpecialityChange(specialistId, {
+          speciality: ProductType.AIRCRAFT,
+        }),
+      ).resolves.toMatchObject({
+        allowed: false,
+        blockers: [{ code: expect.any(String) }],
+      });
+    },
+  );
+
+  it('permite especialidade quando há somente processos concluídos ou rejeitados', async () => {
+    const { prisma, service } = makeService([
+      user(specialistId, UserRole.SPECIALIST, { speciality: ProductType.CAR }),
+    ]);
+
+    await expect(
+      service.validateSpecialityChange(specialistId, {
+        speciality: ProductType.AIRCRAFT,
+      }),
+    ).resolves.toMatchObject({ allowed: true, blockers: [] });
+    expect(prisma.process.count).toHaveBeenCalledWith({
+      where: {
+        specialist_id: specialistId,
+        status: { notIn: [ProcessStatus.COMPLETED, ProcessStatus.REJECTED] },
+        product_type: { not: ProductType.AIRCRAFT },
+      },
+    });
+  });
+
+  it('revalida e bloqueia a mutação quando a transação encontra um conflito', async () => {
+    const { prisma, service } = makeService([
+      user(customerId, UserRole.CUSTOMER, { consultant_id: officeId }),
+    ]);
+
+    await expect(
+      service.changeRole(customerId, {
+        role: UserRole.CONSULTANT,
+        company_id: companyId,
+      }),
+    ).rejects.toBeInstanceOf(ConflictException);
+    expect(prisma.transactionUser.update).not.toHaveBeenCalled();
+  });
+
+  it('traduz conflito único de gerente em bloqueio de escritório em português', async () => {
+    const { prisma, service } = makeService();
+    prisma.$transaction.mockRejectedValue({
+      code: 'P2002',
+      meta: { target: 'one_office_per_company' },
+    });
+
+    await expect(
+      service.changeRole(customerId, {
+        role: UserRole.OFFICE,
+        company_id: companyId,
+      }),
+    ).rejects.toMatchObject({
+      response: {
+        blockers: [
+          {
+            code: 'OFFICE_CONFLICT',
+            message: 'O escritório já possui um gerente ativo.',
+          },
+        ],
+      },
+    });
+  });
+});

--- a/backend/src/features/admin-database/admin-user-management.service.spec.ts
+++ b/backend/src/features/admin-database/admin-user-management.service.spec.ts
@@ -222,6 +222,25 @@ describe('AdminUserManagementService', () => {
     });
   });
 
+  it('bloqueia gerente saindo do cargo fora de uma substituição atômica', async () => {
+    const manager = user(officeId, UserRole.OFFICE, {
+      company_id: companyId,
+    });
+    const { service } = makeService([manager]);
+
+    await expect(
+      service.validateRoleChange(officeId, { role: UserRole.CUSTOMER }),
+    ).resolves.toMatchObject({
+      allowed: false,
+      blockers: [
+        {
+          code: 'OFFICE_REPLACEMENT_REQUIRED',
+          message: 'Informe o novo cargo do gerente atual do escritório.',
+        },
+      ],
+    });
+  });
+
   it.each([
     {
       name: 'Cliente',
@@ -442,4 +461,48 @@ describe('AdminUserManagementService', () => {
       },
     });
   });
+
+  it.each([
+    {
+      name: 'cargo',
+      mutate: (service: AdminUserManagementService) =>
+        service.changeRole(customerId, {
+          role: UserRole.CONSULTANT,
+          company_id: companyId,
+        }),
+    },
+    {
+      name: 'especialidade',
+      mutate: (service: AdminUserManagementService) =>
+        service.changeSpeciality(specialistId, {
+          speciality: ProductType.BOAT,
+        }),
+    },
+  ])(
+    'traduz P2034 ao confirmar alteração de $name em conflito localizado',
+    async ({ mutate }) => {
+      const { prisma, service } = makeService([
+        user(customerId, UserRole.CUSTOMER),
+        user(specialistId, UserRole.SPECIALIST, {
+          speciality: ProductType.CAR,
+        }),
+      ]);
+      prisma.$transaction.mockRejectedValue({ code: 'P2034' });
+
+      await expect(mutate(service)).rejects.toMatchObject({
+        status: 409,
+        response: {
+          allowed: false,
+          summary: 'A alteração não pode ser concluída.',
+          blockers: [
+            {
+              code: 'CONCURRENT_CHANGE',
+              message:
+                'Outra alteração foi concluída ao mesmo tempo. Verifique os dados e tente novamente.',
+            },
+          ],
+        },
+      });
+    },
+  );
 });

--- a/backend/src/features/admin-database/admin-user-management.service.ts
+++ b/backend/src/features/admin-database/admin-user-management.service.ts
@@ -246,24 +246,37 @@ export class AdminUserManagementService {
     blockers: ChangeBlocker[],
     changingSpeciality: boolean,
   ) {
+    const activeProductsWhere = {
+      where: { specialist_id: specialistId, is_active: true },
+    };
+    const incompatibleProductType =
+      changingSpeciality && speciality
+        ? {
+            OR: [{ product_type: { not: speciality } }, { product_type: null }],
+          }
+        : {};
     const [cars, boats, aircraft, appointments, processes] = await Promise.all([
-      db.car.count({ where: { specialist_id: specialistId, is_active: true } }),
-      db.boat.count({
-        where: { specialist_id: specialistId, is_active: true },
-      }),
-      db.aircraft.count({
-        where: { specialist_id: specialistId, is_active: true },
-      }),
+      changingSpeciality && speciality === ProductType.CAR
+        ? 0
+        : db.car.count(activeProductsWhere),
+      changingSpeciality && speciality === ProductType.BOAT
+        ? 0
+        : db.boat.count(activeProductsWhere),
+      changingSpeciality && speciality === ProductType.AIRCRAFT
+        ? 0
+        : db.aircraft.count(activeProductsWhere),
       db.appointment.count({
-        where: { specialist_id: specialistId, status: 'PENDING' },
+        where: {
+          specialist_id: specialistId,
+          status: 'PENDING',
+          ...incompatibleProductType,
+        },
       }),
       db.process.count({
         where: {
           specialist_id: specialistId,
           status: { notIn: [ProcessStatus.COMPLETED, ProcessStatus.REJECTED] },
-          ...(changingSpeciality && speciality
-            ? { product_type: { not: speciality } }
-            : {}),
+          ...incompatibleProductType,
         },
       }),
     ]);
@@ -319,11 +332,13 @@ export class AdminUserManagementService {
   }
 
   private roleData(dto: ChangeRoleDto | OfficeManagerReplacementDto) {
-    return {
-      role: dto.role,
-      ...(dto.company_id !== undefined ? { company_id: dto.company_id } : {}),
-      ...(dto.speciality !== undefined ? { speciality: dto.speciality } : {}),
-    };
+    if (dto.role === UserRole.CONSULTANT || dto.role === UserRole.OFFICE) {
+      return { role: dto.role, company_id: dto.company_id };
+    }
+    if (dto.role === UserRole.SPECIALIST) {
+      return { role: dto.role, speciality: dto.speciality };
+    }
+    return { role: dto.role };
   }
 
   private async findUser(

--- a/backend/src/features/admin-database/admin-user-management.service.ts
+++ b/backend/src/features/admin-database/admin-user-management.service.ts
@@ -1,0 +1,395 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Prisma, ProcessStatus, ProductType, UserRole } from '@prisma/client';
+import { PrismaService } from '../../prisma/prisma.service';
+import { blockerMessage } from './admin-user-management.labels';
+import {
+  ChangeRoleDto,
+  OfficeManagerReplacementDto,
+} from './dto/change-role.dto';
+import { ChangeSpecialityDto } from './dto/change-speciality.dto';
+import {
+  ChangeBlocker,
+  ChangeBlockerCode,
+  ChangeValidationResult,
+} from './admin-user-management.types';
+
+type UserManagementDatabase = Pick<
+  PrismaService,
+  | 'user'
+  | 'company'
+  | 'customerAdvisor'
+  | 'car'
+  | 'boat'
+  | 'aircraft'
+  | 'appointment'
+  | 'process'
+>;
+
+type ManagedUser = {
+  id: string;
+  role: UserRole;
+  is_active: boolean;
+  consultant_id: string | null;
+  company_id: string | null;
+  speciality: ProductType | null;
+};
+
+@Injectable()
+export class AdminUserManagementService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async validateRoleChange(
+    id: string,
+    dto: ChangeRoleDto,
+  ): Promise<ChangeValidationResult> {
+    return this.analyzeRoleChange(this.prisma, id, dto);
+  }
+
+  async changeRole(id: string, dto: ChangeRoleDto) {
+    try {
+      return await this.prisma.$transaction(
+        async (tx) => {
+          const result = await this.analyzeRoleChange(tx, id, dto);
+          if (!result.allowed) throw new ConflictException(result);
+          return this.applyRoleChange(tx, id, dto);
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      if (this.isOfficeConflict(error))
+        throw new ConflictException(this.result(['OFFICE_CONFLICT']));
+      throw error;
+    }
+  }
+
+  async validateSpecialityChange(
+    id: string,
+    dto: ChangeSpecialityDto,
+  ): Promise<ChangeValidationResult> {
+    return this.analyzeSpecialityChange(this.prisma, id, dto);
+  }
+
+  async changeSpeciality(id: string, dto: ChangeSpecialityDto) {
+    return this.prisma.$transaction(
+      async (tx) => {
+        const result = await this.analyzeSpecialityChange(tx, id, dto);
+        if (!result.allowed) throw new ConflictException(result);
+        return tx.user.update({
+          where: { id },
+          data: { speciality: dto.speciality },
+        });
+      },
+      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+    );
+  }
+
+  private async analyzeRoleChange(
+    db: UserManagementDatabase,
+    id: string,
+    dto: ChangeRoleDto,
+    skipOfficeReplacement = false,
+  ): Promise<ChangeValidationResult> {
+    const subject = await this.findUser(db, id);
+    const blockers: ChangeBlocker[] = [];
+
+    if (subject.role === dto.role) this.add(blockers, 'ROLE_UNCHANGED');
+    await this.validateRoleContext(db, dto, blockers);
+    await this.addDepartureBlockers(db, subject, dto.role, blockers);
+
+    let currentManager: ManagedUser | null = null;
+    if (
+      !skipOfficeReplacement &&
+      dto.role === UserRole.OFFICE &&
+      dto.company_id
+    ) {
+      currentManager = (await db.user.findFirst({
+        where: {
+          role: UserRole.OFFICE,
+          company_id: dto.company_id,
+          id: { not: id },
+        },
+        select: this.userSelect(),
+      })) as ManagedUser | null;
+
+      if (currentManager && !dto.replacement) {
+        this.add(blockers, 'OFFICE_REPLACEMENT_REQUIRED');
+      } else if (!currentManager && dto.replacement) {
+        this.add(blockers, 'OFFICE_REPLACEMENT_INVALID');
+      } else if (currentManager && dto.replacement) {
+        await this.validateOfficeReplacement(
+          db,
+          currentManager,
+          dto.replacement,
+          blockers,
+        );
+      }
+    } else if (!skipOfficeReplacement && dto.replacement) {
+      this.add(blockers, 'OFFICE_REPLACEMENT_INVALID');
+    }
+
+    return this.result(blockers);
+  }
+
+  private async analyzeSpecialityChange(
+    db: UserManagementDatabase,
+    id: string,
+    dto: ChangeSpecialityDto,
+  ): Promise<ChangeValidationResult> {
+    const subject = await this.findUser(db, id);
+    if (subject.role !== UserRole.SPECIALIST) {
+      throw new BadRequestException(
+        'A especialidade só pode ser alterada para usuários Especialistas.',
+      );
+    }
+
+    const blockers: ChangeBlocker[] = [];
+    if (subject.speciality === dto.speciality)
+      this.add(blockers, 'SPECIALITY_UNCHANGED');
+    await this.addSpecialistBlockers(
+      db,
+      subject.id,
+      dto.speciality,
+      blockers,
+      true,
+    );
+    return this.result(blockers);
+  }
+
+  private async validateRoleContext(
+    db: UserManagementDatabase,
+    dto: ChangeRoleDto | OfficeManagerReplacementDto,
+    blockers: ChangeBlocker[],
+  ) {
+    if (
+      (dto.role === UserRole.CONSULTANT || dto.role === UserRole.OFFICE) &&
+      !dto.company_id
+    ) {
+      this.add(blockers, 'COMPANY_REQUIRED');
+    }
+    if (dto.role === UserRole.SPECIALIST && !dto.speciality) {
+      this.add(blockers, 'SPECIALITY_REQUIRED');
+    }
+    if (dto.company_id) {
+      const company = await db.company.findUnique({
+        where: { id: dto.company_id },
+        select: { id: true },
+      });
+      if (!company) this.add(blockers, 'COMPANY_NOT_FOUND');
+    }
+  }
+
+  private async addDepartureBlockers(
+    db: UserManagementDatabase,
+    subject: ManagedUser,
+    targetRole: UserRole,
+    blockers: ChangeBlocker[],
+  ) {
+    if (
+      subject.role === UserRole.CUSTOMER &&
+      targetRole !== UserRole.CUSTOMER
+    ) {
+      if (subject.consultant_id) this.add(blockers, 'CUSTOMER_HAS_CONSULTANT');
+      const advisors = await db.customerAdvisor.count({
+        where: { customer_id: subject.id },
+      });
+      if (advisors) this.add(blockers, 'CUSTOMER_HAS_ADVISOR', advisors);
+    }
+
+    if (
+      subject.role === UserRole.CONSULTANT &&
+      targetRole !== UserRole.CONSULTANT
+    ) {
+      const clients = await db.user.count({
+        where: { consultant_id: subject.id },
+      });
+      if (clients) this.add(blockers, 'CONSULTANT_HAS_CLIENTS', clients);
+      const advisees = await db.customerAdvisor.count({
+        where: { advisor_id: subject.id },
+      });
+      if (advisees) this.add(blockers, 'CONSULTANT_HAS_ADVISEES', advisees);
+    }
+
+    if (
+      subject.role === UserRole.SPECIALIST &&
+      targetRole !== UserRole.SPECIALIST
+    ) {
+      await this.addSpecialistBlockers(
+        db,
+        subject.id,
+        undefined,
+        blockers,
+        false,
+      );
+    }
+
+    if (
+      subject.role === UserRole.ADMIN &&
+      subject.is_active &&
+      targetRole !== UserRole.ADMIN
+    ) {
+      const activeAdmins = await db.user.count({
+        where: { role: UserRole.ADMIN, is_active: true },
+      });
+      if (activeAdmins <= 1) this.add(blockers, 'LAST_ACTIVE_ADMIN');
+    }
+  }
+
+  private async addSpecialistBlockers(
+    db: UserManagementDatabase,
+    specialistId: string,
+    speciality: ProductType | undefined,
+    blockers: ChangeBlocker[],
+    changingSpeciality: boolean,
+  ) {
+    const [cars, boats, aircraft, appointments, processes] = await Promise.all([
+      db.car.count({ where: { specialist_id: specialistId, is_active: true } }),
+      db.boat.count({
+        where: { specialist_id: specialistId, is_active: true },
+      }),
+      db.aircraft.count({
+        where: { specialist_id: specialistId, is_active: true },
+      }),
+      db.appointment.count({
+        where: { specialist_id: specialistId, status: 'PENDING' },
+      }),
+      db.process.count({
+        where: {
+          specialist_id: specialistId,
+          status: { notIn: [ProcessStatus.COMPLETED, ProcessStatus.REJECTED] },
+          ...(changingSpeciality && speciality
+            ? { product_type: { not: speciality } }
+            : {}),
+        },
+      }),
+    ]);
+    const products = cars + boats + aircraft;
+    if (products)
+      this.add(blockers, 'SPECIALIST_HAS_ACTIVE_PRODUCTS', products);
+    if (appointments)
+      this.add(blockers, 'SPECIALIST_HAS_PENDING_APPOINTMENTS', appointments);
+    if (processes)
+      this.add(blockers, 'SPECIALIST_HAS_OPEN_PROCESSES', processes);
+  }
+
+  private async validateOfficeReplacement(
+    db: UserManagementDatabase,
+    currentManager: ManagedUser,
+    replacement: OfficeManagerReplacementDto,
+    blockers: ChangeBlocker[],
+  ) {
+    if (replacement.role === UserRole.OFFICE) {
+      this.add(blockers, 'OFFICE_REPLACEMENT_INVALID');
+      return;
+    }
+    const result = await this.analyzeRoleChange(
+      db,
+      currentManager.id,
+      replacement as ChangeRoleDto,
+      true,
+    );
+    blockers.push(...result.blockers);
+  }
+
+  private async applyRoleChange(
+    db: Prisma.TransactionClient,
+    id: string,
+    dto: ChangeRoleDto,
+  ) {
+    if (dto.role === UserRole.OFFICE && dto.company_id && dto.replacement) {
+      const currentManager = await db.user.findFirst({
+        where: {
+          role: UserRole.OFFICE,
+          company_id: dto.company_id,
+          id: { not: id },
+        },
+        select: { id: true },
+      });
+      if (currentManager)
+        await db.user.update({
+          where: { id: currentManager.id },
+          data: this.roleData(dto.replacement),
+        });
+    }
+    return db.user.update({ where: { id }, data: this.roleData(dto) });
+  }
+
+  private roleData(dto: ChangeRoleDto | OfficeManagerReplacementDto) {
+    return {
+      role: dto.role,
+      ...(dto.company_id !== undefined ? { company_id: dto.company_id } : {}),
+      ...(dto.speciality !== undefined ? { speciality: dto.speciality } : {}),
+    };
+  }
+
+  private async findUser(
+    db: UserManagementDatabase,
+    id: string,
+  ): Promise<ManagedUser> {
+    const subject = await db.user.findUnique({
+      where: { id },
+      select: this.userSelect(),
+    });
+    if (!subject) throw new NotFoundException('Usuário não encontrado.');
+    return subject as ManagedUser;
+  }
+
+  private userSelect() {
+    return {
+      id: true,
+      role: true,
+      is_active: true,
+      consultant_id: true,
+      company_id: true,
+      speciality: true,
+    };
+  }
+
+  private add(
+    blockers: ChangeBlocker[],
+    code: ChangeBlockerCode,
+    count?: number,
+  ) {
+    if (!blockers.some((blocker) => blocker.code === code)) {
+      blockers.push({
+        code,
+        message: blockerMessage({ code, count }),
+        ...(count !== undefined ? { count } : {}),
+      });
+    }
+  }
+
+  private result(
+    blockers: ChangeBlocker[] | ChangeBlockerCode[],
+  ): ChangeValidationResult {
+    const normalized = blockers.map((blocker) =>
+      typeof blocker === 'string'
+        ? { code: blocker, message: blockerMessage({ code: blocker }) }
+        : blocker,
+    );
+    return {
+      allowed: normalized.length === 0,
+      summary:
+        normalized.length === 0
+          ? 'Alteração permitida.'
+          : 'A alteração não pode ser concluída.',
+      blockers: normalized,
+    };
+  }
+
+  private isOfficeConflict(error: unknown): boolean {
+    const prismaError = error as { code?: string; meta?: { target?: unknown } };
+    const target = Array.isArray(prismaError?.meta?.target)
+      ? prismaError.meta.target.join(',')
+      : String(prismaError?.meta?.target ?? '');
+    return (
+      prismaError?.code === 'P2002' &&
+      (target.includes('one_office_per_company') ||
+        target.includes('company_id'))
+    );
+  }
+}

--- a/backend/src/features/admin-database/admin-user-management.service.ts
+++ b/backend/src/features/admin-database/admin-user-management.service.ts
@@ -63,6 +63,8 @@ export class AdminUserManagementService {
     } catch (error) {
       if (this.isOfficeConflict(error))
         throw new ConflictException(this.result(['OFFICE_CONFLICT']));
+      if (this.isConcurrentChange(error))
+        throw new ConflictException(this.result(['CONCURRENT_CHANGE']));
       throw error;
     }
   }
@@ -75,35 +77,47 @@ export class AdminUserManagementService {
   }
 
   async changeSpeciality(id: string, dto: ChangeSpecialityDto) {
-    return this.prisma.$transaction(
-      async (tx) => {
-        const result = await this.analyzeSpecialityChange(tx, id, dto);
-        if (!result.allowed) throw new ConflictException(result);
-        return tx.user.update({
-          where: { id },
-          data: { speciality: dto.speciality },
-        });
-      },
-      { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-    );
+    try {
+      return await this.prisma.$transaction(
+        async (tx) => {
+          const result = await this.analyzeSpecialityChange(tx, id, dto);
+          if (!result.allowed) throw new ConflictException(result);
+          return tx.user.update({
+            where: { id },
+            data: { speciality: dto.speciality },
+          });
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      if (this.isConcurrentChange(error))
+        throw new ConflictException(this.result(['CONCURRENT_CHANGE']));
+      throw error;
+    }
   }
 
   private async analyzeRoleChange(
     db: UserManagementDatabase,
     id: string,
     dto: ChangeRoleDto,
-    skipOfficeReplacement = false,
+    isOfficeReplacement = false,
   ): Promise<ChangeValidationResult> {
     const subject = await this.findUser(db, id);
     const blockers: ChangeBlocker[] = [];
 
     if (subject.role === dto.role) this.add(blockers, 'ROLE_UNCHANGED');
     await this.validateRoleContext(db, dto, blockers);
-    await this.addDepartureBlockers(db, subject, dto.role, blockers);
+    await this.addDepartureBlockers(
+      db,
+      subject,
+      dto.role,
+      blockers,
+      isOfficeReplacement,
+    );
 
     let currentManager: ManagedUser | null = null;
     if (
-      !skipOfficeReplacement &&
+      !isOfficeReplacement &&
       dto.role === UserRole.OFFICE &&
       dto.company_id
     ) {
@@ -128,7 +142,7 @@ export class AdminUserManagementService {
           blockers,
         );
       }
-    } else if (!skipOfficeReplacement && dto.replacement) {
+    } else if (!isOfficeReplacement && dto.replacement) {
       this.add(blockers, 'OFFICE_REPLACEMENT_INVALID');
     }
 
@@ -188,6 +202,7 @@ export class AdminUserManagementService {
     subject: ManagedUser,
     targetRole: UserRole,
     blockers: ChangeBlocker[],
+    isOfficeReplacement: boolean,
   ) {
     if (
       subject.role === UserRole.CUSTOMER &&
@@ -225,6 +240,14 @@ export class AdminUserManagementService {
         blockers,
         false,
       );
+    }
+
+    if (
+      subject.role === UserRole.OFFICE &&
+      targetRole !== UserRole.OFFICE &&
+      !isOfficeReplacement
+    ) {
+      this.add(blockers, 'OFFICE_REPLACEMENT_REQUIRED');
     }
 
     if (
@@ -323,12 +346,32 @@ export class AdminUserManagementService {
         select: { id: true },
       });
       if (currentManager)
-        await db.user.update({
-          where: { id: currentManager.id },
-          data: this.roleData(dto.replacement),
-        });
+        await this.applyOfficeReplacement(
+          db,
+          currentManager.id,
+          dto.replacement,
+        );
     }
     return db.user.update({ where: { id }, data: this.roleData(dto) });
+  }
+
+  private async applyOfficeReplacement(
+    db: Prisma.TransactionClient,
+    currentManagerId: string,
+    replacement: OfficeManagerReplacementDto,
+  ) {
+    const result = await this.analyzeRoleChange(
+      db,
+      currentManagerId,
+      replacement as ChangeRoleDto,
+      true,
+    );
+    if (!result.allowed) throw new ConflictException(result);
+
+    return db.user.update({
+      where: { id: currentManagerId },
+      data: this.roleData(replacement),
+    });
   }
 
   private roleData(dto: ChangeRoleDto | OfficeManagerReplacementDto) {
@@ -406,5 +449,9 @@ export class AdminUserManagementService {
       (target.includes('one_office_per_company') ||
         target.includes('company_id'))
     );
+  }
+
+  private isConcurrentChange(error: unknown): boolean {
+    return (error as { code?: string })?.code === 'P2034';
   }
 }

--- a/backend/src/features/admin-database/admin-user-management.types.ts
+++ b/backend/src/features/admin-database/admin-user-management.types.ts
@@ -14,6 +14,7 @@ export type ChangeBlockerCode =
   | 'OFFICE_REPLACEMENT_REQUIRED'
   | 'OFFICE_REPLACEMENT_INVALID'
   | 'OFFICE_CONFLICT'
+  | 'CONCURRENT_CHANGE'
   | 'LAST_ACTIVE_ADMIN';
 
 export type ChangeBlocker = {

--- a/backend/src/features/admin-database/admin-user-management.types.ts
+++ b/backend/src/features/admin-database/admin-user-management.types.ts
@@ -1,0 +1,29 @@
+export type ChangeBlockerCode =
+  | 'ROLE_UNCHANGED'
+  | 'SPECIALITY_UNCHANGED'
+  | 'COMPANY_REQUIRED'
+  | 'COMPANY_NOT_FOUND'
+  | 'SPECIALITY_REQUIRED'
+  | 'CUSTOMER_HAS_CONSULTANT'
+  | 'CUSTOMER_HAS_ADVISOR'
+  | 'CONSULTANT_HAS_CLIENTS'
+  | 'CONSULTANT_HAS_ADVISEES'
+  | 'SPECIALIST_HAS_ACTIVE_PRODUCTS'
+  | 'SPECIALIST_HAS_PENDING_APPOINTMENTS'
+  | 'SPECIALIST_HAS_OPEN_PROCESSES'
+  | 'OFFICE_REPLACEMENT_REQUIRED'
+  | 'OFFICE_REPLACEMENT_INVALID'
+  | 'OFFICE_CONFLICT'
+  | 'LAST_ACTIVE_ADMIN';
+
+export type ChangeBlocker = {
+  code: ChangeBlockerCode;
+  message: string;
+  count?: number;
+};
+
+export type ChangeValidationResult = {
+  allowed: boolean;
+  summary: string;
+  blockers: ChangeBlocker[];
+};

--- a/backend/src/features/admin-database/dto/change-role.dto.ts
+++ b/backend/src/features/admin-database/dto/change-role.dto.ts
@@ -1,0 +1,34 @@
+import { ProductType, UserRole } from '@prisma/client';
+import { Type } from 'class-transformer';
+import { IsEnum, IsOptional, IsUUID, ValidateNested } from 'class-validator';
+
+export class OfficeManagerReplacementDto {
+  @IsEnum(UserRole)
+  role: UserRole;
+
+  @IsOptional()
+  @IsUUID('4')
+  company_id?: string;
+
+  @IsOptional()
+  @IsEnum(ProductType)
+  speciality?: ProductType;
+}
+
+export class ChangeRoleDto {
+  @IsEnum(UserRole)
+  role: UserRole;
+
+  @IsOptional()
+  @IsUUID('4')
+  company_id?: string;
+
+  @IsOptional()
+  @IsEnum(ProductType)
+  speciality?: ProductType;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => OfficeManagerReplacementDto)
+  replacement?: OfficeManagerReplacementDto;
+}

--- a/backend/src/features/admin-database/dto/change-role.dto.ts
+++ b/backend/src/features/admin-database/dto/change-role.dto.ts
@@ -3,32 +3,44 @@ import { Type } from 'class-transformer';
 import { IsEnum, IsOptional, IsUUID, ValidateNested } from 'class-validator';
 
 export class OfficeManagerReplacementDto {
-  @IsEnum(UserRole)
+  @IsEnum(UserRole, {
+    message:
+      'O novo cargo do gerente atual deve ser Cliente, Consultor, Especialista ou Administrador.',
+  })
   role: UserRole;
 
   @IsOptional()
-  @IsUUID('4')
+  @IsUUID('4', { message: 'O escritório deve ter um identificador válido.' })
   company_id?: string;
 
   @IsOptional()
-  @IsEnum(ProductType)
+  @IsEnum(ProductType, {
+    message: 'A especialidade deve ser Carros, Embarcações ou Aeronaves.',
+  })
   speciality?: ProductType;
 }
 
 export class ChangeRoleDto {
-  @IsEnum(UserRole)
+  @IsEnum(UserRole, {
+    message:
+      'O cargo deve ser Cliente, Consultor, Especialista, Gerente de escritório ou Administrador.',
+  })
   role: UserRole;
 
   @IsOptional()
-  @IsUUID('4')
+  @IsUUID('4', { message: 'O escritório deve ter um identificador válido.' })
   company_id?: string;
 
   @IsOptional()
-  @IsEnum(ProductType)
+  @IsEnum(ProductType, {
+    message: 'A especialidade deve ser Carros, Embarcações ou Aeronaves.',
+  })
   speciality?: ProductType;
 
   @IsOptional()
-  @ValidateNested()
+  @ValidateNested({
+    message: 'Informe dados válidos para o novo cargo do gerente atual.',
+  })
   @Type(() => OfficeManagerReplacementDto)
   replacement?: OfficeManagerReplacementDto;
 }

--- a/backend/src/features/admin-database/dto/change-speciality.dto.ts
+++ b/backend/src/features/admin-database/dto/change-speciality.dto.ts
@@ -1,0 +1,7 @@
+import { ProductType } from '@prisma/client';
+import { IsEnum } from 'class-validator';
+
+export class ChangeSpecialityDto {
+  @IsEnum(ProductType)
+  speciality: ProductType;
+}

--- a/backend/src/features/admin-database/dto/change-speciality.dto.ts
+++ b/backend/src/features/admin-database/dto/change-speciality.dto.ts
@@ -2,6 +2,8 @@ import { ProductType } from '@prisma/client';
 import { IsEnum } from 'class-validator';
 
 export class ChangeSpecialityDto {
-  @IsEnum(ProductType)
+  @IsEnum(ProductType, {
+    message: 'A especialidade deve ser Carros, Embarcações ou Aeronaves.',
+  })
   speciality: ProductType;
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,6 +9,7 @@ import {
 import cookieParser from 'cookie-parser';
 import express, { Express } from 'express';
 import { getFrontendUrl, stripEnvQuotes } from './shared/utils/frontend-url';
+import { localizedValidationExceptionFactory } from './shared/validation/localized-validation-exception';
 
 export async function createApp(): Promise<Express> {
   const server = express();
@@ -69,6 +70,7 @@ export async function createApp(): Promise<Express> {
       forbidNonWhitelisted: true,
       transform: true,
       disableErrorMessages: process.env.NODE_ENV === 'production',
+      exceptionFactory: localizedValidationExceptionFactory,
     }),
   );
 

--- a/backend/src/shared/validation/localized-validation-exception.ts
+++ b/backend/src/shared/validation/localized-validation-exception.ts
@@ -4,6 +4,14 @@ import type { ValidationError } from 'class-validator';
 export function localizedValidationExceptionFactory(
   errors: ValidationError[],
 ): BadRequestException {
+  if (process.env.NODE_ENV === 'production') {
+    return new BadRequestException({
+      statusCode: 400,
+      message: 'Os dados informados não são válidos.',
+      error: 'Requisição inválida',
+    });
+  }
+
   const messages = collectValidationMessages(errors);
 
   return new BadRequestException({

--- a/backend/src/shared/validation/localized-validation-exception.ts
+++ b/backend/src/shared/validation/localized-validation-exception.ts
@@ -1,0 +1,26 @@
+import { BadRequestException } from '@nestjs/common';
+import type { ValidationError } from 'class-validator';
+
+export function localizedValidationExceptionFactory(
+  errors: ValidationError[],
+): BadRequestException {
+  const messages = collectValidationMessages(errors);
+
+  return new BadRequestException({
+    statusCode: 400,
+    message:
+      messages.length > 0 ? messages : ['Os dados informados não são válidos.'],
+    error: 'Requisição inválida',
+  });
+}
+
+function collectValidationMessages(errors: ValidationError[]): string[] {
+  return errors.flatMap((error) => [
+    ...Object.values(error.constraints ?? {}).map((message) =>
+      error.constraints?.whitelistValidation
+        ? `O campo ${error.property} não é permitido.`
+        : message,
+    ),
+    ...collectValidationMessages(error.children ?? []),
+  ]);
+}

--- a/frontend/src/components/admin/AdminUserManagementDialog.tsx
+++ b/frontend/src/components/admin/AdminUserManagementDialog.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   blockerMessage,
+  ChangeValidationError,
   changeRole,
   changeSpeciality,
+  createLatestRequestGuard,
   getDialogRequirements,
   ROLE_LABELS,
   SPECIALITY_LABELS,
@@ -33,6 +35,23 @@ type Props = {
   onSuccess: () => void | Promise<void>;
 };
 
+type ChangeSnapshot =
+  | {
+      userId: string;
+      mode: "role";
+      payload: ChangeRolePayload;
+    }
+  | {
+      userId: string;
+      mode: "speciality";
+      payload: ChangeSpecialityPayload;
+    };
+
+type ValidatedChange = ChangeSnapshot & {
+  requestId: number;
+  result: ChangeValidationResult;
+};
+
 const ROLE_OPTIONS = Object.entries(ROLE_LABELS) as [UserRoleCode, string][];
 const REPLACEMENT_ROLE_OPTIONS = ROLE_OPTIONS.filter(
   ([role]) => role !== "OFFICE",
@@ -46,6 +65,23 @@ const selectClassName =
   "block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-focus-ring disabled:cursor-not-allowed disabled:opacity-60";
 
 export default function AdminUserManagementDialog({
+  state,
+  onClose,
+  onSuccess,
+}: Props) {
+  const sessionKey = state ? `${state.userId}:${state.mode}` : "closed";
+
+  return (
+    <AdminUserManagementDialogSession
+      key={sessionKey}
+      state={state}
+      onClose={onClose}
+      onSuccess={onSuccess}
+    />
+  );
+}
+
+function AdminUserManagementDialogSession({
   state,
   onClose,
   onSuccess,
@@ -66,6 +102,8 @@ export default function AdminUserManagementDialog({
   const [verifying, setVerifying] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestGuard = useRef(createLatestRequestGuard());
+  const validatedChange = useRef<ValidatedChange | null>(null);
 
   const requirements = useMemo(
     () =>
@@ -111,6 +149,8 @@ export default function AdminUserManagementDialog({
   }, [companies, requirements, state?.mode]);
 
   function reset() {
+    requestGuard.current.invalidate();
+    validatedChange.current = null;
     setTargetRole("");
     setCompanyId("");
     setSpeciality("");
@@ -132,8 +172,33 @@ export default function AdminUserManagementDialog({
   }
 
   function invalidateValidation() {
+    requestGuard.current.invalidate();
+    validatedChange.current = null;
     setValidation(null);
+    setVerifying(false);
     setError(null);
+  }
+
+  function applyValidation(
+    snapshot: ChangeSnapshot,
+    requestId: number,
+    result: ChangeValidationResult,
+  ) {
+    if (!requestGuard.current.isCurrent(requestId)) return;
+
+    const officeConflict = result.blockers.some(
+      ({ code }) =>
+        code === "OFFICE_REPLACEMENT_REQUIRED" || code === "OFFICE_CONFLICT",
+    );
+    if (
+      snapshot.mode === "role" &&
+      snapshot.payload.role === "OFFICE" &&
+      officeConflict
+    ) {
+      setHasOfficeConflict(true);
+    }
+    validatedChange.current = { ...snapshot, requestId, result };
+    setValidation(result);
   }
 
   function rolePayload(): ChangeRolePayload | null {
@@ -182,6 +247,20 @@ export default function AdminUserManagementDialog({
       state.mode === "role" ? rolePayload() : specialityPayload();
     if (!payload) return;
 
+    const snapshot: ChangeSnapshot =
+      state.mode === "role"
+        ? {
+            userId: state.userId,
+            mode: "role",
+            payload: payload as ChangeRolePayload,
+          }
+        : {
+            userId: state.userId,
+            mode: "speciality",
+            payload: payload as ChangeSpecialityPayload,
+          };
+    const requestId = requestGuard.current.begin();
+
     setVerifying(true);
     setError(null);
     try {
@@ -195,45 +274,51 @@ export default function AdminUserManagementDialog({
               state.userId,
               payload as ChangeSpecialityPayload,
             );
-      const officeConflict = result.blockers.some(
-        ({ code }) =>
-          code === "OFFICE_REPLACEMENT_REQUIRED" ||
-          code === "OFFICE_CONFLICT",
-      );
-      if (targetRole === "OFFICE" && officeConflict) {
-        setHasOfficeConflict(true);
-      }
-      setValidation(result);
+      applyValidation(snapshot, requestId, result);
     } catch (caught) {
+      if (!requestGuard.current.isCurrent(requestId)) return;
       setValidation(null);
+      validatedChange.current = null;
       setError((caught as Error).message);
     } finally {
-      setVerifying(false);
+      if (requestGuard.current.isCurrent(requestId)) setVerifying(false);
     }
   }
 
   async function confirm() {
-    if (!state || !validation?.allowed) return;
+    const approved = validatedChange.current;
+    if (
+      !state ||
+      !approved?.result.allowed ||
+      !requestGuard.current.isCurrent(approved.requestId) ||
+      approved.userId !== state.userId ||
+      approved.mode !== state.mode
+    ) {
+      return;
+    }
 
-    const payload =
-      state.mode === "role" ? rolePayload() : specialityPayload();
-    if (!payload) return;
+    const requestId = requestGuard.current.begin();
+    validatedChange.current = { ...approved, requestId };
 
     setSubmitting(true);
     setError(null);
     try {
-      if (state.mode === "role") {
-        await changeRole(state.userId, payload as ChangeRolePayload);
+      if (approved.mode === "role") {
+        await changeRole(approved.userId, approved.payload);
       } else {
-        await changeSpeciality(
-          state.userId,
-          payload as ChangeSpecialityPayload,
-        );
+        await changeSpeciality(approved.userId, approved.payload);
       }
+      if (!requestGuard.current.isCurrent(requestId)) return;
       close();
       await onSuccess();
     } catch (caught) {
-      setError((caught as Error).message);
+      if (!requestGuard.current.isCurrent(requestId)) return;
+      if (caught instanceof ChangeValidationError) {
+        applyValidation(approved, requestId, caught.validation);
+        setError(null);
+      } else {
+        setError((caught as Error).message);
+      }
       setSubmitting(false);
     }
   }

--- a/frontend/src/components/admin/AdminUserManagementDialog.tsx
+++ b/frontend/src/components/admin/AdminUserManagementDialog.tsx
@@ -1,0 +1,502 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  blockerMessage,
+  changeRole,
+  changeSpeciality,
+  getDialogRequirements,
+  ROLE_LABELS,
+  SPECIALITY_LABELS,
+  validateRoleChange,
+  validateSpecialityChange,
+  type ChangeRolePayload,
+  type ChangeSpecialityPayload,
+  type ChangeValidationResult,
+  type SpecialityCode,
+  type UserRoleCode,
+} from "../../lib/admin-user-management";
+import {
+  getCompanies,
+  type Company,
+} from "../../services/companies.service";
+import Button from "../ui/button";
+import { Alert } from "../ui/alert";
+import { Dialog, DialogContent } from "../ui/dialog";
+
+export type AdminUserManagementDialogState = {
+  userId: string;
+  mode: "role" | "speciality";
+};
+
+type Props = {
+  state: AdminUserManagementDialogState | null;
+  onClose: () => void;
+  onSuccess: () => void | Promise<void>;
+};
+
+const ROLE_OPTIONS = Object.entries(ROLE_LABELS) as [UserRoleCode, string][];
+const REPLACEMENT_ROLE_OPTIONS = ROLE_OPTIONS.filter(
+  ([role]) => role !== "OFFICE",
+);
+const SPECIALITY_OPTIONS = Object.entries(SPECIALITY_LABELS) as [
+  SpecialityCode,
+  string,
+][];
+
+const selectClassName =
+  "block w-full rounded-md border border-border bg-surface px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-focus-ring disabled:cursor-not-allowed disabled:opacity-60";
+
+export default function AdminUserManagementDialog({
+  state,
+  onClose,
+  onSuccess,
+}: Props) {
+  const [targetRole, setTargetRole] = useState<UserRoleCode | "">("");
+  const [companyId, setCompanyId] = useState("");
+  const [speciality, setSpeciality] = useState<SpecialityCode | "">("");
+  const [replacementRole, setReplacementRole] =
+    useState<UserRoleCode | "">("");
+  const [replacementCompanyId, setReplacementCompanyId] = useState("");
+  const [replacementSpeciality, setReplacementSpeciality] =
+    useState<SpecialityCode | "">("");
+  const [hasOfficeConflict, setHasOfficeConflict] = useState(false);
+  const [companies, setCompanies] = useState<Company[] | null>(null);
+  const [loadingCompanies, setLoadingCompanies] = useState(false);
+  const [validation, setValidation] =
+    useState<ChangeValidationResult | null>(null);
+  const [verifying, setVerifying] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requirements = useMemo(
+    () =>
+      targetRole
+        ? getDialogRequirements(targetRole, hasOfficeConflict)
+        : [],
+    [hasOfficeConflict, targetRole],
+  );
+  const replacementRequirements = useMemo(
+    () =>
+      replacementRole ? getDialogRequirements(replacementRole) : [],
+    [replacementRole],
+  );
+
+  useEffect(() => {
+    let ignore = false;
+    const needsCompanies =
+      state?.mode === "role" && requirements.includes("company");
+
+    if (!needsCompanies || companies !== null) return;
+
+    setLoadingCompanies(true);
+    setError(null);
+    getCompanies()
+      .then((list) => {
+        if (!ignore) setCompanies(list);
+      })
+      .catch((caught) => {
+        if (!ignore) {
+          setError(
+            (caught as Error).message ||
+              "Não foi possível carregar os escritórios.",
+          );
+        }
+      })
+      .finally(() => {
+        if (!ignore) setLoadingCompanies(false);
+      });
+
+    return () => {
+      ignore = true;
+    };
+  }, [companies, requirements, state?.mode]);
+
+  function reset() {
+    setTargetRole("");
+    setCompanyId("");
+    setSpeciality("");
+    setReplacementRole("");
+    setReplacementCompanyId("");
+    setReplacementSpeciality("");
+    setHasOfficeConflict(false);
+    setCompanies(null);
+    setLoadingCompanies(false);
+    setValidation(null);
+    setVerifying(false);
+    setSubmitting(false);
+    setError(null);
+  }
+
+  function close() {
+    reset();
+    onClose();
+  }
+
+  function invalidateValidation() {
+    setValidation(null);
+    setError(null);
+  }
+
+  function rolePayload(): ChangeRolePayload | null {
+    if (!targetRole) {
+      setError("Selecione o novo cargo.");
+      return null;
+    }
+
+    const payload: ChangeRolePayload = { role: targetRole };
+    if (requirements.includes("company") && companyId) {
+      payload.company_id = companyId;
+    }
+    if (requirements.includes("speciality") && speciality) {
+      payload.speciality = speciality;
+    }
+    if (requirements.includes("replacement") && replacementRole) {
+      payload.replacement = { role: replacementRole };
+      if (
+        replacementRequirements.includes("company") &&
+        replacementCompanyId
+      ) {
+        payload.replacement.company_id = replacementCompanyId;
+      }
+      if (
+        replacementRequirements.includes("speciality") &&
+        replacementSpeciality
+      ) {
+        payload.replacement.speciality = replacementSpeciality;
+      }
+    }
+    return payload;
+  }
+
+  function specialityPayload(): ChangeSpecialityPayload | null {
+    if (!speciality) {
+      setError("Selecione a nova especialidade.");
+      return null;
+    }
+    return { speciality };
+  }
+
+  async function verify() {
+    if (!state) return;
+
+    const payload =
+      state.mode === "role" ? rolePayload() : specialityPayload();
+    if (!payload) return;
+
+    setVerifying(true);
+    setError(null);
+    try {
+      const result =
+        state.mode === "role"
+          ? await validateRoleChange(
+              state.userId,
+              payload as ChangeRolePayload,
+            )
+          : await validateSpecialityChange(
+              state.userId,
+              payload as ChangeSpecialityPayload,
+            );
+      const officeConflict = result.blockers.some(
+        ({ code }) =>
+          code === "OFFICE_REPLACEMENT_REQUIRED" ||
+          code === "OFFICE_CONFLICT",
+      );
+      if (targetRole === "OFFICE" && officeConflict) {
+        setHasOfficeConflict(true);
+      }
+      setValidation(result);
+    } catch (caught) {
+      setValidation(null);
+      setError((caught as Error).message);
+    } finally {
+      setVerifying(false);
+    }
+  }
+
+  async function confirm() {
+    if (!state || !validation?.allowed) return;
+
+    const payload =
+      state.mode === "role" ? rolePayload() : specialityPayload();
+    if (!payload) return;
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (state.mode === "role") {
+        await changeRole(state.userId, payload as ChangeRolePayload);
+      } else {
+        await changeSpeciality(
+          state.userId,
+          payload as ChangeSpecialityPayload,
+        );
+      }
+      close();
+      await onSuccess();
+    } catch (caught) {
+      setError((caught as Error).message);
+      setSubmitting(false);
+    }
+  }
+
+  const title =
+    state?.mode === "speciality" ? "Alterar especialidade" : "Alterar cargo";
+
+  return (
+    <Dialog open={Boolean(state)} onOpenChange={(open) => !open && close()}>
+      <DialogContent open={Boolean(state)} title={title}>
+        <div className="space-y-4">
+          {state?.mode === "role" ? (
+            <>
+              <div>
+                <label
+                  htmlFor="admin-user-target-role"
+                  className="mb-1 block text-sm font-medium text-ink-soft"
+                >
+                  Novo cargo
+                </label>
+                <select
+                  id="admin-user-target-role"
+                  value={targetRole}
+                  onChange={(event) => {
+                    setTargetRole(event.target.value as UserRoleCode | "");
+                    setCompanyId("");
+                    setSpeciality("");
+                    setReplacementRole("");
+                    setReplacementCompanyId("");
+                    setReplacementSpeciality("");
+                    setHasOfficeConflict(false);
+                    invalidateValidation();
+                  }}
+                  className={selectClassName}
+                >
+                  <option value="">Selecione um cargo</option>
+                  {ROLE_OPTIONS.map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {requirements.includes("company") ? (
+                <CompanySelect
+                  id="admin-user-company"
+                  label="Escritório"
+                  value={companyId}
+                  companies={companies}
+                  loading={loadingCompanies}
+                  onChange={(value) => {
+                    setCompanyId(value);
+                    setHasOfficeConflict(false);
+                    setReplacementRole("");
+                    setReplacementCompanyId("");
+                    setReplacementSpeciality("");
+                    invalidateValidation();
+                  }}
+                />
+              ) : null}
+
+              {requirements.includes("speciality") ? (
+                <SpecialitySelect
+                  id="admin-user-role-speciality"
+                  label="Especialidade"
+                  value={speciality}
+                  onChange={(value) => {
+                    setSpeciality(value);
+                    invalidateValidation();
+                  }}
+                />
+              ) : null}
+
+              {requirements.includes("replacement") ? (
+                <fieldset className="space-y-3 rounded-md border border-border p-4">
+                  <legend className="px-1 text-sm font-semibold text-ink">
+                    Novo cargo do gerente atual
+                  </legend>
+                  <div>
+                    <label
+                      htmlFor="admin-user-replacement-role"
+                      className="mb-1 block text-sm font-medium text-ink-soft"
+                    >
+                      Cargo de substituição
+                    </label>
+                    <select
+                      id="admin-user-replacement-role"
+                      value={replacementRole}
+                      onChange={(event) => {
+                        setReplacementRole(
+                          event.target.value as UserRoleCode | "",
+                        );
+                        setReplacementCompanyId("");
+                        setReplacementSpeciality("");
+                        invalidateValidation();
+                      }}
+                      className={selectClassName}
+                    >
+                      <option value="">Selecione um cargo</option>
+                      {REPLACEMENT_ROLE_OPTIONS.map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+
+                  {replacementRequirements.includes("company") ? (
+                    <CompanySelect
+                      id="admin-user-replacement-company"
+                      label="Escritório do gerente atual"
+                      value={replacementCompanyId}
+                      companies={companies}
+                      loading={loadingCompanies}
+                      onChange={(value) => {
+                        setReplacementCompanyId(value);
+                        invalidateValidation();
+                      }}
+                    />
+                  ) : null}
+
+                  {replacementRequirements.includes("speciality") ? (
+                    <SpecialitySelect
+                      id="admin-user-replacement-speciality"
+                      label="Especialidade do gerente atual"
+                      value={replacementSpeciality}
+                      onChange={(value) => {
+                        setReplacementSpeciality(value);
+                        invalidateValidation();
+                      }}
+                    />
+                  ) : null}
+                </fieldset>
+              ) : null}
+            </>
+          ) : (
+            <SpecialitySelect
+              id="admin-user-speciality"
+              label="Nova especialidade"
+              value={speciality}
+              onChange={(value) => {
+                setSpeciality(value);
+                invalidateValidation();
+              }}
+            />
+          )}
+
+          {validation?.blockers.length ? (
+            <Alert variant="danger">
+              {validation.blockers.map(blockerMessage).join(" ")}
+            </Alert>
+          ) : null}
+          {validation?.allowed ? (
+            <Alert variant="success">
+              Alteração verificada. Você já pode confirmar.
+            </Alert>
+          ) : null}
+          {error ? <Alert variant="danger">{error}</Alert> : null}
+
+          <div className="flex flex-wrap justify-end gap-3 pt-2">
+            <Button type="button" variant="light" onClick={close}>
+              Cancelar
+            </Button>
+            <Button
+              type="button"
+              variant="light"
+              disabled={verifying || submitting}
+              onClick={verify}
+            >
+              {verifying ? "Verificando..." : "Verificar alteração"}
+            </Button>
+            <Button
+              type="button"
+              disabled={!validation?.allowed || submitting || verifying}
+              onClick={confirm}
+            >
+              {submitting ? "Confirmando..." : "Confirmar alteração"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function CompanySelect({
+  id,
+  label,
+  value,
+  companies,
+  loading,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  companies: Company[] | null;
+  loading: boolean;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-sm font-medium text-ink-soft"
+      >
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={loading}
+        className={selectClassName}
+      >
+        <option value="">
+          {loading ? "Carregando escritórios..." : "Selecione um escritório"}
+        </option>
+        {(companies ?? []).map((company) => (
+          <option key={company.id} value={company.id}>
+            {company.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function SpecialitySelect({
+  id,
+  label,
+  value,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: SpecialityCode | "";
+  onChange: (value: SpecialityCode | "") => void;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="mb-1 block text-sm font-medium text-ink-soft"
+      >
+        {label}
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) =>
+          onChange(event.target.value as SpecialityCode | "")
+        }
+        className={selectClassName}
+      >
+        <option value="">Selecione uma especialidade</option>
+        {SPECIALITY_OPTIONS.map(([optionValue, optionLabel]) => (
+          <option key={optionValue} value={optionValue}>
+            {optionLabel}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/admin/AdminUserManagementDialog.tsx
+++ b/frontend/src/components/admin/AdminUserManagementDialog.tsx
@@ -5,6 +5,7 @@ import {
   changeRole,
   changeSpeciality,
   createLatestRequestGuard,
+  getManagementDialogInteractionPolicy,
   getDialogRequirements,
   ROLE_LABELS,
   SPECIALITY_LABELS,
@@ -104,6 +105,7 @@ function AdminUserManagementDialogSession({
   const [error, setError] = useState<string | null>(null);
   const requestGuard = useRef(createLatestRequestGuard());
   const validatedChange = useRef<ValidatedChange | null>(null);
+  const interactionPolicy = getManagementDialogInteractionPolicy(submitting);
 
   const requirements = useMemo(
     () =>
@@ -166,9 +168,14 @@ function AdminUserManagementDialogSession({
     setError(null);
   }
 
-  function close() {
+  function closeDialog() {
     reset();
     onClose();
+  }
+
+  function dismiss() {
+    if (!interactionPolicy.dismissalAllowed) return;
+    closeDialog();
   }
 
   function invalidateValidation() {
@@ -309,7 +316,7 @@ function AdminUserManagementDialogSession({
         await changeSpeciality(approved.userId, approved.payload);
       }
       if (!requestGuard.current.isCurrent(requestId)) return;
-      close();
+      closeDialog();
       await onSuccess();
     } catch (caught) {
       if (!requestGuard.current.isCurrent(requestId)) return;
@@ -327,9 +334,19 @@ function AdminUserManagementDialogSession({
     state?.mode === "speciality" ? "Alterar especialidade" : "Alterar cargo";
 
   return (
-    <Dialog open={Boolean(state)} onOpenChange={(open) => !open && close()}>
-      <DialogContent open={Boolean(state)} title={title}>
-        <div className="space-y-4">
+    <Dialog
+      open={Boolean(state)}
+      onOpenChange={(open) => !open && dismiss()}
+    >
+      <DialogContent
+        open={Boolean(state)}
+        title={title}
+        dismissible={interactionPolicy.dismissalAllowed}
+      >
+        <fieldset
+          className="space-y-4"
+          disabled={interactionPolicy.controlsDisabled}
+        >
           {state?.mode === "role" ? (
             <>
               <div>
@@ -480,7 +497,7 @@ function AdminUserManagementDialogSession({
           {error ? <Alert variant="danger">{error}</Alert> : null}
 
           <div className="flex flex-wrap justify-end gap-3 pt-2">
-            <Button type="button" variant="light" onClick={close}>
+            <Button type="button" variant="light" onClick={dismiss}>
               Cancelar
             </Button>
             <Button
@@ -499,7 +516,7 @@ function AdminUserManagementDialogSession({
               {submitting ? "Confirmando..." : "Confirmar alteração"}
             </Button>
           </div>
-        </div>
+        </fieldset>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -12,12 +12,14 @@ export function DialogContent({
   children,
   className,
   hideTitle,
+  dismissible = true,
 }: {
   open: boolean;
   title: ReactNode;
   children: ReactNode;
   className?: string;
   hideTitle?: boolean;
+  dismissible?: boolean;
 }) {
   const shouldReduceMotion = useReducedMotion();
   const duration = shouldReduceMotion ? 0 : 0.15;
@@ -35,7 +37,17 @@ export function DialogContent({
               transition={{ duration }}
             />
           </DialogPrimitive.Overlay>
-          <DialogPrimitive.Content asChild forceMount aria-describedby={undefined}>
+          <DialogPrimitive.Content
+            asChild
+            forceMount
+            aria-describedby={undefined}
+            onEscapeKeyDown={(event) => {
+              if (!dismissible) event.preventDefault();
+            }}
+            onPointerDownOutside={(event) => {
+              if (!dismissible) event.preventDefault();
+            }}
+          >
             <motion.div
               className={cn(
                 "fixed left-1/2 top-1/2 z-50 w-[min(560px,90vw)] max-h-[85vh] overflow-y-auto -translate-x-1/2 -translate-y-1/2 rounded-lg bg-surface p-6 shadow-ds-modal",
@@ -53,6 +65,7 @@ export function DialogContent({
                 <DialogPrimitive.Close
                   className="text-muted hover:text-ink"
                   aria-label="Fechar"
+                  disabled={!dismissible}
                 >
                   <X size={18} />
                 </DialogPrimitive.Close>

--- a/frontend/src/lib/admin-user-management.test.ts
+++ b/frontend/src/lib/admin-user-management.test.ts
@@ -1,9 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   blockerMessage,
+  ChangeValidationError,
   changeRole,
   changeSpeciality,
+  createLatestRequestGuard,
   getDialogRequirements,
+  isSameRecordsOrigin,
   roleLabel,
   specialityLabel,
   validateRoleChange,
@@ -104,5 +107,57 @@ describe("admin-user-management", () => {
     await expect(changeSpeciality("user-1", { speciality: "CAR" })).rejects.toThrow(
       "Não foi possível concluir a alteração. Tente novamente.",
     );
+  });
+
+  it("aceita somente a resposta da requisição mais recente", () => {
+    const guard = createLatestRequestGuard();
+    const firstRequest = guard.begin();
+    const secondRequest = guard.begin();
+
+    expect(guard.isCurrent(firstRequest)).toBe(false);
+    expect(guard.isCurrent(secondRequest)).toBe(true);
+
+    guard.invalidate();
+
+    expect(guard.isCurrent(secondRequest)).toBe(false);
+  });
+
+  it("associa registros somente à entidade e página que os originaram", () => {
+    const usersPage = { entity: "users", page: 1 };
+
+    expect(isSameRecordsOrigin(usersPage, { entity: "users", page: 1 })).toBe(
+      true,
+    );
+    expect(isSameRecordsOrigin(usersPage, { entity: "companies", page: 1 })).toBe(
+      false,
+    );
+    expect(isSameRecordsOrigin(usersPage, { entity: "users", page: 2 })).toBe(
+      false,
+    );
+  });
+
+  it("preserva a revalidação estruturada devolvida pelo PATCH em conflito", async () => {
+    const validation = {
+      allowed: false,
+      summary: "A alteração não pode ser concluída.",
+      blockers: [
+        {
+          code: "OFFICE_CONFLICT" as const,
+          message: "O escritório já possui um gerente ativo.",
+        },
+      ],
+    };
+    vi.mocked(api.patch).mockRejectedValueOnce({
+      response: { status: 409, data: validation },
+      friendlyMessage: "Conflito: o registro já existe.",
+    });
+
+    const caught = await changeRole("user-1", {
+      role: "OFFICE",
+      company_id: "company-1",
+    }).catch((error: unknown) => error);
+
+    expect(caught).toBeInstanceOf(ChangeValidationError);
+    expect(caught).toMatchObject({ validation });
   });
 });

--- a/frontend/src/lib/admin-user-management.test.ts
+++ b/frontend/src/lib/admin-user-management.test.ts
@@ -5,10 +5,12 @@ import {
   changeRole,
   changeSpeciality,
   createLatestRequestGuard,
+  getManagementDialogInteractionPolicy,
   getDialogRequirements,
   isSameRecordsOrigin,
   roleLabel,
   specialityLabel,
+  shouldInvalidateRecordsRequest,
   validateRoleChange,
   validateSpecialityChange,
 } from "./admin-user-management";
@@ -40,6 +42,15 @@ describe("admin-user-management", () => {
 
     expect(text).toContain("2 produtos ativos");
     expect(text).not.toMatch(/SPECIALIST|PRODUCTS|CAR|BOAT|AIRCRAFT/);
+  });
+
+  it("flexiona bloqueios contáveis no singular e no plural", () => {
+    expect(
+      blockerMessage({ code: "CONSULTANT_HAS_CLIENTS", count: 1 }),
+    ).toBe("O consultor ainda possui 1 cliente vinculado.");
+    expect(
+      blockerMessage({ code: "SPECIALIST_HAS_OPEN_PROCESSES", count: 2 }),
+    ).toBe("O especialista ainda possui 2 processos em andamento.");
   });
 
   it("pede contexto do destino", () => {
@@ -122,6 +133,17 @@ describe("admin-user-management", () => {
     expect(guard.isCurrent(secondRequest)).toBe(false);
   });
 
+  it("bloqueia edição e fechamento do diálogo enquanto o PATCH está em andamento", () => {
+    expect(getManagementDialogInteractionPolicy(true)).toEqual({
+      controlsDisabled: true,
+      dismissalAllowed: false,
+    });
+    expect(getManagementDialogInteractionPolicy(false)).toEqual({
+      controlsDisabled: false,
+      dismissalAllowed: true,
+    });
+  });
+
   it("associa registros somente à entidade e página que os originaram", () => {
     const usersPage = { entity: "users", page: 1 };
 
@@ -134,6 +156,35 @@ describe("admin-user-management", () => {
     expect(isSameRecordsOrigin(usersPage, { entity: "users", page: 2 })).toBe(
       false,
     );
+  });
+
+  it("não invalida a carga atual quando a seleção de aba e página é um no-op", () => {
+    const guard = createLatestRequestGuard();
+    const requestId = guard.begin();
+    const currentOrigin = { entity: "users", page: 1 };
+
+    if (
+      shouldInvalidateRecordsRequest(currentOrigin, {
+        entity: "users",
+        page: 1,
+      })
+    ) {
+      guard.invalidate();
+    }
+
+    expect(guard.isCurrent(requestId)).toBe(true);
+    expect(
+      shouldInvalidateRecordsRequest(currentOrigin, {
+        entity: "companies",
+        page: 1,
+      }),
+    ).toBe(true);
+    expect(
+      shouldInvalidateRecordsRequest(
+        { entity: "users", page: 2 },
+        { entity: "users", page: 1 },
+      ),
+    ).toBe(true);
   });
 
   it("preserva a revalidação estruturada devolvida pelo PATCH em conflito", async () => {

--- a/frontend/src/lib/admin-user-management.test.ts
+++ b/frontend/src/lib/admin-user-management.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  blockerMessage,
+  changeRole,
+  changeSpeciality,
+  getDialogRequirements,
+  roleLabel,
+  specialityLabel,
+  validateRoleChange,
+  validateSpecialityChange,
+} from "./admin-user-management";
+import api from "../services/api";
+
+vi.mock("../services/api", () => ({
+  default: {
+    patch: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+describe("admin-user-management", () => {
+  beforeEach(() => {
+    vi.mocked(api.post).mockReset();
+    vi.mocked(api.patch).mockReset();
+  });
+
+  it("localiza enums", () => {
+    expect(roleLabel("OFFICE")).toBe("Gerente de escritório");
+    expect(specialityLabel("AIRCRAFT")).toBe("Aeronaves");
+  });
+
+  it("não expõe enum em bloqueio", () => {
+    const text = blockerMessage({
+      code: "SPECIALIST_HAS_ACTIVE_PRODUCTS",
+      count: 2,
+    });
+
+    expect(text).toContain("2 produtos ativos");
+    expect(text).not.toMatch(/SPECIALIST|PRODUCTS|CAR|BOAT|AIRCRAFT/);
+  });
+
+  it("pede contexto do destino", () => {
+    expect(getDialogRequirements("CONSULTANT")).toEqual(["company"]);
+    expect(getDialogRequirements("SPECIALIST")).toEqual(["speciality"]);
+    expect(getDialogRequirements("ADMIN")).toEqual([]);
+  });
+
+  it("usa Não informado para enum ausente ou desconhecido", () => {
+    expect(roleLabel()).toBe("Não informado");
+    expect(specialityLabel("OUTRO")).toBe("Não informado");
+  });
+
+  it("valida e aplica a alteração de cargo nas rotas protegidas", async () => {
+    const payload = { role: "CONSULTANT" as const, company_id: "company-1" };
+    vi.mocked(api.post).mockResolvedValueOnce({ data: { allowed: true } });
+    vi.mocked(api.patch).mockResolvedValueOnce({ data: { id: "user-1" } });
+
+    await expect(validateRoleChange("user-1", payload)).resolves.toEqual({
+      allowed: true,
+    });
+    await expect(changeRole("user-1", payload)).resolves.toEqual({ id: "user-1" });
+
+    expect(api.post).toHaveBeenCalledWith(
+      "admin/database/users/user-1/role-change/validate",
+      payload,
+    );
+    expect(api.patch).toHaveBeenCalledWith(
+      "admin/database/users/user-1/role-change",
+      payload,
+    );
+  });
+
+  it("valida e aplica a alteração de especialidade nas rotas protegidas", async () => {
+    const payload = { speciality: "BOAT" as const };
+    vi.mocked(api.post).mockResolvedValueOnce({ data: { allowed: true } });
+    vi.mocked(api.patch).mockResolvedValueOnce({ data: { id: "user-1" } });
+
+    await expect(validateSpecialityChange("user-1", payload)).resolves.toEqual({
+      allowed: true,
+    });
+    await expect(changeSpeciality("user-1", payload)).resolves.toEqual({ id: "user-1" });
+
+    expect(api.post).toHaveBeenCalledWith(
+      "admin/database/users/user-1/speciality-change/validate",
+      payload,
+    );
+    expect(api.patch).toHaveBeenCalledWith(
+      "admin/database/users/user-1/speciality-change",
+      payload,
+    );
+  });
+
+  it("normaliza falhas inesperadas das alterações", async () => {
+    vi.mocked(api.patch).mockRejectedValueOnce(new Error("network exploded"));
+
+    await expect(changeSpeciality("user-1", { speciality: "CAR" })).rejects.toThrow(
+      "Não foi possível concluir a alteração. Tente novamente.",
+    );
+  });
+});

--- a/frontend/src/lib/admin-user-management.test.ts
+++ b/frontend/src/lib/admin-user-management.test.ts
@@ -45,6 +45,14 @@ describe("admin-user-management", () => {
     expect(getDialogRequirements("ADMIN")).toEqual([]);
   });
 
+  it("pede substituição quando escritório já tem gerente", () => {
+    expect(getDialogRequirements("OFFICE", true)).toEqual([
+      "company",
+      "replacement",
+    ]);
+    expect(getDialogRequirements("OFFICE", false)).toEqual(["company"]);
+  });
+
   it("usa Não informado para enum ausente ou desconhecido", () => {
     expect(roleLabel()).toBe("Não informado");
     expect(specialityLabel("OUTRO")).toBe("Não informado");

--- a/frontend/src/lib/admin-user-management.ts
+++ b/frontend/src/lib/admin-user-management.ts
@@ -39,6 +39,16 @@ export type ChangeValidationResult = {
   blockers: ChangeBlocker[];
 };
 
+export class ChangeValidationError extends Error {
+  validation: ChangeValidationResult;
+
+  constructor(validation: ChangeValidationResult) {
+    super(validation.summary);
+    this.name = "ChangeValidationError";
+    this.validation = validation;
+  }
+}
+
 export type RoleContext = {
   role: UserRoleCode;
   company_id?: string;
@@ -56,6 +66,17 @@ export type ChangeSpecialityPayload = {
 export type RecordRowMeta = {
   id: string;
   role?: UserRoleCode;
+};
+
+export type RecordsOrigin = {
+  entity: string;
+  page: number;
+};
+
+export type LatestRequestGuard = {
+  begin: () => number;
+  invalidate: () => void;
+  isCurrent: (requestId: number) => boolean;
 };
 
 export type DialogRequirement = "company" | "speciality" | "replacement";
@@ -136,6 +157,25 @@ export function getDialogRequirements(
   return [];
 }
 
+export function createLatestRequestGuard(): LatestRequestGuard {
+  let latestRequestId = 0;
+
+  return {
+    begin: () => ++latestRequestId,
+    invalidate: () => {
+      latestRequestId += 1;
+    },
+    isCurrent: (requestId) => requestId === latestRequestId,
+  };
+}
+
+export function isSameRecordsOrigin(
+  left: RecordsOrigin,
+  right: RecordsOrigin,
+): boolean {
+  return left.entity === right.entity && left.page === right.page;
+}
+
 export async function validateRoleChange(
   id: string,
   payload: ChangeRolePayload,
@@ -190,6 +230,9 @@ async function requestChange<T>(request: () => Promise<T>): Promise<T> {
   try {
     return await request();
   } catch (error) {
+    const validation = extractConflictValidation(error);
+    if (validation) throw new ChangeValidationError(validation);
+
     const message =
       typeof error === "object" &&
       error !== null &&
@@ -199,4 +242,50 @@ async function requestChange<T>(request: () => Promise<T>): Promise<T> {
         : "Não foi possível concluir a alteração. Tente novamente.";
     throw new Error(message);
   }
+}
+
+function extractConflictValidation(
+  error: unknown,
+): ChangeValidationResult | null {
+  if (typeof error !== "object" || error === null || !("response" in error)) {
+    return null;
+  }
+
+  const response = error.response;
+  if (typeof response !== "object" || response === null) return null;
+
+  const candidate =
+    "status" in response && response.status === 409 && "data" in response
+      ? response.data
+      : null;
+  if (typeof candidate !== "object" || candidate === null) return null;
+
+  if (
+    !("allowed" in candidate) ||
+    typeof candidate.allowed !== "boolean" ||
+    !("summary" in candidate) ||
+    typeof candidate.summary !== "string" ||
+    !("blockers" in candidate) ||
+    !Array.isArray(candidate.blockers)
+  ) {
+    return null;
+  }
+
+  const blockers = candidate.blockers;
+  if (
+    !blockers.every(
+      (blocker) =>
+        typeof blocker === "object" &&
+        blocker !== null &&
+        "code" in blocker &&
+        typeof blocker.code === "string" &&
+        blocker.code in BLOCKER_MESSAGES &&
+        "message" in blocker &&
+        typeof blocker.message === "string",
+    )
+  ) {
+    return null;
+  }
+
+  return candidate as ChangeValidationResult;
 }

--- a/frontend/src/lib/admin-user-management.ts
+++ b/frontend/src/lib/admin-user-management.ts
@@ -58,7 +58,7 @@ export type RecordRowMeta = {
   role?: UserRoleCode;
 };
 
-export type DialogRequirement = "company" | "speciality";
+export type DialogRequirement = "company" | "speciality" | "replacement";
 
 export const ROLE_LABELS: Record<UserRoleCode, string> = {
   CUSTOMER: "Cliente",
@@ -125,8 +125,13 @@ export function blockerMessage(
   return BLOCKER_MESSAGES[blocker.code](blocker.count);
 }
 
-export function getDialogRequirements(role: UserRoleCode): DialogRequirement[] {
-  if (role === "CONSULTANT" || role === "OFFICE") return ["company"];
+export function getDialogRequirements(
+  role: UserRoleCode,
+  hasOfficeConflict = false,
+): DialogRequirement[] {
+  if (role === "OFFICE")
+    return hasOfficeConflict ? ["company", "replacement"] : ["company"];
+  if (role === "CONSULTANT") return ["company"];
   if (role === "SPECIALIST") return ["speciality"];
   return [];
 }

--- a/frontend/src/lib/admin-user-management.ts
+++ b/frontend/src/lib/admin-user-management.ts
@@ -25,6 +25,7 @@ export type ChangeBlockerCode =
   | "OFFICE_REPLACEMENT_REQUIRED"
   | "OFFICE_REPLACEMENT_INVALID"
   | "OFFICE_CONFLICT"
+  | "CONCURRENT_CHANGE"
   | "LAST_ACTIVE_ADMIN";
 
 export type ChangeBlocker = {
@@ -79,6 +80,11 @@ export type LatestRequestGuard = {
   isCurrent: (requestId: number) => boolean;
 };
 
+export type ManagementDialogInteractionPolicy = {
+  controlsDisabled: boolean;
+  dismissalAllowed: boolean;
+};
+
 export type DialogRequirement = "company" | "speciality" | "replacement";
 
 export const ROLE_LABELS: Record<UserRoleCode, string> = {
@@ -95,6 +101,15 @@ export const SPECIALITY_LABELS: Record<SpecialityCode, string> = {
   AIRCRAFT: "Aeronaves",
 };
 
+function quantityMessage(
+  count: number | undefined,
+  singular: string,
+  plural: string,
+): string {
+  const quantity = count ?? 0;
+  return `${quantity} ${quantity === 1 ? singular : plural}`;
+}
+
 export const BLOCKER_MESSAGES: Record<
   ChangeBlockerCode,
   (count?: number) => string
@@ -110,20 +125,22 @@ export const BLOCKER_MESSAGES: Record<
     "O cliente ainda possui um consultor vinculado.",
   CUSTOMER_HAS_ADVISOR: () => "O cliente ainda possui um assessor vinculado.",
   CONSULTANT_HAS_CLIENTS: (count) =>
-    `O consultor ainda possui ${count ?? 0} clientes vinculados.`,
+    `O consultor ainda possui ${quantityMessage(count, "cliente vinculado", "clientes vinculados")}.`,
   CONSULTANT_HAS_ADVISEES: (count) =>
-    `O consultor ainda possui ${count ?? 0} assessorias sob sua responsabilidade.`,
+    `O consultor ainda possui ${quantityMessage(count, "assessoria sob sua responsabilidade", "assessorias sob sua responsabilidade")}.`,
   SPECIALIST_HAS_ACTIVE_PRODUCTS: (count) =>
-    `O especialista ainda possui ${count ?? 0} produtos ativos.`,
+    `O especialista ainda possui ${quantityMessage(count, "produto ativo", "produtos ativos")}.`,
   SPECIALIST_HAS_PENDING_APPOINTMENTS: (count) =>
-    `O especialista ainda possui ${count ?? 0} agendamentos pendentes.`,
+    `O especialista ainda possui ${quantityMessage(count, "agendamento pendente", "agendamentos pendentes")}.`,
   SPECIALIST_HAS_OPEN_PROCESSES: (count) =>
-    `O especialista ainda possui ${count ?? 0} processos em andamento.`,
+    `O especialista ainda possui ${quantityMessage(count, "processo em andamento", "processos em andamento")}.`,
   OFFICE_REPLACEMENT_REQUIRED: () =>
     "Informe o novo cargo do gerente atual do escritório.",
   OFFICE_REPLACEMENT_INVALID: () =>
     "A substituição do gerente de escritório é inválida.",
   OFFICE_CONFLICT: () => "O escritório já possui um gerente ativo.",
+  CONCURRENT_CHANGE: () =>
+    "Outra alteração foi concluída ao mesmo tempo. Verifique os dados e tente novamente.",
   LAST_ACTIVE_ADMIN: () =>
     "Não é possível remover o último administrador ativo da plataforma.",
 };
@@ -169,11 +186,27 @@ export function createLatestRequestGuard(): LatestRequestGuard {
   };
 }
 
+export function getManagementDialogInteractionPolicy(
+  submitting: boolean,
+): ManagementDialogInteractionPolicy {
+  return {
+    controlsDisabled: submitting,
+    dismissalAllowed: !submitting,
+  };
+}
+
 export function isSameRecordsOrigin(
   left: RecordsOrigin,
   right: RecordsOrigin,
 ): boolean {
   return left.entity === right.entity && left.page === right.page;
+}
+
+export function shouldInvalidateRecordsRequest(
+  current: RecordsOrigin | null,
+  next: RecordsOrigin,
+): boolean {
+  return current === null || !isSameRecordsOrigin(current, next);
 }
 
 export async function validateRoleChange(

--- a/frontend/src/lib/admin-user-management.ts
+++ b/frontend/src/lib/admin-user-management.ts
@@ -1,0 +1,197 @@
+import api from "../services/api";
+
+export type UserRoleCode =
+  | "CUSTOMER"
+  | "CONSULTANT"
+  | "SPECIALIST"
+  | "OFFICE"
+  | "ADMIN";
+
+export type SpecialityCode = "CAR" | "BOAT" | "AIRCRAFT";
+
+export type ChangeBlockerCode =
+  | "ROLE_UNCHANGED"
+  | "SPECIALITY_UNCHANGED"
+  | "COMPANY_REQUIRED"
+  | "COMPANY_NOT_FOUND"
+  | "SPECIALITY_REQUIRED"
+  | "CUSTOMER_HAS_CONSULTANT"
+  | "CUSTOMER_HAS_ADVISOR"
+  | "CONSULTANT_HAS_CLIENTS"
+  | "CONSULTANT_HAS_ADVISEES"
+  | "SPECIALIST_HAS_ACTIVE_PRODUCTS"
+  | "SPECIALIST_HAS_PENDING_APPOINTMENTS"
+  | "SPECIALIST_HAS_OPEN_PROCESSES"
+  | "OFFICE_REPLACEMENT_REQUIRED"
+  | "OFFICE_REPLACEMENT_INVALID"
+  | "OFFICE_CONFLICT"
+  | "LAST_ACTIVE_ADMIN";
+
+export type ChangeBlocker = {
+  code: ChangeBlockerCode;
+  message: string;
+  count?: number;
+};
+
+export type ChangeValidationResult = {
+  allowed: boolean;
+  summary: string;
+  blockers: ChangeBlocker[];
+};
+
+export type RoleContext = {
+  role: UserRoleCode;
+  company_id?: string;
+  speciality?: SpecialityCode;
+};
+
+export type ChangeRolePayload = RoleContext & {
+  replacement?: RoleContext;
+};
+
+export type ChangeSpecialityPayload = {
+  speciality: SpecialityCode;
+};
+
+export type RecordRowMeta = {
+  id: string;
+  role?: UserRoleCode;
+};
+
+export type DialogRequirement = "company" | "speciality";
+
+export const ROLE_LABELS: Record<UserRoleCode, string> = {
+  CUSTOMER: "Cliente",
+  CONSULTANT: "Consultor",
+  SPECIALIST: "Especialista",
+  OFFICE: "Gerente de escritório",
+  ADMIN: "Administrador",
+};
+
+export const SPECIALITY_LABELS: Record<SpecialityCode, string> = {
+  CAR: "Carros",
+  BOAT: "Embarcações",
+  AIRCRAFT: "Aeronaves",
+};
+
+export const BLOCKER_MESSAGES: Record<
+  ChangeBlockerCode,
+  (count?: number) => string
+> = {
+  ROLE_UNCHANGED: () => "O cargo selecionado já está atribuído a este usuário.",
+  SPECIALITY_UNCHANGED: () =>
+    "A especialidade selecionada já está atribuída a este especialista.",
+  COMPANY_REQUIRED: () => "Informe o escritório para o cargo selecionado.",
+  COMPANY_NOT_FOUND: () => "O escritório informado não foi encontrado.",
+  SPECIALITY_REQUIRED: () =>
+    "Informe a especialidade para o cargo de Especialista.",
+  CUSTOMER_HAS_CONSULTANT: () =>
+    "O cliente ainda possui um consultor vinculado.",
+  CUSTOMER_HAS_ADVISOR: () => "O cliente ainda possui um assessor vinculado.",
+  CONSULTANT_HAS_CLIENTS: (count) =>
+    `O consultor ainda possui ${count ?? 0} clientes vinculados.`,
+  CONSULTANT_HAS_ADVISEES: (count) =>
+    `O consultor ainda possui ${count ?? 0} assessorias sob sua responsabilidade.`,
+  SPECIALIST_HAS_ACTIVE_PRODUCTS: (count) =>
+    `O especialista ainda possui ${count ?? 0} produtos ativos.`,
+  SPECIALIST_HAS_PENDING_APPOINTMENTS: (count) =>
+    `O especialista ainda possui ${count ?? 0} agendamentos pendentes.`,
+  SPECIALIST_HAS_OPEN_PROCESSES: (count) =>
+    `O especialista ainda possui ${count ?? 0} processos em andamento.`,
+  OFFICE_REPLACEMENT_REQUIRED: () =>
+    "Informe o novo cargo do gerente atual do escritório.",
+  OFFICE_REPLACEMENT_INVALID: () =>
+    "A substituição do gerente de escritório é inválida.",
+  OFFICE_CONFLICT: () => "O escritório já possui um gerente ativo.",
+  LAST_ACTIVE_ADMIN: () =>
+    "Não é possível remover o último administrador ativo da plataforma.",
+};
+
+export function roleLabel(role?: string | null): string {
+  return role && role in ROLE_LABELS
+    ? ROLE_LABELS[role as UserRoleCode]
+    : "Não informado";
+}
+
+export function specialityLabel(speciality?: string | null): string {
+  return speciality && speciality in SPECIALITY_LABELS
+    ? SPECIALITY_LABELS[speciality as SpecialityCode]
+    : "Não informado";
+}
+
+export function blockerMessage(
+  blocker: Pick<ChangeBlocker, "code" | "count">,
+): string {
+  return BLOCKER_MESSAGES[blocker.code](blocker.count);
+}
+
+export function getDialogRequirements(role: UserRoleCode): DialogRequirement[] {
+  if (role === "CONSULTANT" || role === "OFFICE") return ["company"];
+  if (role === "SPECIALIST") return ["speciality"];
+  return [];
+}
+
+export async function validateRoleChange(
+  id: string,
+  payload: ChangeRolePayload,
+): Promise<ChangeValidationResult> {
+  return requestChange(() =>
+    api
+      .post<ChangeValidationResult>(
+        `admin/database/users/${id}/role-change/validate`,
+        payload,
+      )
+      .then((response) => response.data),
+  );
+}
+
+export async function changeRole(
+  id: string,
+  payload: ChangeRolePayload,
+): Promise<unknown> {
+  return requestChange(() =>
+    api
+      .patch(`admin/database/users/${id}/role-change`, payload)
+      .then((response) => response.data),
+  );
+}
+
+export async function validateSpecialityChange(
+  id: string,
+  payload: ChangeSpecialityPayload,
+): Promise<ChangeValidationResult> {
+  return requestChange(() =>
+    api
+      .post<ChangeValidationResult>(
+        `admin/database/users/${id}/speciality-change/validate`,
+        payload,
+      )
+      .then((response) => response.data),
+  );
+}
+
+export async function changeSpeciality(
+  id: string,
+  payload: ChangeSpecialityPayload,
+): Promise<unknown> {
+  return requestChange(() =>
+    api
+      .patch(`admin/database/users/${id}/speciality-change`, payload)
+      .then((response) => response.data),
+  );
+}
+
+async function requestChange<T>(request: () => Promise<T>): Promise<T> {
+  try {
+    return await request();
+  } catch (error) {
+    const message =
+      typeof error === "object" &&
+      error !== null &&
+      "friendlyMessage" in error &&
+      typeof error.friendlyMessage === "string"
+        ? error.friendlyMessage
+        : "Não foi possível concluir a alteração. Tente novamente.";
+    throw new Error(message);
+  }
+}

--- a/frontend/src/pages/admin/DatabasePage.tsx
+++ b/frontend/src/pages/admin/DatabasePage.tsx
@@ -28,6 +28,7 @@ import AdminUserManagementDialog, {
 import {
   createLatestRequestGuard,
   isSameRecordsOrigin,
+  shouldInvalidateRecordsRequest,
   type RecordsOrigin,
 } from "../../lib/admin-user-management";
 
@@ -53,6 +54,7 @@ export default function DatabasePage() {
   );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [dialogState, setDialogState] =
     useState<AdminUserManagementDialogState | null>(null);
   const recordsRequestGuard = useRef(createLatestRequestGuard());
@@ -60,13 +62,14 @@ export default function DatabasePage() {
   useEffect(() => {
     getEntities()
       .then((list) => {
-        recordsRequestGuard.current.invalidate();
         setEntities(list);
         setActive(list[0]?.key ?? null);
+        if (list.length === 0) setLoading(false);
       })
-      .catch((err) =>
-        setError((err as Error).message || "Erro ao carregar entidades."),
-      );
+      .catch((err) => {
+        setError((err as Error).message || "Erro ao carregar entidades.");
+        setLoading(false);
+      });
   }, []);
 
   const loadRecords = useCallback(async () => {
@@ -132,9 +135,13 @@ export default function DatabasePage() {
             key={e.key}
             type="button"
             onClick={() => {
+              const current = active ? { entity: active, page } : null;
+              const next = { entity: e.key, page: 1 };
+              if (!shouldInvalidateRecordsRequest(current, next)) return;
               recordsRequestGuard.current.invalidate();
               setActive(e.key);
               setPage(1);
+              setSuccessMessage(null);
             }}
             className={`px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors ${
               active === e.key
@@ -150,6 +157,12 @@ export default function DatabasePage() {
       {error && (
         <Alert variant="danger" className="mb-4">
           {error}
+        </Alert>
+      )}
+
+      {successMessage && (
+        <Alert variant="success" className="mb-4">
+          {successMessage}
         </Alert>
       )}
 
@@ -216,12 +229,13 @@ export default function DatabasePage() {
                             variant="ghost"
                             className="px-2 py-1 text-xs"
                             disabled={!result?.rowMeta[i]?.id}
-                            onClick={() =>
+                            onClick={() => {
+                              setSuccessMessage(null);
                               setDialogState({
                                 userId: result!.rowMeta[i].id,
                                 mode: "role",
-                              })
-                            }
+                              });
+                            }}
                           >
                             Alterar cargo
                           </Button>
@@ -230,12 +244,13 @@ export default function DatabasePage() {
                               type="button"
                               variant="ghost"
                               className="px-2 py-1 text-xs"
-                              onClick={() =>
+                              onClick={() => {
+                                setSuccessMessage(null);
                                 setDialogState({
                                   userId: result.rowMeta[i].id,
                                   mode: "speciality",
-                                })
-                              }
+                                });
+                              }}
                             >
                               Alterar especialidade
                             </Button>
@@ -314,7 +329,10 @@ export default function DatabasePage() {
       <AdminUserManagementDialog
         state={dialogState}
         onClose={() => setDialogState(null)}
-        onSuccess={loadRecords}
+        onSuccess={async () => {
+          setSuccessMessage("Alteração realizada com sucesso.");
+          await loadRecords();
+        }}
       />
     </div>
   );

--- a/frontend/src/pages/admin/DatabasePage.tsx
+++ b/frontend/src/pages/admin/DatabasePage.tsx
@@ -2,7 +2,7 @@
 // A formatação toda (labels pt-BR, máscaras, moeda, enums) vive no backend,
 // em admin-database.columns.ts — aqui só renderizamos o que chega, e o export
 // consome exatamente a mesma matriz da tela.
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -22,6 +22,9 @@ import { downloadCsv, openPrintablePdf } from "../../utils/export";
 import Button from "../../components/ui/button";
 import { Alert } from "../../components/ui/alert";
 import { EmptyState } from "../../components/patterns/EmptyState";
+import AdminUserManagementDialog, {
+  type AdminUserManagementDialogState,
+} from "../../components/admin/AdminUserManagementDialog";
 
 const PAGE_SIZE = 20;
 
@@ -38,6 +41,8 @@ export default function DatabasePage() {
   const [result, setResult] = useState<RecordsPage | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [dialogState, setDialogState] =
+    useState<AdminUserManagementDialogState | null>(null);
 
   useEffect(() => {
     getEntities()
@@ -50,20 +55,25 @@ export default function DatabasePage() {
       );
   }, []);
 
-  useEffect(() => {
+  const loadRecords = useCallback(async () => {
     if (!active) return;
     setLoading(true);
     setError(null);
-    getRecords(active, page, PAGE_SIZE)
-      .then(setResult)
-      .catch((err) => {
-        // Descarta o resultado anterior: sem isso a aba nova mostra as linhas
-        // da aba antiga, e o CSV sai nomeado com a entidade errada.
-        setResult(null);
-        setError((err as Error).message || "Erro ao carregar registros.");
-      })
-      .finally(() => setLoading(false));
+    try {
+      setResult(await getRecords(active, page, PAGE_SIZE));
+    } catch (err) {
+      // Descarta o resultado anterior: sem isso a aba nova mostra as linhas
+      // da aba antiga, e o CSV sai nomeado com a entidade errada.
+      setResult(null);
+      setError((err as Error).message || "Erro ao carregar registros.");
+    } finally {
+      setLoading(false);
+    }
   }, [active, page]);
+
+  useEffect(() => {
+    void loadRecords();
+  }, [loadRecords]);
 
   const columns = result?.columns ?? [];
   const rows = result?.data ?? [];
@@ -150,6 +160,11 @@ export default function DatabasePage() {
             <table className="min-w-full text-sm">
               <thead className="bg-border-soft sticky top-0 z-10">
                 <tr>
+                  {active === "users" ? (
+                    <th className="px-3 py-2 text-left font-medium text-muted whitespace-nowrap">
+                      Ações
+                    </th>
+                  ) : null}
                   {columns.map((c) => (
                     <th
                       key={c.label}
@@ -163,6 +178,41 @@ export default function DatabasePage() {
               <tbody>
                 {rows.map((row, i) => (
                   <tr key={i} className="border-t border-border-soft">
+                    {active === "users" ? (
+                      <td className="px-3 py-2 whitespace-nowrap align-top">
+                        <div className="flex flex-col items-start gap-1">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            className="px-2 py-1 text-xs"
+                            disabled={!result?.rowMeta[i]?.id}
+                            onClick={() =>
+                              setDialogState({
+                                userId: result!.rowMeta[i].id,
+                                mode: "role",
+                              })
+                            }
+                          >
+                            Alterar cargo
+                          </Button>
+                          {result?.rowMeta[i]?.role === "SPECIALIST" ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              className="px-2 py-1 text-xs"
+                              onClick={() =>
+                                setDialogState({
+                                  userId: result.rowMeta[i].id,
+                                  mode: "speciality",
+                                })
+                              }
+                            >
+                              Alterar especialidade
+                            </Button>
+                          ) : null}
+                        </div>
+                      </td>
+                    ) : null}
                     {row.map((cell, j) => {
                       const wide = columns[j]?.wide;
                       const text = cellText(cell);
@@ -224,6 +274,12 @@ export default function DatabasePage() {
           </div>
         </>
       )}
+
+      <AdminUserManagementDialog
+        state={dialogState}
+        onClose={() => setDialogState(null)}
+        onSuccess={loadRecords}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/admin/DatabasePage.tsx
+++ b/frontend/src/pages/admin/DatabasePage.tsx
@@ -2,7 +2,7 @@
 // A formatação toda (labels pt-BR, máscaras, moeda, enums) vive no backend,
 // em admin-database.columns.ts — aqui só renderizamos o que chega, e o export
 // consome exatamente a mesma matriz da tela.
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ChevronLeft,
   ChevronRight,
@@ -25,8 +25,18 @@ import { EmptyState } from "../../components/patterns/EmptyState";
 import AdminUserManagementDialog, {
   type AdminUserManagementDialogState,
 } from "../../components/admin/AdminUserManagementDialog";
+import {
+  createLatestRequestGuard,
+  isSameRecordsOrigin,
+  type RecordsOrigin,
+} from "../../lib/admin-user-management";
 
 const PAGE_SIZE = 20;
+
+type LoadedRecords = {
+  origin: RecordsOrigin;
+  records: RecordsPage;
+};
 
 /** Versão textual da célula — usada no CSV e no PDF. Imagem vira Sim/—. */
 function cellText(cell: Cell): string {
@@ -38,15 +48,19 @@ export default function DatabasePage() {
   const [entities, setEntities] = useState<EntityInfo[]>([]);
   const [active, setActive] = useState<string | null>(null);
   const [page, setPage] = useState(1);
-  const [result, setResult] = useState<RecordsPage | null>(null);
+  const [loadedRecords, setLoadedRecords] = useState<LoadedRecords | null>(
+    null,
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [dialogState, setDialogState] =
     useState<AdminUserManagementDialogState | null>(null);
+  const recordsRequestGuard = useRef(createLatestRequestGuard());
 
   useEffect(() => {
     getEntities()
       .then((list) => {
+        recordsRequestGuard.current.invalidate();
         setEntities(list);
         setActive(list[0]?.key ?? null);
       })
@@ -57,23 +71,38 @@ export default function DatabasePage() {
 
   const loadRecords = useCallback(async () => {
     if (!active) return;
+    const origin = { entity: active, page };
+    const requestId = recordsRequestGuard.current.begin();
     setLoading(true);
     setError(null);
     try {
-      setResult(await getRecords(active, page, PAGE_SIZE));
+      const records = await getRecords(active, page, PAGE_SIZE);
+      if (!recordsRequestGuard.current.isCurrent(requestId)) return;
+      setLoadedRecords({ origin, records });
     } catch (err) {
+      if (!recordsRequestGuard.current.isCurrent(requestId)) return;
       // Descarta o resultado anterior: sem isso a aba nova mostra as linhas
       // da aba antiga, e o CSV sai nomeado com a entidade errada.
-      setResult(null);
+      setLoadedRecords(null);
       setError((err as Error).message || "Erro ao carregar registros.");
     } finally {
-      setLoading(false);
+      if (recordsRequestGuard.current.isCurrent(requestId)) setLoading(false);
     }
   }, [active, page]);
 
   useEffect(() => {
+    const requestGuard = recordsRequestGuard.current;
     void loadRecords();
+    return () => requestGuard.invalidate();
   }, [loadRecords]);
+
+  const currentOrigin = active ? { entity: active, page } : null;
+  const result =
+    loadedRecords &&
+    currentOrigin &&
+    isSameRecordsOrigin(loadedRecords.origin, currentOrigin)
+      ? loadedRecords.records
+      : null;
 
   const columns = result?.columns ?? [];
   const rows = result?.data ?? [];
@@ -103,6 +132,7 @@ export default function DatabasePage() {
             key={e.key}
             type="button"
             onClick={() => {
+              recordsRequestGuard.current.invalidate();
               setActive(e.key);
               setPage(1);
             }}
@@ -255,7 +285,10 @@ export default function DatabasePage() {
                 type="button"
                 variant="light"
                 disabled={page <= 1}
-                onClick={() => setPage((p) => p - 1)}
+                onClick={() => {
+                  recordsRequestGuard.current.invalidate();
+                  setPage((p) => p - 1);
+                }}
               >
                 <ChevronLeft className="w-4 h-4" /> Anterior
               </Button>
@@ -266,7 +299,10 @@ export default function DatabasePage() {
                 type="button"
                 variant="light"
                 disabled={page >= totalPages}
-                onClick={() => setPage((p) => p + 1)}
+                onClick={() => {
+                  recordsRequestGuard.current.invalidate();
+                  setPage((p) => p + 1);
+                }}
               >
                 Próxima <ChevronRight className="w-4 h-4" />
               </Button>

--- a/frontend/src/services/admin-database.service.ts
+++ b/frontend/src/services/admin-database.service.ts
@@ -1,4 +1,5 @@
 import api from "./api";
+import type { RecordRowMeta } from "../lib/admin-user-management";
 
 export type EntityInfo = { key: string; label: string };
 
@@ -12,6 +13,7 @@ export type ColumnMeta = { label: string; wide?: boolean };
 export type RecordsPage = {
   columns: ColumnMeta[];
   data: Cell[][];
+  rowMeta: RecordRowMeta[];
   total: number;
   page: number;
   pageSize: number;


### PR DESCRIPTION
## Resumo\n- adiciona alteração segura de cargos e especialidades na Base de dados\n- protege vínculos, último administrador e substituição atômica de gerente\n- inclui diálogo localizado, coluna Ações e bloqueios claros\n\n## Verificação\n- backend: Jest focado com --runInBand (91 testes) e build\n- frontend: Vitest limitado a dois workers e build\n\nSem auditoria ou autoatendimento nesta versão.