### PR TITLE
feat(contracts): divide o formulario de contrato em duas etapas

### DIFF
--- a/frontend/src/pages/specialist/ContractCommissionStep.tsx
+++ b/frontend/src/pages/specialist/ContractCommissionStep.tsx
@@ -1,0 +1,142 @@
+import { ArrowRight } from "lucide-react";
+import type {
+  FieldErrors,
+  UseFormRegister,
+} from "react-hook-form";
+import Button from "../../components/ui/button";
+import { formatBRL } from "../../services/contracts.service";
+
+/**
+ * Etapa 1 do contrato: a comissão, isolada do resto.
+ *
+ * Fica fora do <form> da etapa 2 de propósito — assim o Enter aqui não dispara
+ * o submit do contrato. Os valores continuam no mesmo useForm da página, então
+ * o que for digitado aqui chega junto no payload final.
+ */
+interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register: UseFormRegister<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors: FieldErrors<any>;
+  productLabel: string;
+  vehiclePrice: number;
+  totalCommissionValue: number;
+  sellerNetPreviewValue: number;
+  onContinue: () => void;
+  onCancel: () => void;
+}
+
+export default function ContractCommissionStep({
+  register,
+  errors,
+  productLabel,
+  vehiclePrice,
+  totalCommissionValue,
+  sellerNetPreviewValue,
+  onContinue,
+  onCancel,
+}: Props) {
+  const commissionError = errors.total_commission_rate as
+    | { message?: string }
+    | undefined;
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-surface rounded-lg border border-border p-6">
+        <div className="border-b pb-3 mb-5">
+          <h2 className="text-base font-semibold text-ink">
+            Comissão da venda
+          </h2>
+          <p className="text-sm text-subtle mt-1">
+            Defina a comissão total antes de preencher o restante do contrato.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-muted mb-1">
+              Valor total do {productLabel}
+            </label>
+            <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-lg text-ink-soft cursor-default text-sm min-h-[38px] font-medium">
+              {vehiclePrice > 0 ? (
+                formatBRL(vehiclePrice)
+              ) : (
+                <span className="text-subtle">—</span>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="total_commission_rate"
+              className="block text-sm font-medium text-ink-soft mb-1"
+            >
+              Comissão total da venda (%) *
+            </label>
+            <input
+              id="total_commission_rate"
+              type="number"
+              step="0.01"
+              autoFocus
+              {...register("total_commission_rate", {
+                required: "Taxa de comissão é obrigatória",
+                valueAsNumber: true,
+                min: { value: 0, message: "Valor deve ser positivo" },
+                max: { value: 100, message: "Valor deve ser no máximo 100" },
+              })}
+              className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
+            />
+            <p className="text-xs text-subtle mt-1">
+              Único valor editável — plataforma e escritório ficam travados nas
+              taxas cadastradas; seu corte é o restante.
+            </p>
+            {commissionError && (
+              <p className="text-status-bad text-sm mt-1">
+                {commissionError.message}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Consequência do percentual, para a escolha não ser às cegas. */}
+        {vehiclePrice > 0 && totalCommissionValue > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6 pt-5 border-t">
+            <div>
+              <p className="text-xs text-subtle">Comissão total</p>
+              <p className="text-sm font-medium text-ink mt-0.5">
+                {formatBRL(totalCommissionValue)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-subtle">Valor líquido do vendedor</p>
+              <p className="text-sm font-medium text-ink mt-0.5">
+                {formatBRL(sellerNetPreviewValue)}
+              </p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <div className="flex flex-col-reverse sm:flex-row gap-3 pb-8">
+        <Button
+          type="button"
+          variant="light"
+          onClick={onCancel}
+          className="sm:w-auto px-8 py-4"
+        >
+          Cancelar
+        </Button>
+        <Button
+          type="button"
+          onClick={onContinue}
+          className="flex-1 px-8 py-4 text-base shadow-sm"
+        >
+          <span className="flex items-center justify-center gap-2">
+            Continuar para os dados do contrato
+            <ArrowRight className="w-5 h-5" />
+          </span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/specialist/CreateContractPage.tsx
+++ b/frontend/src/pages/specialist/CreateContractPage.tsx
@@ -11,6 +11,7 @@ import {
   Check,
 } from "lucide-react";
 import { useIsMobile } from "../../hooks/use-is-mobile";
+import ContractCommissionStep from "./ContractCommissionStep";
 import {
   prefillContract,
   previewContract,
@@ -131,6 +132,7 @@ export default function CreateContractPage() {
     control,
     setValue,
     watch,
+    trigger,
     formState: { errors },
   } = useForm<ContractFormData>({
     defaultValues: {
@@ -200,6 +202,11 @@ export default function CreateContractPage() {
   const [previewFormData, setPreviewFormData] =
     useState<PreviewContractData | null>(null);
   const [isSendingAfterPreview, setIsSendingAfterPreview] = useState(false);
+
+  // Wizard: a comissão é decidida antes de o especialista ver o resto do
+  // contrato. Um único useForm cobre as duas etapas, então o payload final
+  // continua sendo montado exatamente como antes.
+  const [step, setStep] = useState<1 | 2>(1);
 
   const [templates, setTemplates] = useState<ContractTemplate[]>([]);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
@@ -761,7 +768,26 @@ export default function CreateContractPage() {
           </Alert>
         )}
 
-        {/* Form */}
+        {/* Etapa 1: comissão */}
+        {step === 1 && (
+          <ContractCommissionStep
+            register={register}
+            errors={errors}
+            productLabel={getProductTypeLabel(prefillData?.product_type)}
+            vehiclePrice={vehiclePrice || 0}
+            totalCommissionValue={totalCommissionValue}
+            sellerNetPreviewValue={sellerNetPreviewValue}
+            onCancel={() => navigate(-1)}
+            onContinue={async () => {
+              // Valida só a comissão: o resto do contrato ainda nem foi exibido.
+              const ok = await trigger("total_commission_rate");
+              if (ok) setStep(2);
+            }}
+          />
+        )}
+
+        {/* Etapa 2: demais dados do contrato */}
+        {step === 2 && (
         <form onSubmit={handleSubmit(onPreview)} className="space-y-8">
 
           {/* Seção: Modelo de contrato */}
@@ -1311,35 +1337,6 @@ export default function CreateContractPage() {
                 )}
               </div>
 
-              <div className="hidden">
-                <label className="block text-sm font-medium text-ink-soft mb-1">
-                  Comissão Total da Venda (%) *
-                </label>
-                <input
-                  type="number"
-                  step="0.01"
-                  {...register("total_commission_rate", {
-                    required: "Taxa de comissão é obrigatória",
-                    valueAsNumber: true,
-                    min: { value: 0, message: "Valor deve ser positivo" },
-                  })}
-                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
-                />
-                <p className="text-xs text-subtle mt-1">
-                  Único valor editável — plataforma e escritório ficam travados nas
-                  taxas cadastradas; seu corte é o restante.
-                </p>
-                {totalCommissionValue > 0 && (
-                  <p className="text-sm text-muted mt-1">
-                    {formatBRL(totalCommissionValue)}
-                  </p>
-                )}
-                {errors.total_commission_rate && (
-                  <p className="text-status-bad text-sm mt-1">
-                    {errors.total_commission_rate.message}
-                  </p>
-                )}
-              </div>
 
               <div className="hidden">
                 <label className="block text-sm font-medium text-ink-soft mb-1">
@@ -1945,6 +1942,15 @@ export default function CreateContractPage() {
               <Button
                 type="button"
                 variant="light"
+                onClick={() => setStep(1)}
+                disabled={isSubmitting}
+                className="sm:w-auto px-8 py-4"
+              >
+                Voltar
+              </Button>
+              <Button
+                type="button"
+                variant="light"
                 onClick={() => navigate(-1)}
                 disabled={isSubmitting}
                 className="sm:w-auto px-8 py-4"
@@ -1954,6 +1960,7 @@ export default function CreateContractPage() {
             </div>
           </div>
         </form>
+        )}
       </div>
 
       {/* Modal de Preview do Contrato */}


### PR DESCRIPTION
# Changelog

- Divide o formulário de contrato em duas etapas: comissão primeiro, demais dados depois;
- Extrai a etapa 1 para `ContractCommissionStep.tsx`;
- Torna o campo de comissão **visível** — ele estava dentro de um `<div className="hidden">`;
- Mostra na etapa 1 o valor da comissão e o líquido do vendedor resultantes do percentual;
- Adiciona botão "Voltar" na etapa 2.

closes: [TASK 3.6 — Contrato: dividir envio em duas etapas (comissão → dados)](https://github.com/orgs/InteliJR/projects/23)

> [!IMPORTANT]
> **PR empilhada:** sai de `feat/contract-flexible-fields` (#208), não de `develop`. As duas mexem em `CreateContractPage.tsx` e conflitariam. **Revisar e mergear o #208 primeiro.**

---

## O achado que muda a leitura da task

O campo `total_commission_rate` **já existia no formulário, dentro de um `<div className="hidden">`** — invisível para o especialista. Na prática o contrato saía com o percentual que viesse do prefill (`suggested_total_rate`), ou com o default `0` se o prefill não trouxesse nada, sem ninguém confirmar.

Ou seja: a task não é só "reorganizar em duas telas", é **dar ao especialista o controle que ele não tinha**. Removi o bloco oculto e o campo passou a viver na etapa 1, visível e obrigatório.

Deixei intactos os outros blocos ocultos da mesma seção (comissão da plataforma, do escritório e do especialista) — esses são a repartição interna, e escondê-los parece deliberado. Se a intenção era esconder o total junto, essa é a parte a questionar na revisão.

## Decisões de implementação

**Um `useForm` só, duas etapas.** O payload final continua montado exatamente como antes — não mexi em `onPreview` nem na chamada de API. O react-hook-form v7 preserva valores de campos desmontados (`shouldUnregister` é `false` por padrão), então o percentual digitado na etapa 1 chega no submit da etapa 2.

**A etapa 1 fica fora do `<form>`.** Se ficasse dentro, o Enter no campo de comissão dispararia o submit do contrato inteiro. Como o RHF guarda os valores no próprio estado (e não por containment no DOM), a etapa 1 registra o campo normalmente estando fora.

**Avanço valida só a comissão**, via `trigger("total_commission_rate")` em vez de `handleSubmit` — o resto do contrato ainda nem foi exibido, então validar tudo aqui mostraria erros de campos que o especialista não teve chance de preencher.

**A etapa 1 mostra a consequência do percentual** (comissão total e líquido do vendedor). Uma tela cujo único campo é "%" sem mostrar o que aquilo produz é uma escolha às cegas.

## Sobre quebrar o componente

A task sugere quebrar em dois componentes em vez de esconder/mostrar campos. Fiz isso para a etapa 1, que virou arquivo próprio.

**Não extraí a etapa 2.** São ~1.100 linhas de JSX sem nenhuma cobertura de teste, e movê-las de arquivo não muda comportamento nenhum — é churn com risco de regressão real e zero ganho funcional. Se o time quiser essa decomposição, ela rende um PR próprio de refactor, revisável como refactor, sem estar misturada com a mudança de fluxo.

## O que NÃO foi verificado

**Não consegui abrir esta tela no navegador.** Ela exige backend, banco e um processo válido: sem `processId` a página retorna cedo ("Voltar ao Dashboard"), e com um `processId` inexistente o `prefillContract` falha e ela renderiza o estado de erro, sem formulário. Tentei com o dev server rodando e um usuário SPECIALIST semeado; a tela não chega a montar sem a stack completa.

Então o que está verificado é: `tsc -b` limpo, `eslint` sem aviso novo (só os 3 `any` que já existiam), e `vitest` 37 passando — **nada disso exercita o wizard**. O projeto não tem `jsdom`/testing-library configurado (o `environment` do vitest é `node`), então também não deu para cobrir com teste de componente sem adicionar infra de teste, o que seria outra discussão.

**A revisão precisa incluir o teste manual do fluxo.** O que eu checaria:

1. A etapa 1 abre primeiro, com o campo de comissão visível e focado;
2. "Continuar" bloqueia se a comissão estiver vazia, e avança se estiver preenchida;
3. O valor digitado na etapa 1 chega no contrato gerado (é o ponto onde eu confio no comportamento do RHF sem ter visto);
4. "Voltar" retorna à etapa 1 com o valor preservado.

Um detalhe que a revisão deve olhar: se `total_commission_rate` ficar inválido, o resumo de erros da etapa 2 vai listá-lo, mas o campo não está mais ali — a saída é o botão "Voltar". Como o valor é validado antes de avançar, isso não deve acontecer na prática, mas não é impossível.
