### PR TITLE
fix(auth): segredos JWT liam process.env antes do .env ser carregado

### DIFF
--- a/backend/src/auth/constants.spec.ts
+++ b/backend/src/auth/constants.spec.ts
@@ -1,0 +1,58 @@
+import { jwtConstants } from './constants';
+
+// Este import já aconteceu — é justamente o ponto: as variáveis abaixo são
+// definidas DEPOIS dele, simulando o ConfigModule carregando o .env após o
+// módulo ter sido importado. Era esse intervalo que deixava os segredos
+// `undefined` para sempre e derrubava toda rota protegida em ambiente local.
+describe('jwtConstants — leitura tardia', () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it.each([
+    ['access', 'JWT_SECRET_ACCESS'],
+    ['refresh', 'JWT_SECRET_REFRESH'],
+    ['referral', 'JWT_SECRET_REFERRAL'],
+    ['advisor', 'JWT_SECRET_ADVISOR'],
+  ])('%s lê a variável definida após o import', (prop, envVar) => {
+    process.env[envVar] = `valor-de-${envVar}`;
+
+    expect(jwtConstants[prop as keyof typeof jwtConstants]).toBe(
+      `valor-de-${envVar}`,
+    );
+  });
+
+  it('reflete mudanças no ambiente em vez de congelar o primeiro valor', () => {
+    process.env.JWT_SECRET_ACCESS = 'primeiro';
+    expect(jwtConstants.access).toBe('primeiro');
+
+    process.env.JWT_SECRET_ACCESS = 'segundo';
+    expect(jwtConstants.access).toBe('segundo');
+  });
+
+  // Falhar com o nome da variável é melhor que assinar/verificar com undefined
+  // e devolver 401 sem explicação.
+  it('diz qual variável falta em vez de devolver undefined', () => {
+    delete process.env.JWT_SECRET_ACCESS;
+
+    expect(() => jwtConstants.access).toThrow(
+      'Missing environment variable: JWT_SECRET_ACCESS',
+    );
+  });
+
+  it('passwordReset cai para o segredo de referral', () => {
+    delete process.env.JWT_SECRET_PASSWORD_RESET;
+    process.env.JWT_SECRET_REFERRAL = 'referral-secreto';
+
+    expect(jwtConstants.passwordReset).toBe('referral-secreto');
+  });
+
+  it('passwordReset prefere o segredo dedicado quando existe', () => {
+    process.env.JWT_SECRET_PASSWORD_RESET = 'dedicado';
+    process.env.JWT_SECRET_REFERRAL = 'referral-secreto';
+
+    expect(jwtConstants.passwordReset).toBe('dedicado');
+  });
+});

--- a/backend/src/auth/constants.ts
+++ b/backend/src/auth/constants.ts
@@ -1,8 +1,41 @@
+import { requiredEnv } from 'src/shared/utils/required-env';
+
+/**
+ * Segredos JWT lidos sob demanda, não no import.
+ *
+ * Antes eram propriedades comuns, avaliadas quando este módulo era importado —
+ * o que acontece ANTES de o ConfigModule carregar o `.env` para process.env.
+ * Com variáveis de ambiente reais (produção) isso funciona; com arquivo `.env`
+ * (desenvolvimento) todos os segredos ficavam `undefined`.
+ *
+ * O efeito era silencioso e difícil de diagnosticar: o login assinava com o
+ * segredo certo (injetado via ConfigService), mas o AuthGuard verificava com
+ * `undefined` e devolvia 401 em toda rota protegida — dava a impressão de que
+ * o próprio login estava quebrado.
+ *
+ * Getters resolvem no momento do uso, quando o `.env` já foi carregado. Se o
+ * segredo faltar de verdade, o erro diz qual variável falta em vez de virar
+ * um 401 sem explicação.
+ */
 export const jwtConstants = {
-  access: process.env.JWT_SECRET_ACCESS,
-  refresh: process.env.JWT_SECRET_REFRESH,
-  referral: process.env.JWT_SECRET_REFERRAL,
-  advisor: process.env.JWT_SECRET_ADVISOR,
-  passwordReset:
-    process.env.JWT_SECRET_PASSWORD_RESET || process.env.JWT_SECRET_REFERRAL,
+  get access(): string {
+    return requiredEnv(process.env.JWT_SECRET_ACCESS, 'JWT_SECRET_ACCESS');
+  },
+  get refresh(): string {
+    return requiredEnv(process.env.JWT_SECRET_REFRESH, 'JWT_SECRET_REFRESH');
+  },
+  get referral(): string {
+    return requiredEnv(process.env.JWT_SECRET_REFERRAL, 'JWT_SECRET_REFERRAL');
+  },
+  get advisor(): string {
+    return requiredEnv(process.env.JWT_SECRET_ADVISOR, 'JWT_SECRET_ADVISOR');
+  },
+  /** Cai para o segredo de referral quando não há um dedicado — comportamento preservado. */
+  get passwordReset(): string {
+    return requiredEnv(
+      process.env.JWT_SECRET_PASSWORD_RESET ||
+        process.env.JWT_SECRET_REFERRAL,
+      'JWT_SECRET_PASSWORD_RESET (ou JWT_SECRET_REFERRAL)',
+    );
+  },
 };

--- a/backend/src/features/office/office.service.spec.ts
+++ b/backend/src/features/office/office.service.spec.ts
@@ -18,6 +18,13 @@ jest.mock('src/shared/services/logo-sanitizer.service', () => ({
 
 import { OfficeService } from './office.service';
 
+// inviteConsultant assina o convite com jwtConstants.referral. O JwtService é
+// mockado, então o valor em si não importa — mas o segredo precisa existir:
+// desde que a leitura passou a ser tardia, ausência vira erro explícito em vez
+// de assinar com `undefined`.
+process.env.JWT_SECRET_REFERRAL =
+  process.env.JWT_SECRET_REFERRAL || 'test-referral-secret';
+
 const SCOPE_OFFICE_A = { companyId: 'companyA', isAdmin: false };
 const SCOPE_OFFICE_B = { companyId: 'companyB', isAdmin: false };
 const SCOPE_ADMIN = { companyId: null, isAdmin: true };


### PR DESCRIPTION
# Changelog

- Corrige `auth/constants.ts`, que lia `process.env` no import — antes do `ConfigModule` carregar o `.env`;
- Segredo ausente agora falha dizendo qual variável falta, em vez de virar 401 sem explicação;
- Adiciona 8 testes travando a leitura tardia;
- Ajusta `office.service.spec`, que dependia do segredo ausente.

---

## O sintoma

**Em ambiente local, toda rota protegida devolvia 401** — mesmo com um token recém-emitido pelo próprio `POST /auth/login`, na mesma sessão, segundos antes.

Encontrei isso enquanto verificava o [#212](https://github.com/InteliJR/high-classShop/pull/212) com banco real, e perdi um tempo achando que meu ambiente estava mal configurado.

## A causa

`auth/constants.ts` era um objeto literal:

```ts
export const jwtConstants = {
  access: process.env.JWT_SECRET_ACCESS,   // avaliado no import
  ...
};
```

Essas expressões rodam quando o módulo é importado, e isso acontece **antes** de o `ConfigModule` carregar o `.env` para `process.env`.

Com variáveis de ambiente reais (produção, Docker) funciona, porque `process.env` já está populado quando o processo sobe. Com arquivo `.env` (o fluxo documentado no `CLAUDE.md` para desenvolvimento local) todos os segredos ficavam `undefined` para sempre.

O que tornava difícil de achar é a assimetria: o **login funciona**, porque `AuthModule` registra o `JwtModule` via `ConfigService`, que resolve no momento certo. Só a **verificação** quebrava, porque o `AuthGuard` usa `jwtConstants.access`. Login OK, tudo depois 401.

## O alcance era maior que o AuthGuard

Os quatro segredos eram lidos assim, em seis arquivos:

| Consumidor | Segredo | O que quebrava local |
|---|---|---|
| `auth.guard.ts` | `access` | toda rota protegida |
| `customer-advisors.service.ts` | `advisor` | convite e aceite de assessor |
| `office.service.ts`, `consultant-invite-jobs.service.ts`, `specialists.service.ts` | `referral` | convites de consultor e especialista |
| `auth.service.ts` | `passwordReset`, `referral` | reset de senha |

## A correção

Getters, resolvidos no momento do uso — quando o `.env` já foi carregado:

```ts
get access(): string {
  return requiredEnv(process.env.JWT_SECRET_ACCESS, 'JWT_SECRET_ACCESS');
}
```

O `requiredEnv` já existia em `shared/utils/required-env.ts` e é o mesmo mecanismo que o projeto usa para as chaves do DocuSign. Segredo faltando vira `Missing environment variable: JWT_SECRET_ACCESS` em vez de um 401 mudo.

O fallback de `passwordReset` para o segredo de referral foi preservado.

## Verificado ponta a ponta

Backend contra Postgres local, com as variáveis **apenas no arquivo `.env`** (sem exportar nada para o shell) — o cenário exato que falhava:

```
1. POST  /auth/login                  -> HTTP 201 (token recebido)
2. PATCH /users/:id (rota protegida)  -> HTTP 200
```

Antes desta correção, o passo 2 era **401** com esse mesmo setup.

## Testes

- 8 testes novos em `constants.spec.ts`. O desenho importa: o `import` acontece no topo e as variáveis são definidas **depois**, reproduzindo o intervalo em que o `ConfigModule` ainda não carregou o `.env`. Um deles verifica que o getter reflete mudanças em vez de congelar o primeiro valor — é exatamente o defeito;
- Suíte completa: **307 passando**. As 5 falhas em `contracts.service.spec.ts` já existem na develop, sem relação;
- `nest build` passa.

## Uma mudança de comportamento que vale revisar

`office.service.spec` quebrou com a correção, e o motivo é interessante: ele chamava `inviteConsultant` sem `JWT_SECRET_REFERRAL` definido. Antes o segredo vinha `undefined` e o teste passava porque o `JwtService` é mockado. Agora a leitura falha explicitamente.

Defini a variável no spec. Vale conferir se algum ambiente real depende de rodar sem algum desses segredos — se depender, hoje já estaria assinando token com `undefined`, o que o `jsonwebtoken` rejeita de qualquer forma; a diferença é só a qualidade da mensagem.
