### PR TITLE
fix: retira do especialista o acesso a base inteira de clientes

### DIFF
--- a/backend/src/features/users/users.controller.ts
+++ b/backend/src/features/users/users.controller.ts
@@ -19,25 +19,41 @@ export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   /**
-   * GET /api/users
-   * Get all users with pagination and optional role filter
-   * @param query - Query parameters (page, perPage, role)
-   * @example
-   * GET /api/users?page=1&perPage=20&role=CUSTOMER
+   * DESATIVADA — GET /api/users (listagem)
+   *
+   * A rota não tinha @Roles(), então qualquer usuário autenticado listava
+   * todos os usuários da plataforma com nome, e-mail e CPF. O único consumidor
+   * era o select de clientes do CreateProcessModal, na tela de processos do
+   * especialista — ou seja, para escolher um cliente o especialista via a base
+   * inteira, inclusive clientes de outros escritórios.
+   *
+   * O botão que abria esse modal foi retirado da tela, e a função que chamava
+   * esta rota (fetchClients, em select-options.service.ts) foi comentada.
+   *
+   * Comentada em vez de apagada: se a listagem voltar, ela precisa nascer
+   * escopada por papel — o ADMIN tem visão global legítima, os demais não.
+   * Note que GET /api/users/:id (abaixo) continua ativa e é @Public().
    */
-  @Get()
-  async getAll(@Query() query: GetUsersDto) {
-    const result = await this.usersService.getAll(query);
-
-    return {
-      success: true,
-      message: 'Usuários recuperados com sucesso',
-      data: result.data,
-      meta: {
-        pagination: result.pagination,
-      },
-    };
-  }
+  // /**
+  // * GET /api/users
+  // * Get all users with pagination and optional role filter
+  // * @param query - Query parameters (page, perPage, role)
+  // * @example
+  // * GET /api/users?page=1&perPage=20&role=CUSTOMER
+  // */
+  // @Get()
+  // async getAll(@Query() query: GetUsersDto) {
+  // const result = await this.usersService.getAll(query);
+  //
+  // return {
+  // success: true,
+  // message: 'Usuários recuperados com sucesso',
+  // data: result.data,
+  // meta: {
+  // pagination: result.pagination,
+  // },
+  // };
+  // }
 
   /**
    * GET /api/users/:id

--- a/frontend/src/components/processes/CreateProcessModal.tsx
+++ b/frontend/src/components/processes/CreateProcessModal.tsx
@@ -1,206 +1,224 @@
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { X } from "lucide-react";
-import {
-  fetchClients,
-  fetchAvailableProducts,
-} from "../../services/select-options.service";
-import { createProcess } from "../../services/processes.service";
-import { useAuth } from "../../store/authStateManager";
-import InfiniteScrollSelect from "../ui/InfiniteScrollSelect";
-
-interface CreateProcessFormData {
-  client_id: string;
-  product_id: string;
-}
-
-interface CreateProcessModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSuccess?: () => void;
-}
-
 /**
- * Modal for creating a new process with client and product selection
- * Products are automatically filtered by specialist's speciality
- * Uses InfiniteScrollSelect for better performance with many records
+ * DESATIVADO — modal de criação de processo pelo especialista.
+ *
+ * Este modal era aberto pelo botão "Novo Processo" da tela de processos do
+ * especialista. Para escolher o cliente, ele populava um select com
+ * `fetchClients()`, que chamava `GET /users?role=CUSTOMER` e trazia a base
+ * inteira de clientes da plataforma — nome, e-mail e CPF de todo mundo,
+ * inclusive de clientes de outros escritórios.
+ *
+ * Retirado por isso. Ficam comentados juntos:
+ *   - o botão, em pages/specialist/ProcessesPage.tsx
+ *   - fetchClients, em services/select-options.service.ts
+ *   - a rota GET /api/users, em backend users.controller.ts
+ *
+ * Mantido comentado, e não apagado, para servir de base caso o fluxo volte
+ * com uma fonte de clientes escopada ao próprio especialista.
  */
-export default function CreateProcessModal({
-  isOpen,
-  onClose,
-  onSuccess,
-}: CreateProcessModalProps) {
-  const { user } = useAuth();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const {
-    handleSubmit,
-    reset,
-    formState: { errors },
-    setValue,
-    watch,
-  } = useForm<CreateProcessFormData>({
-    defaultValues: {
-      client_id: "",
-      product_id: "",
-    },
-  });
-
-  const clientId = watch("client_id");
-  const productId = watch("product_id");
-
-  const onSubmit = async (data: CreateProcessFormData) => {
-    try {
-      setIsSubmitting(true);
-      setError(null);
-
-      // Validação manual adicional
-      if (!data.client_id) {
-        setError("Por favor, selecione um cliente");
-        return;
-      }
-      if (!data.product_id) {
-        setError("Por favor, selecione um produto");
-        return;
-      }
-
-      await createProcess({
-        client_id: data.client_id,
-        specialist_id: user?.id,
-        product_type: user?.speciality as "CAR" | "BOAT" | "AIRCRAFT",
-        product_id: data.product_id,
-      });
-
-      reset();
-      onClose();
-      onSuccess?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Erro ao criar processo");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleClose = () => {
-    reset();
-    setError(null);
-    onClose();
-  };
-
-  if (!isOpen) return null;
-
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-3 sm:p-4" onClick={!isSubmitting ? handleClose : undefined}>
-      <div className="bg-white rounded-lg shadow-xl w-full max-w-sm md:max-w-md max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
-        {/* Header */}
-        <div className="flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 sticky top-0 bg-white">
-          <h2 className="text-base sm:text-lg font-semibold text-gray-900">
-            Novo Processo
-          </h2>
-          <button
-            onClick={handleClose}
-            className="p-1 hover:bg-gray-100 rounded transition shrink-0"
-            aria-label="Close modal"
-          >
-            <X size={20} />
-          </button>
-        </div>
-
-        {/* Form */}
-        <form
-          onSubmit={handleSubmit(onSubmit)}
-          className="p-4 sm:p-6 space-y-4 sm:space-y-5"
-        >
-          {/* Error Alert */}
-          {error && (
-            <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
-              <p className="text-xs sm:text-sm text-red-700">{error}</p>
-            </div>
-          )}
-
-          {/* Client Select - Infinite Scroll */}
-          <InfiniteScrollSelect
-            label="Cliente"
-            placeholder="Selecione um cliente"
-            value={clientId}
-            onChange={(value) => {
-              setValue("client_id", value);
-              setError(null);
-            }}
-            onLoadMore={async (page) => {
-              try {
-                const clients = await fetchClients(page, 20);
-                return clients;
-              } catch (err) {
-                setError(
-                  err instanceof Error
-                    ? err.message
-                    : "Erro ao carregar clientes"
-                );
-                return [];
-              }
-            }}
-            error={errors.client_id?.message}
-            required
-          />
-
-          {/* Product Select - Infinite Scroll */}
-          <InfiniteScrollSelect
-            label="Produto"
-            placeholder={
-              !user?.speciality
-                ? "Especialidade não configurada"
-                : "Selecione um produto"
-            }
-            value={productId}
-            onChange={(value) => {
-              setValue("product_id", value);
-              setError(null);
-            }}
-            onLoadMore={async (page) => {
-              if (!user?.speciality) return [];
-              try {
-                const products = await fetchAvailableProducts(
-                  user.speciality as "CAR" | "BOAT" | "AIRCRAFT",
-                  page,
-                  20
-                );
-                return products;
-              } catch (err) {
-                setError(
-                  err instanceof Error
-                    ? err.message
-                    : "Erro ao carregar produtos"
-                );
-                return [];
-              }
-            }}
-            disabled={!user?.speciality}
-            error={errors.product_id?.message}
-            required
-          />
-
-          {/* Form Actions */}
-          <div className="flex flex-col-reverse sm:flex-row gap-3 pt-4">
-            <button
-              type="button"
-              onClick={handleClose}
-              disabled={isSubmitting}
-              className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-            >
-              Cancelar
-            </button>
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="flex-1 px-4 py-2 bg-slate-700 text-white font-medium rounded-lg hover:bg-slate-800 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm"
-            >
-              {isSubmitting ? "Criando..." : "Criar Processo"}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
-  );
-}
+// import { useState } from "react";
+// import { useForm } from "react-hook-form";
+// import { X } from "lucide-react";
+// import {
+//   fetchClients,
+//   fetchAvailableProducts,
+// } from "../../services/select-options.service";
+// import { createProcess } from "../../services/processes.service";
+// import { useAuth } from "../../store/authStateManager";
+// import InfiniteScrollSelect from "../ui/InfiniteScrollSelect";
+//
+// interface CreateProcessFormData {
+//   client_id: string;
+//   product_id: string;
+// }
+//
+// interface CreateProcessModalProps {
+//   isOpen: boolean;
+//   onClose: () => void;
+//   onSuccess?: () => void;
+// }
+//
+// /**
+//  * Modal for creating a new process with client and product selection
+//  * Products are automatically filtered by specialist's speciality
+//  * Uses InfiniteScrollSelect for better performance with many records
+//  */
+// export default function CreateProcessModal({
+//   isOpen,
+//   onClose,
+//   onSuccess,
+// }: CreateProcessModalProps) {
+//   const { user } = useAuth();
+//   const [isSubmitting, setIsSubmitting] = useState(false);
+//   const [error, setError] = useState<string | null>(null);
+//
+//   const {
+//     handleSubmit,
+//     reset,
+//     formState: { errors },
+//     setValue,
+//     watch,
+//   } = useForm<CreateProcessFormData>({
+//     defaultValues: {
+//       client_id: "",
+//       product_id: "",
+//     },
+//   });
+//
+//   const clientId = watch("client_id");
+//   const productId = watch("product_id");
+//
+//   const onSubmit = async (data: CreateProcessFormData) => {
+//     try {
+//       setIsSubmitting(true);
+//       setError(null);
+//
+//       // Validação manual adicional
+//       if (!data.client_id) {
+//         setError("Por favor, selecione um cliente");
+//         return;
+//       }
+//       if (!data.product_id) {
+//         setError("Por favor, selecione um produto");
+//         return;
+//       }
+//
+//       await createProcess({
+//         client_id: data.client_id,
+//         specialist_id: user?.id,
+//         product_type: user?.speciality as "CAR" | "BOAT" | "AIRCRAFT",
+//         product_id: data.product_id,
+//       });
+//
+//       reset();
+//       onClose();
+//       onSuccess?.();
+//     } catch (err) {
+//       setError(err instanceof Error ? err.message : "Erro ao criar processo");
+//     } finally {
+//       setIsSubmitting(false);
+//     }
+//   };
+//
+//   const handleClose = () => {
+//     reset();
+//     setError(null);
+//     onClose();
+//   };
+//
+//   if (!isOpen) return null;
+//
+//   return (
+//     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-3 sm:p-4" onClick={!isSubmitting ? handleClose : undefined}>
+//       <div className="bg-white rounded-lg shadow-xl w-full max-w-sm md:max-w-md max-h-[90vh] overflow-y-auto" onClick={(e) => e.stopPropagation()}>
+//         {/* Header */}
+//         <div className="flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 border-b border-gray-200 sticky top-0 bg-white">
+//           <h2 className="text-base sm:text-lg font-semibold text-gray-900">
+//             Novo Processo
+//           </h2>
+//           <button
+//             onClick={handleClose}
+//             className="p-1 hover:bg-gray-100 rounded transition shrink-0"
+//             aria-label="Close modal"
+//           >
+//             <X size={20} />
+//           </button>
+//         </div>
+//
+//         {/* Form */}
+//         <form
+//           onSubmit={handleSubmit(onSubmit)}
+//           className="p-4 sm:p-6 space-y-4 sm:space-y-5"
+//         >
+//           {/* Error Alert */}
+//           {error && (
+//             <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+//               <p className="text-xs sm:text-sm text-red-700">{error}</p>
+//             </div>
+//           )}
+//
+//           {/* Client Select - Infinite Scroll */}
+//           <InfiniteScrollSelect
+//             label="Cliente"
+//             placeholder="Selecione um cliente"
+//             value={clientId}
+//             onChange={(value) => {
+//               setValue("client_id", value);
+//               setError(null);
+//             }}
+//             onLoadMore={async (page) => {
+//               try {
+//                 const clients = await fetchClients(page, 20);
+//                 return clients;
+//               } catch (err) {
+//                 setError(
+//                   err instanceof Error
+//                     ? err.message
+//                     : "Erro ao carregar clientes"
+//                 );
+//                 return [];
+//               }
+//             }}
+//             error={errors.client_id?.message}
+//             required
+//           />
+//
+//           {/* Product Select - Infinite Scroll */}
+//           <InfiniteScrollSelect
+//             label="Produto"
+//             placeholder={
+//               !user?.speciality
+//                 ? "Especialidade não configurada"
+//                 : "Selecione um produto"
+//             }
+//             value={productId}
+//             onChange={(value) => {
+//               setValue("product_id", value);
+//               setError(null);
+//             }}
+//             onLoadMore={async (page) => {
+//               if (!user?.speciality) return [];
+//               try {
+//                 const products = await fetchAvailableProducts(
+//                   user.speciality as "CAR" | "BOAT" | "AIRCRAFT",
+//                   page,
+//                   20
+//                 );
+//                 return products;
+//               } catch (err) {
+//                 setError(
+//                   err instanceof Error
+//                     ? err.message
+//                     : "Erro ao carregar produtos"
+//                 );
+//                 return [];
+//               }
+//             }}
+//             disabled={!user?.speciality}
+//             error={errors.product_id?.message}
+//             required
+//           />
+//
+//           {/* Form Actions */}
+//           <div className="flex flex-col-reverse sm:flex-row gap-3 pt-4">
+//             <button
+//               type="button"
+//               onClick={handleClose}
+//               disabled={isSubmitting}
+//               className="flex-1 px-4 py-2 border border-gray-300 text-gray-700 font-medium rounded-lg hover:bg-gray-50 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+//             >
+//               Cancelar
+//             </button>
+//             <button
+//               type="submit"
+//               disabled={isSubmitting}
+//               className="flex-1 px-4 py-2 bg-slate-700 text-white font-medium rounded-lg hover:bg-slate-800 transition disabled:opacity-50 disabled:cursor-not-allowed text-sm"
+//             >
+//               {isSubmitting ? "Criando..." : "Criar Processo"}
+//             </button>
+//           </div>
+//         </form>
+//       </div>
+//     </div>
+//   );
+// }

--- a/frontend/src/pages/specialist/ProcessesPage.tsx
+++ b/frontend/src/pages/specialist/ProcessesPage.tsx
@@ -10,7 +10,6 @@ import {
   Loader2,
 } from "lucide-react";
 import ProcessCard from "../../components/processes/ProcessCard";
-import CreateProcessModal from "../../components/processes/CreateProcessModal";
 import ProductSelectorModal from "../../components/product/ProductSelectorModal";
 import Button from "../../components/ui/button";
 import { Alert } from "../../components/ui/alert";
@@ -80,7 +79,6 @@ export default function ProcessesPage() {
   const [showFilters, setShowFilters] = useState(false);
 
   // Modal state
-  const [showCreateModal, setShowCreateModal] = useState(false);
   const [showProductSelectorModal, setShowProductSelectorModal] =
     useState(false);
   const [selectedProcessForProduct, setSelectedProcessForProduct] =
@@ -210,13 +208,6 @@ export default function ProcessesPage() {
     navigate(`/specialist/contracts/new?processId=${processId}`);
   };
 
-  // Handle successful process creation
-  const handleProcessCreated = () => {
-    setShowCreateModal(false);
-    setIsEditing(false); // Resume polling after creation
-    loadProcesses(1); // Reload from first page
-  };
-
   // Handle opening product selector for consultancy processes
   const handleSelectProduct = (process: ProcessWithProduct) => {
     setSelectedProcessForProduct(process);
@@ -268,10 +259,6 @@ export default function ProcessesPage() {
                 {hasActiveFilters && (
                   <span className="ml-1 w-2 h-2 bg-status-bad rounded-full" />
                 )}
-              </Button>
-              <Button type="button" onClick={() => setShowCreateModal(true)}>
-                <Plus size={16} />
-                <span className="hidden sm:inline">Novo Processo</span>
               </Button>
             </>
           }
@@ -430,15 +417,10 @@ export default function ProcessesPage() {
                 ? "Tente ajustar os filtros para encontrar mais resultados"
                 : "Crie seu primeiro processo para começar"}
             </p>
-            {hasActiveFilters ? (
+            {hasActiveFilters && (
               <Button type="button" variant="light" onClick={handleClearFilters}>
                 <X size={18} />
                 Limpar Filtros
-              </Button>
-            ) : (
-              <Button type="button" onClick={() => setShowCreateModal(true)}>
-                <Plus size={18} />
-                Criar Novo Processo
               </Button>
             )}
           </div>
@@ -497,13 +479,6 @@ export default function ProcessesPage() {
           </div>
         )}
       </div>
-
-      {/* Create Process Modal */}
-      <CreateProcessModal
-        isOpen={showCreateModal}
-        onClose={() => setShowCreateModal(false)}
-        onSuccess={handleProcessCreated}
-      />
 
       {/* Product Selector Modal for Consultancy Processes */}
       {selectedProcessForProduct && user?.speciality && (

--- a/frontend/src/services/select-options.service.ts
+++ b/frontend/src/services/select-options.service.ts
@@ -23,43 +23,60 @@ export interface ProductOption extends Omit<SelectOption, "id"> {
 }
 
 /**
- * Fetch all clients (CUSTOMER users)
- * Used to populate Client select in CreateProcessModal
- * @param page - Page number for pagination
- * @param perPage - Number of items per page
+ * DESATIVADO — listagem de todos os clientes.
+ *
+ * Esta função chamava `GET /users?role=CUSTOMER`, que devolve a base inteira
+ * de clientes. Ela existia só para popular o select do CreateProcessModal, na
+ * tela de processos do especialista: para escolher um cliente, o especialista
+ * enxergava todos os clientes da plataforma — inclusive os de outros
+ * escritórios, com nome, e-mail e CPF.
+ *
+ * O botão de iniciar processo foi retirado da tela do especialista e a rota
+ * `GET /users` foi comentada no backend (users.controller.ts), então esta
+ * função não tem mais para onde apontar.
+ *
+ * Mantida comentada, e não apagada, para o caso de o fluxo voltar com um
+ * endpoint escopado (por exemplo, só os clientes com processo do próprio
+ * especialista).
  */
-export async function fetchClients(
-  page = 1,
-  perPage = 20
-): Promise<ClientOption[]> {
-  try {
-    const response = await api.get("/users", {
-      withCredentials: true,
-      params: { role: "CUSTOMER", page, perPage },
-    });
-
-    return (response.data.data || []).map(
-      (user: {
-        id: string;
-        name: string;
-        surname: string;
-        email: string;
-        role: UserRole;
-      }) => ({
-        id: user.id,
-        label: `${user.name} ${user.surname}`,
-        value: user.id,
-        email: user.email,
-        role: user.role,
-      })
-    );
-  } catch (error) {
-    console.error("Erro ao buscar clientes:", error);
-    throw new Error(
-      "Não foi possível carregar a lista de clientes. Por favor, tente novamente."
-    );
-  }
-}
+// /**
+//  * Fetch all clients (CUSTOMER users)
+//  * Used to populate Client select in CreateProcessModal
+//  * @param page - Page number for pagination
+//  * @param perPage - Number of items per page
+//  */
+// export async function fetchClients(
+//   page = 1,
+//   perPage = 20
+// ): Promise<ClientOption[]> {
+//   try {
+//     const response = await api.get("/users", {
+//       withCredentials: true,
+//       params: { role: "CUSTOMER", page, perPage },
+//     });
+//
+//     return (response.data.data || []).map(
+//       (user: {
+//         id: string;
+//         name: string;
+//         surname: string;
+//         email: string;
+//         role: UserRole;
+//       }) => ({
+//         id: user.id,
+//         label: `${user.name} ${user.surname}`,
+//         value: user.id,
+//         email: user.email,
+//         role: user.role,
+//       })
+//     );
+//   } catch (error) {
+//     console.error("Erro ao buscar clientes:", error);
+//     throw new Error(
+//       "Não foi possível carregar a lista de clientes. Por favor, tente novamente."
+//     );
+//   }
+// }
 
 /**
  * Fetch products by type (CAR, BOAT, AIRCRAFT)


### PR DESCRIPTION
# Changelog

- Retira os botões de iniciar processo da tela de processos do especialista;
- Comenta `fetchClients`, que buscava a base inteira de clientes;
- Comenta o `CreateProcessModal`, que ficou sem consumidor e sem fonte de dados;
- Comenta a rota `GET /api/users`, cujo único consumidor era esse select.

closes: [FRONTEND] Retirar a possibilidade do especialista ver toda a base de clientes

---

## O caminho da exposição

O botão "Novo Processo" abria o `CreateProcessModal`. Para escolher o cliente, ele populava um select com `fetchClients()`, que chamava `GET /users?role=CUSTOMER`.

Essa rota devolve **id, nome, sobrenome, e-mail, CPF, papel e data de cadastro de todos os usuários** — sem filtro por escritório, consultor ou vínculo com o especialista. Para escolher um cliente, o especialista via a base inteira da plataforma.

## O que foi retirado

**Tela** (`ProcessesPage.tsx`) — dois botões abriam o modal, não um: o do cabeçalho e o do estado vazio ("Criar Novo Processo", que aparecia quando não havia processos). Saíram os dois, junto com o estado `showCreateModal` e o handler `handleProcessCreated`, que só existiam para eles. O estado vazio agora mostra só o botão de limpar filtros, quando há filtros ativos.

**Comentados, não apagados**, conforme pedido na task:

| Onde | O quê |
|---|---|
| `services/select-options.service.ts` | `fetchClients()` |
| `components/processes/CreateProcessModal.tsx` | o componente inteiro |
| `backend/.../users.controller.ts` | a rota `GET /api/users` |

Cada um leva um comentário explicando o motivo e apontando para os outros dois, para quem for restaurar não deixar metade para trás.

O `CreateProcessModal` entrou na lista por necessidade: sem `fetchClients` ele não compila, e sem o botão ninguém o abre. Comentá-lo mantém o desenho disponível caso o fluxo volte com uma fonte de clientes escopada.

## A rota é a parte que fecha o buraco

Tirar o botão só some com o caminho pela interface. `GET /api/users` **não tinha `@Roles()`**, e o `RolesGuard` libera quando não há metadata — então qualquer usuário autenticado, de qualquer papel, listava todos os usuários chamando a rota direto. Sem comentá-la, a task fecharia a porta e deixaria a janela aberta.

Verifiquei que o select era o único consumidor: nenhuma outra chamada a `GET /users` (listagem) existe no frontend. `GET /api/users/:id` continua ativa e `@Public()` — é usada no perfil e na página de produto. O admin usa outro controller (`admin/database/users/...`), não afetado.

**Se a listagem voltar, ela precisa nascer escopada por papel** — o ADMIN tem visão global legítima, os demais não. Deixei isso escrito no comentário da rota.

## Testes

- Backend: **322 passando**, suíte inteira verde;
- `nest build` passa;
- Frontend: `tsc -b` limpo, 56 testes passando;
- `eslint` na `ProcessesPage`: 24 avisos antes, 23 depois — nenhum novo (todos pré-existentes, de `react-hooks`).

## O que não foi verificado

Não abri a tela no navegador: ela exige backend, banco e um especialista com processos. A mudança é remoção de JSX, coberta por typecheck e por busca no fonte (nenhuma referência restante a `showCreateModal` ou `CreateProcessModal` na página), mas quem revisar vale abrir a tela de processos como especialista e confirmar que não sobrou botão — inclusive no estado sem nenhum processo, que era o segundo ponto de entrada.
