### PR TITLE
feat(contracts): divide o formulario de contrato em duas etapas (reaplica #210)

### DIFF
--- a/frontend/src/pages/specialist/ContractCommissionStep.tsx
+++ b/frontend/src/pages/specialist/ContractCommissionStep.tsx
@@ -1,0 +1,142 @@
+import { ArrowRight } from "lucide-react";
+import type {
+  FieldErrors,
+  UseFormRegister,
+} from "react-hook-form";
+import Button from "../../components/ui/button";
+import { formatBRL } from "../../services/contracts.service";
+
+/**
+ * Etapa 1 do contrato: a comissão, isolada do resto.
+ *
+ * Fica fora do <form> da etapa 2 de propósito — assim o Enter aqui não dispara
+ * o submit do contrato. Os valores continuam no mesmo useForm da página, então
+ * o que for digitado aqui chega junto no payload final.
+ */
+interface Props {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  register: UseFormRegister<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  errors: FieldErrors<any>;
+  productLabel: string;
+  vehiclePrice: number;
+  totalCommissionValue: number;
+  sellerNetPreviewValue: number;
+  onContinue: () => void;
+  onCancel: () => void;
+}
+
+export default function ContractCommissionStep({
+  register,
+  errors,
+  productLabel,
+  vehiclePrice,
+  totalCommissionValue,
+  sellerNetPreviewValue,
+  onContinue,
+  onCancel,
+}: Props) {
+  const commissionError = errors.total_commission_rate as
+    | { message?: string }
+    | undefined;
+
+  return (
+    <div className="space-y-6">
+      <section className="bg-surface rounded-lg border border-border p-6">
+        <div className="border-b pb-3 mb-5">
+          <h2 className="text-base font-semibold text-ink">
+            Comissão da venda
+          </h2>
+          <p className="text-sm text-subtle mt-1">
+            Defina a comissão total antes de preencher o restante do contrato.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-muted mb-1">
+              Valor total do {productLabel}
+            </label>
+            <div className="w-full px-3 py-2 bg-border-soft border border-border rounded-lg text-ink-soft cursor-default text-sm min-h-[38px] font-medium">
+              {vehiclePrice > 0 ? (
+                formatBRL(vehiclePrice)
+              ) : (
+                <span className="text-subtle">—</span>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <label
+              htmlFor="total_commission_rate"
+              className="block text-sm font-medium text-ink-soft mb-1"
+            >
+              Comissão total da venda (%) *
+            </label>
+            <input
+              id="total_commission_rate"
+              type="number"
+              step="0.01"
+              autoFocus
+              {...register("total_commission_rate", {
+                required: "Taxa de comissão é obrigatória",
+                valueAsNumber: true,
+                min: { value: 0, message: "Valor deve ser positivo" },
+                max: { value: 100, message: "Valor deve ser no máximo 100" },
+              })}
+              className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
+            />
+            <p className="text-xs text-subtle mt-1">
+              Único valor editável — plataforma e escritório ficam travados nas
+              taxas cadastradas; seu corte é o restante.
+            </p>
+            {commissionError && (
+              <p className="text-status-bad text-sm mt-1">
+                {commissionError.message}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Consequência do percentual, para a escolha não ser às cegas. */}
+        {vehiclePrice > 0 && totalCommissionValue > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-6 pt-5 border-t">
+            <div>
+              <p className="text-xs text-subtle">Comissão total</p>
+              <p className="text-sm font-medium text-ink mt-0.5">
+                {formatBRL(totalCommissionValue)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-subtle">Valor líquido do vendedor</p>
+              <p className="text-sm font-medium text-ink mt-0.5">
+                {formatBRL(sellerNetPreviewValue)}
+              </p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <div className="flex flex-col-reverse sm:flex-row gap-3 pb-8">
+        <Button
+          type="button"
+          variant="light"
+          onClick={onCancel}
+          className="sm:w-auto px-8 py-4"
+        >
+          Cancelar
+        </Button>
+        <Button
+          type="button"
+          onClick={onContinue}
+          className="flex-1 px-8 py-4 text-base shadow-sm"
+        >
+          <span className="flex items-center justify-center gap-2">
+            Continuar para os dados do contrato
+            <ArrowRight className="w-5 h-5" />
+          </span>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/specialist/CreateContractPage.tsx
+++ b/frontend/src/pages/specialist/CreateContractPage.tsx
@@ -11,6 +11,7 @@ import {
   Check,
 } from "lucide-react";
 import { useIsMobile } from "../../hooks/use-is-mobile";
+import ContractCommissionStep from "./ContractCommissionStep";
 import {
   prefillContract,
   previewContract,
@@ -131,6 +132,7 @@ export default function CreateContractPage() {
     control,
     setValue,
     watch,
+    trigger,
     formState: { errors },
   } = useForm<ContractFormData>({
     defaultValues: {
@@ -200,6 +202,11 @@ export default function CreateContractPage() {
   const [previewFormData, setPreviewFormData] =
     useState<PreviewContractData | null>(null);
   const [isSendingAfterPreview, setIsSendingAfterPreview] = useState(false);
+
+  // Wizard: a comissão é decidida antes de o especialista ver o resto do
+  // contrato. Um único useForm cobre as duas etapas, então o payload final
+  // continua sendo montado exatamente como antes.
+  const [step, setStep] = useState<1 | 2>(1);
 
   const [templates, setTemplates] = useState<ContractTemplate[]>([]);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>("");
@@ -761,7 +768,26 @@ export default function CreateContractPage() {
           </Alert>
         )}
 
-        {/* Form */}
+        {/* Etapa 1: comissão */}
+        {step === 1 && (
+          <ContractCommissionStep
+            register={register}
+            errors={errors}
+            productLabel={getProductTypeLabel(prefillData?.product_type)}
+            vehiclePrice={vehiclePrice || 0}
+            totalCommissionValue={totalCommissionValue}
+            sellerNetPreviewValue={sellerNetPreviewValue}
+            onCancel={() => navigate(-1)}
+            onContinue={async () => {
+              // Valida só a comissão: o resto do contrato ainda nem foi exibido.
+              const ok = await trigger("total_commission_rate");
+              if (ok) setStep(2);
+            }}
+          />
+        )}
+
+        {/* Etapa 2: demais dados do contrato */}
+        {step === 2 && (
         <form onSubmit={handleSubmit(onPreview)} className="space-y-8">
 
           {/* Seção: Modelo de contrato */}
@@ -1311,35 +1337,6 @@ export default function CreateContractPage() {
                 )}
               </div>
 
-              <div className="hidden">
-                <label className="block text-sm font-medium text-ink-soft mb-1">
-                  Comissão Total da Venda (%) *
-                </label>
-                <input
-                  type="number"
-                  step="0.01"
-                  {...register("total_commission_rate", {
-                    required: "Taxa de comissão é obrigatória",
-                    valueAsNumber: true,
-                    min: { value: 0, message: "Valor deve ser positivo" },
-                  })}
-                  className="w-full px-3 py-2 border border-border rounded-lg focus:ring-2 focus:ring-focus-ring focus:border-transparent bg-surface"
-                />
-                <p className="text-xs text-subtle mt-1">
-                  Único valor editável — plataforma e escritório ficam travados nas
-                  taxas cadastradas; seu corte é o restante.
-                </p>
-                {totalCommissionValue > 0 && (
-                  <p className="text-sm text-muted mt-1">
-                    {formatBRL(totalCommissionValue)}
-                  </p>
-                )}
-                {errors.total_commission_rate && (
-                  <p className="text-status-bad text-sm mt-1">
-                    {errors.total_commission_rate.message}
-                  </p>
-                )}
-              </div>
 
               <div className="hidden">
                 <label className="block text-sm font-medium text-ink-soft mb-1">
@@ -1945,6 +1942,15 @@ export default function CreateContractPage() {
               <Button
                 type="button"
                 variant="light"
+                onClick={() => setStep(1)}
+                disabled={isSubmitting}
+                className="sm:w-auto px-8 py-4"
+              >
+                Voltar
+              </Button>
+              <Button
+                type="button"
+                variant="light"
                 onClick={() => navigate(-1)}
                 disabled={isSubmitting}
                 className="sm:w-auto px-8 py-4"
@@ -1954,6 +1960,7 @@ export default function CreateContractPage() {
             </div>
           </div>
         </form>
+        )}
       </div>
 
       {/* Modal de Preview do Contrato */}


### PR DESCRIPTION
# Changelog

- Reaplica na `develop` o conteúdo da TASK 3.6, que ficou fora do merge (ver abaixo);
- Nenhuma mudança de código em relação ao que foi aprovado no #210 — é o mesmo commit, reaplicado.

closes: [TASK 3.6 — Contrato: dividir envio em duas etapas (comissão → dados)](https://github.com/orgs/InteliJR/projects/23)

---

## Por que este PR existe

Mesmo problema do [#206](https://github.com/InteliJR/high-classShop/pull/206): o [#210](https://github.com/InteliJR/high-classShop/pull/210) aparece como **merged**, mas o código **não chegou na `develop`**.

Ele era empilhado sobre `feat/contract-flexible-fields` (a branch da 3.5, PR #208). O #208 foi mergeado na `develop` primeiro; o #210 foi mergeado depois na branch dele, que já tinha sido absorvida. O commit ficou parado ali.

Confirmação: `ContractCommissionStep.tsx` não existe em `origin/develop`.

## O que este PR contém

O commit `6a101d6` do #210, aplicado por cherry-pick sobre a `develop` atual. **Sem conflitos.**

Conteúdo, igual ao que foi revisado:

- Formulário de contrato dividido em duas etapas — comissão primeiro, demais dados depois;
- Etapa 1 extraída para `ContractCommissionStep.tsx`, fora do `<form>` da etapa 2 (para o Enter não disparar o submit do contrato);
- Campo de comissão **visível** — ele estava dentro de um `<div className="hidden">`, invisível para o especialista;
- Etapa 1 mostra a comissão em reais e o líquido do vendedor;
- Botão "Voltar" na etapa 2.

## Testes

Rodados nesta branch, sobre a develop atual: `tsc -b` limpo, `eslint` sem aviso novo (só os 3 `any` que já existiam no arquivo), 51 testes passando.

**Nada disso exercita o wizard** — segue valendo o que estava escrito no #210: o projeto não tem `jsdom`/testing-library configurado, e a tela exige backend, banco e processo válido para montar.

## O que continua pendente

O teste manual do fluxo, igual ao pedido no #210:

1. A etapa 1 abre primeiro, com o campo de comissão visível;
2. "Continuar" bloqueia sem comissão preenchida e avança com ela;
3. O valor digitado na etapa 1 chega no contrato gerado;
4. "Voltar" retorna à etapa 1 com o valor preservado.
