### PR TITLE
fix(users): telefone do perfil nao era retornado nem gravado

### DIFF
--- a/backend/src/features/users/users.controller.ts
+++ b/backend/src/features/users/users.controller.ts
@@ -59,7 +59,7 @@ export class UsersController {
 
   /**
    * PATCH /api/users/:id
-   * Update user data (name, surname, cpf, rg, calendly_url)
+   * Update user data (name, surname, cpf, rg, phone, calendly_url)
    *
    * @param userId - The ID of the user to update
    * @param updateUserDto - Data to update

--- a/backend/src/features/users/users.service.spec.ts
+++ b/backend/src/features/users/users.service.spec.ts
@@ -1,0 +1,84 @@
+import { UsersService } from './users.service';
+import { UpdateUserDto } from './dto/update-user.dto';
+
+const userId = '11111111-1111-4111-8111-111111111111';
+
+function mkService(overrides: Record<string, any> = {}) {
+  const findUnique = jest.fn().mockResolvedValue({
+    id: userId,
+    name: 'Fulano',
+    surname: 'Silva',
+    email: 'fulano@example.com',
+    role: 'CUSTOMER',
+    cpf: '12345678901',
+    rg: '123456789',
+    phone: '11987654321',
+    calendly_url: null,
+  });
+  const findFirst = jest.fn().mockResolvedValue(null);
+  const update = jest.fn().mockResolvedValue({ id: userId });
+
+  const prisma = {
+    user: { findUnique, findFirst, update },
+    ...overrides,
+  } as any;
+
+  return {
+    service: new UsersService(prisma),
+    findUnique,
+    update,
+  };
+}
+
+describe('UsersService — telefone no perfil', () => {
+  // O campo é editável na tela de perfil; sem ele no select a tela abria
+  // vazia e parecia que o valor não tinha sido salvo.
+  it('getById retorna o telefone', async () => {
+    const { service, findUnique } = mkService();
+
+    const user = await service.getById(userId);
+
+    expect(findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ phone: true }),
+      }),
+    );
+    expect(user.phone).toBe('11987654321');
+  });
+
+  // O DTO validava `phone`, mas o service não gravava: a edição sumia.
+  it('update grava o telefone recebido', async () => {
+    const { service, update } = mkService();
+
+    await service.update(userId, { phone: '11912345678' } as UpdateUserDto);
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ phone: '11912345678' }),
+      }),
+    );
+  });
+
+  it('update devolve o telefone na resposta', async () => {
+    const { service, update } = mkService();
+
+    await service.update(userId, { phone: '11912345678' } as UpdateUserDto);
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ phone: true }),
+      }),
+    );
+  });
+
+  // Limpar o campo é diferente de não mexer nele.
+  it('telefone vazio limpa o valor, e ausente não toca no campo', async () => {
+    const comVazio = mkService();
+    await comVazio.service.update(userId, { phone: '' } as UpdateUserDto);
+    expect(comVazio.update.mock.calls[0][0].data.phone).toBeNull();
+
+    const semCampo = mkService();
+    await semCampo.service.update(userId, { name: 'Novo' } as UpdateUserDto);
+    expect(semCampo.update.mock.calls[0][0].data).not.toHaveProperty('phone');
+  });
+});

--- a/backend/src/features/users/users.service.ts
+++ b/backend/src/features/users/users.service.ts
@@ -108,6 +108,7 @@ export class UsersService {
     role: string;
     cpf: string | null;
     rg: string;
+    phone: string | null;
     civil_state: string | null;
     speciality: string | null;
     calendly_url: string | null;
@@ -123,6 +124,10 @@ export class UsersService {
         role: true,
         cpf: true,
         rg: true,
+        // O telefone é editável no perfil (PATCH /users/:id aceita `phone`).
+        // Sem ele no select o campo voltava vazio a cada carregamento da tela
+        // e passava a impressão de que o valor não tinha sido salvo.
+        phone: true,
         civil_state: true,
         speciality: true,
         calendly_url: true,
@@ -156,6 +161,7 @@ export class UsersService {
     role: string;
     cpf: string | null;
     rg: string;
+    phone: string | null;
     calendly_url: string | null;
   }> {
     // Verificar se o usuário existe
@@ -195,6 +201,11 @@ export class UsersService {
         ...(updateUserDto.surname && { surname: updateUserDto.surname }),
         ...(updateUserDto.cpf && { cpf: updateUserDto.cpf }),
         ...(updateUserDto.rg && { rg: updateUserDto.rg }),
+        // O DTO já validava `phone`, mas ele não era gravado: a edição do
+        // telefone no perfil era descartada em silêncio.
+        ...(updateUserDto.phone !== undefined && {
+          phone: updateUserDto.phone?.trim() || null,
+        }),
         ...(updateUserDto.calendly_url !== undefined && {
           calendly_url: updateUserDto.calendly_url?.trim() || null,
         }),
@@ -208,6 +219,7 @@ export class UsersService {
         role: true,
         cpf: true,
         rg: true,
+        phone: true,
         calendly_url: true,
       },
     });


### PR DESCRIPTION
﻿# Changelog

- Corrige `GET /users/:id`, que não devolvia o telefone — o campo do perfil abria sempre vazio;
- Corrige `PATCH /users/:id`, que aceitava `phone` no DTO mas não gravava o valor;
- Adiciona 4 testes cobrindo leitura, escrita, resposta e limpeza do campo.

closes: [Telefone não aparece na tela de configurações do usuário](https://github.com/orgs/InteliJR/projects/23)

---

## A correção é backend, não frontend

A task veio marcada como frontend, mas a tela já estava certa: `ProfilePage.tsx:92` aplica `applyPhoneMask(userData.phone)` ao carregar, e `ProfilePage.tsx:234` mascara enquanto o usuário digita. **Não mudei uma linha do frontend** — ela só recebia `undefined`.

## Eram dois defeitos, não um

O enunciado diz que o número "está sendo salvo corretamente" e só não aparece. A primeira metade não se confirma.

**Leitura** — `UsersService.getById` monta um `select` explícito no Prisma e `phone` não estava nele. O endpoint nunca devolvia o número, então o formulário abria vazio a cada carregamento. É o sintoma relatado.

**Escrita** — `UsersService.update` recebia `phone` no DTO, já com validação de 10-11 dígitos, mas o objeto `data` do Prisma listava só `name`, `surname`, `cpf`, `rg` e `calendly_url`. O telefone era descartado em silêncio: nenhum erro, resposta 200, valor inalterado no banco.

Ou seja, o número que existe no banco veio do **cadastro inicial** e nunca pôde ser alterado pelo perfil. O `select` da resposta do PATCH também omitia `phone`, então nem a resposta do salvamento carregava o valor.

**Corrigir só a leitura deixaria a experiência pior**: o número passaria a aparecer, o usuário editaria, salvaria sem erro nenhum, e o valor antigo voltaria no próximo carregamento. Sai de "parece que não salvou" para "salva errado", que é mais difícil de diagnosticar. Por isso os dois vão juntos.

## Detalhe de comportamento

Telefone vazio (`""`) grava `null`, limpando o campo; telefone ausente do payload não toca no valor gravado. Segue o mesmo padrão que `calendly_url` já usava ali.

## Testes

4 testes novos em `users.service.spec.ts` — o arquivo não existia. Cobrem: `getById` inclui `phone` no select e devolve o valor; `update` grava o telefone recebido; a resposta do update inclui o campo; e a distinção entre limpar e não mexer.

Os três primeiros falham sem a correção, então travam a regressão — o defeito é exatamente do tipo que volta quando alguém edita um `select` explícito.

Suíte completa: 303 passando. As 5 falhas em `contracts.service.spec.ts` **já existem na develop**, sem relação com esta mudança.

## O que não foi verificado

Não abri a tela de perfil com a stack completa — não tenho banco com um usuário de telefone cadastrado. A validação aqui é unitária, com Prisma mockado.

O teste manual que fecha o caso: abrir o perfil e conferir que o número aparece formatado como `(11) 98765-4321`, editar, salvar e **recarregar a página** para confirmar que o novo valor persistiu. O recarregamento é a parte que importa — é ele que expunha o segundo defeito.


---

## ✅ Verificado com banco real

Rodei o ciclo completo contra Postgres local (o `.env` do repo aponta para Supabase de produção — **não foi tocado**).

**Antes (develop, sem a correção):**

```
GET   /api/users/:id        -> phone: None            ← campo nem vinha na resposta
PATCH /api/users/:id        -> resposta sem `phone`
GET   /api/users/:id        -> 11987654321            ← valor antigo, edição descartada
banco                       -> 11987654321
```

**Depois (esta branch):**

```
1. GET   (abrir a tela)      -> 11987654321
2. PATCH (salvar) HTTP 200   -> 11912345678
3. GET   (recarregar a tela) -> 11912345678   ← persistiu
4. valor gravado no banco    -> 11912345678
```

O passo 3 é o que fecha o caso: recarregar a página e o valor novo continuar lá.

Login feito pelo endpoint real (`POST /api/auth/login`), não com token forjado.

## Achado de ambiente (não bloqueia este PR)

Durante a verificação, todas as rotas protegidas devolviam **401 em ambiente local**, mesmo com token válido do próprio login.

Causa: `src/auth/constants.ts` lê `process.env.JWT_SECRET_ACCESS` **no momento do import**, que acontece antes do `ConfigModule` carregar o `.env`. O `AuthGuard` acaba verificando o token com segredo `undefined`, enquanto o login assina com o segredo correto (injetado via `ConfigService`).

Em produção não aparece, porque as variáveis já estão no ambiente do processo. Localmente só funciona se o `.env` for exportado para o shell antes de subir o backend.

Vale uma issue à parte — é o tipo de coisa que faz alguém perder uma tarde achando que o próprio login está quebrado.
