### PR TITLE
feat(processes): exibe e copia contatos da contraparte no card

### DIFF
--- a/frontend/src/components/processes/CopyableContact.tsx
+++ b/frontend/src/components/processes/CopyableContact.tsx
@@ -1,0 +1,97 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+/**
+ * Linha de contato copiável usada no ProcessCard.
+ *
+ * O texto e o ícone são o mesmo botão: a task pede que tocar em qualquer um
+ * dos dois copie, e um botão único evita duas áreas de toque disputando espaço
+ * no card em telas pequenas.
+ *
+ * Quem chama decide se renderiza — este componente não trata ausência de
+ * valor, justamente para não existir uma linha vazia na tela.
+ */
+interface Props {
+  /** Ícone do tipo de contato (envelope, telefone). */
+  icon: React.ReactNode;
+  /** Texto exibido — pode ser formatado (ex.: telefone com máscara). */
+  label: string;
+  /** Valor efetivamente copiado — cru, sem formatação. */
+  value: string;
+  /** Descrição para leitores de tela, ex.: "e-mail do cliente". */
+  description: string;
+}
+
+export default function CopyableContact({
+  icon,
+  label,
+  value,
+  description,
+}: Props) {
+  const [copied, setCopied] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Evita setState depois de desmontado: o card some da lista enquanto a
+  // confirmação ainda está no ar.
+  useEffect(() => {
+    return () => {
+      if (timer.current) clearTimeout(timer.current);
+    };
+  }, []);
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    // O card inteiro é clicável em algumas telas; copiar não deve navegar.
+    e.stopPropagation();
+    e.preventDefault();
+
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setFailed(false);
+    } catch {
+      // Clipboard indisponível (contexto não seguro, permissão negada).
+      // Falhar em silêncio deixaria o usuário achando que copiou.
+      setFailed(true);
+      setCopied(false);
+    }
+
+    if (timer.current) clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      setCopied(false);
+      setFailed(false);
+    }, 2000);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      title={`Copiar ${description}`}
+      aria-label={`Copiar ${description}: ${label}`}
+      className="group inline-flex max-w-full items-center gap-1.5 rounded px-1 -mx-1 py-0.5 text-xs text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+    >
+      <span className="shrink-0 text-gray-400 group-hover:text-gray-600">
+        {icon}
+      </span>
+      <span className="truncate">{label}</span>
+
+      {/* aria-live: o leitor de tela anuncia a confirmação sem mover o foco. */}
+      <span className="shrink-0" aria-live="polite">
+        {copied ? (
+          <span className="inline-flex items-center gap-1 font-medium text-green-600">
+            <Check size={12} />
+            Copiado
+          </span>
+        ) : failed ? (
+          <span className="font-medium text-red-600">Não foi possível copiar</span>
+        ) : (
+          <Copy
+            size={12}
+            className="text-gray-300 transition-colors group-hover:text-gray-500"
+          />
+        )}
+      </span>
+    </button>
+  );
+}

--- a/frontend/src/components/processes/ProcessCard.tsx
+++ b/frontend/src/components/processes/ProcessCard.tsx
@@ -12,6 +12,8 @@ import {
   XCircle,
   Package,
   Video,
+  Mail,
+  Phone,
 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
@@ -19,6 +21,8 @@ import type { Process } from "../../services/processes.service";
 import type { Product, SpecialityType } from "../../types/types";
 import React from "react";
 import UpdateProcessStatusModal from "./UpdateProcessStatusModal";
+import CopyableContact from "./CopyableContact";
+import { applyPhoneMask } from "../../utils/mask";
 import { getContextualStatusMessage } from "../../utils/processStatusMessages";
 import {
   getProcessCompletionReason,
@@ -109,6 +113,14 @@ export default function ProcessCard({
 
   // Verifica se é um processo de consultoria (sem produto atribuído)
   const isConsultancy = !process.product_type || !process.product_id;
+
+  // Contraparte do processo: quem esta olhando quer o contato do outro lado.
+  // Nao ha fallback entre os dois — se o dado da contraparte nao veio, a
+  // linha simplesmente nao aparece, em vez de mostrar o contato errado.
+  const counterpart = isClientView ? process.specialist : process.client;
+  const counterpartLabel = isClientView ? "especialista" : "cliente";
+  const counterpartEmail = counterpart?.email?.trim() || null;
+  const counterpartPhone = counterpart?.phone?.trim() || null;
   const isAppointmentConfirmed =
     process.appointment_status === "SCHEDULED" ||
     process.appointment_status === "COMPLETED";
@@ -353,6 +365,32 @@ export default function ProcessCard({
               ? "Aguardando produto"
               : product?.modelo || "Produto"}
           </h3>
+          {/* Contatos da contraparte: quem olha o card quer falar com o outro
+              lado. Cliente vê o especialista; especialista e demais papeis
+              veem o cliente. Cada linha so aparece se a API mandou o dado —
+              telefone do especialista, por exemplo, vem null enquanto o
+              agendamento nao esta confirmado. */}
+          {(counterpartEmail || counterpartPhone) && (
+            <div className="mt-1 flex flex-col items-start gap-0.5">
+              {counterpartEmail && (
+                <CopyableContact
+                  icon={<Mail size={12} />}
+                  label={counterpartEmail}
+                  value={counterpartEmail}
+                  description={`e-mail do ${counterpartLabel}`}
+                />
+              )}
+              {counterpartPhone && (
+                <CopyableContact
+                  icon={<Phone size={12} />}
+                  label={applyPhoneMask(counterpartPhone)}
+                  value={counterpartPhone}
+                  description={`telefone do ${counterpartLabel}`}
+                />
+              )}
+            </div>
+          )}
+
           {isConsultancy && (
             <p className="text-xs text-slate-600 mt-1">
               {isClientView

--- a/frontend/src/services/processes.service.ts
+++ b/frontend/src/services/processes.service.ts
@@ -28,6 +28,9 @@ export interface Process {
     id: string;
     email?: string;
     name?: string;
+    // Opcionais porque nem toda rota de processo devolve contato: hoje só
+    // GET /processes/:id monta telefone, e sob regra de permissão.
+    phone?: string | null;
   };
   product?: {
     id: string;
@@ -41,6 +44,10 @@ export interface Process {
     id: string;
     name?: string;
     especialidade?: string;
+    email?: string;
+    // Backend oculta o telefone do especialista para o cliente enquanto o
+    // agendamento não está confirmado — aqui chega null nesse caso.
+    phone?: string | null;
   };
   // Flag para identificar consultoria (sem produto ainda)
   isConsultancy?: boolean;


### PR DESCRIPTION
# Changelog

- Exibe e-mail e telefone da contraparte abaixo do título, no `ProcessCard`;
- Adiciona `CopyableContact`, que copia ao clique no texto ou no ícone e confirma visualmente;
- Estende o tipo `Process` com os campos de contato que a API pode enviar.

closes: [FE] TASK 3.10 — Exibir e copiar contatos no card de processos

> [!IMPORTANT]
> **O componente está pronto, mas hoje ele vai aparecer quase vazio.** As rotas que alimentam o card não enviam telefone, e nunca enviam o e-mail do especialista. Detalhe na seção "O que a API realmente entrega" — vale ler antes de testar e concluir que não funcionou.

---

## O que foi feito

Cada linha é um botão só: o texto e o ícone copiam a mesma coisa. Duas áreas de toque disputando espaço num card já denso não ajudaria em tela pequena.

A contraparte sai do `isClientView` que o card já recebia: o cliente vê o especialista, os demais papéis veem o cliente. **Não há fallback entre os dois** — se o contato da contraparte não veio, a linha some, em vez de cair para o contato do outro lado e mostrar a informação errada.

O telefone aparece com `applyPhoneMask` (`(11) 98765-4321`), mas o valor copiado é o cru (`11987654321`) — é o que serve para colar em discador ou planilha.

Quando a área de transferência não está disponível (contexto não seguro, permissão negada), o botão mostra **"Não foi possível copiar"**. Confirmar uma cópia que não aconteceu seria pior que não ter o recurso.

## Sobre a regra de permissão

O card não decide nada: renderiza o que veio e omite o que não veio. Quem oculta é o backend — `canSeeSpecialistPhone` devolve `null` para o cliente enquanto o agendamento não está confirmado. Como a linha só existe quando há valor, a interface **não revela que existe um telefone oculto**, nem deixa campo vazio.

## O que a API realmente entrega

O contexto da task diz que a API já retorna e-mail e telefone de cliente e especialista. Isso vale para `GET /processes/:id`, mas **não para as rotas que alimentam o card**:

| Rota | Usada por | `client.email` | `client.phone` | `specialist.email` | `specialist.phone` |
|---|---|---|---|---|---|
| `GET /processes` | — | ✅ | ❌ | ❌ | ❌ |
| `GET /processes/specialist/:id` | tela do especialista | ✅ | ❌ | ❌ | ❌ |
| `GET /processes/client/:id` | tela do cliente | ✅ | ❌ | ❌ | ❌ |
| `GET /processes/:id` | (detalhe) | ✅ | ✅ | ❌ | ✅ (com regra) |

Ou seja, hoje: na tela do especialista aparece só o e-mail do cliente; na tela do cliente **não aparece nada**, porque `specialist.email` não existe em nenhuma rota e o telefone não vem na listagem.

O componente já lê os campos, então **passa a exibir sozinho assim que o backend enviar** — nada muda no frontend depois.

Não fui adiante por escolha: a task é `[FE]` e pede explicitamente para não ampliar a exposição de dados. Levar telefone para as listagens é replicar a regra que já existe em `getById`, defensável. Mas **expor o e-mail do especialista é dado novo**, que hoje não sai em rota nenhuma — é decisão de produto/privacidade, não minha.

**Sugestão:** uma task `[BE]` que (a) leve `phone` às três listagens com a mesma regra do `getById` e (b) decida sobre o e-mail do especialista. Posso abrir e implementar.

## Verificado no navegador

Montei uma rota temporária com quatro cenários, exercitei e removi antes do commit (o diff tem só 3 arquivos).

Renderização, por cenário:

| Cenário | Resultado |
|---|---|
| Especialista, dados completos | e-mail + telefone do **cliente** |
| Cliente, dados completos | e-mail + telefone do **especialista** |
| Sem telefone | só a linha de e-mail |
| Sem contato da contraparte | nenhuma linha, nenhum espaço vazio |

Cópia (instrumentando `navigator.clipboard.writeText`, porque o navegador do preview bloqueia a área de transferência sem foco no documento):

```
copiado: ["maria@example.dev", "11987654321", "joao@example.dev"]
exibido: "maria@example.dev Copiado" | "(11) 98765-4321 Copiado" | "joao@example.dev Copiado"
```

O telefone confirma a distinção: exibe mascarado, copia cru.

E o bloqueio real da área de transferência acabou testando o caminho de erro sem eu precisar forçar — o botão mostrou "Não foi possível copiar".

`tsc -b` limpo, 56 testes passando, `eslint` sem aviso novo (o único no `ProcessCard` é um `any` pré-existente, na linha 100).

## O que não foi verificado

Não exercitei com a API real — precisaria de backend, banco e processos, e as rotas ainda não mandam os campos. A verificação acima usa dados injetados no componente.

Também não há teste automatizado: o projeto não tem `jsdom`/testing-library (o vitest roda em `environment: node`), então um componente com clique e estado não é testável hoje sem adicionar essa infra.
