### PR TITLE
feat(admin-database): exibe imagem de capa nas abas de produto

### DIFF
--- a/backend/src/features/admin-database/admin-database.columns.ts
+++ b/backend/src/features/admin-database/admin-database.columns.ts
@@ -38,6 +38,17 @@ export type Column = {
   wide?: boolean;
   /** get() devolve uma key do S3 que vira URL assinada. */
   image?: true;
+  /**
+   * Como interpretar a key devolvida por get().
+   *
+   * 'company-logo' (padrão) aplica a heurística de prefixo `companies/`:
+   * logos legados, gravados em base64 sem path, viram célula vazia.
+   *
+   * 's3-key' assina a key direto. É o caso das imagens de produto, cujo
+   * campo `image_url` guarda a key (o nome engana) e é assinado do mesmo
+   * jeito nos endpoints públicos de catálogo.
+   */
+  imageSource?: 'company-logo' | 's3-key';
   /** Texto alternativo da imagem. Obrigatório quando image. */
   alt?: (row: any) => string;
 };
@@ -66,6 +77,25 @@ const produto = (r: any) => {
   const p = r.car ?? r.boat ?? r.aircraft;
   return p ? `${p.marca ?? ''} ${p.modelo ?? ''}`.trim() : undefined;
 };
+
+/** Projeção da imagem de capa de um produto.
+ *
+ * `orderBy` resolve a preferência no banco: is_primary desc traz a principal
+ * primeiro e, quando nenhuma está marcada, created_at asc devolve a mais
+ * antiga — a "primeira disponível". `take: 1` evita arrastar a galeria
+ * inteira só para mostrar uma miniatura.
+ *
+ * Apesar do nome, `image_url` guarda a key do S3, e é assim que os endpoints
+ * de catálogo a tratam.
+ */
+const imagemDeCapa = {
+  select: { image_url: true },
+  orderBy: [{ is_primary: 'desc' }, { created_at: 'asc' }],
+  take: 1,
+} as const;
+
+/** Key da imagem de capa, ou undefined para o guarda de vazio. */
+const capa = (r: any) => r.images?.[0]?.image_url ?? undefined;
 
 /** Identifica um processo por gente e coisa, não por UUID:
  *  "João Silva — Ferrari F8 Tributo". Sem produto (consultoria), só o cliente. */
@@ -135,8 +165,16 @@ export const ENTITIES: Record<string, EntityConfig> = {
       tipo_categoria: true, cor: true, km: true, cambio: true,
       combustivel: true, identificador: true, is_active: true, created_at: true,
       specialist: { select: { name: true, surname: true } },
+      images: imagemDeCapa,
     },
     columns: [
+      {
+        label: 'Imagem',
+        get: capa,
+        image: true,
+        imageSource: 's3-key',
+        alt: (r) => `Foto de ${[r.marca, r.modelo].filter(Boolean).join(' ') || 'produto'}`,
+      },
       { label: 'Marca', get: (r) => r.marca },
       { label: 'Modelo', get: (r) => r.modelo },
       { label: 'Ano', get: (r) => r.ano },
@@ -163,8 +201,16 @@ export const ENTITIES: Record<string, EntityConfig> = {
       motor: true, ano_motor: true, combustivel: true, identificador: true,
       is_active: true, created_at: true,
       specialist: { select: { name: true, surname: true } },
+      images: imagemDeCapa,
     },
     columns: [
+      {
+        label: 'Imagem',
+        get: capa,
+        image: true,
+        imageSource: 's3-key',
+        alt: (r) => `Foto de ${[r.marca, r.modelo].filter(Boolean).join(' ') || 'produto'}`,
+      },
       { label: 'Marca', get: (r) => r.marca },
       { label: 'Modelo', get: (r) => r.modelo },
       { label: 'Ano', get: (r) => r.ano },
@@ -192,8 +238,16 @@ export const ENTITIES: Record<string, EntityConfig> = {
       tipo_aeronave: true, categoria: true, assentos: true,
       identificador: true, is_active: true, created_at: true,
       specialist: { select: { name: true, surname: true } },
+      images: imagemDeCapa,
     },
     columns: [
+      {
+        label: 'Imagem',
+        get: capa,
+        image: true,
+        imageSource: 's3-key',
+        alt: (r) => `Foto de ${[r.marca, r.modelo].filter(Boolean).join(' ') || 'produto'}`,
+      },
       { label: 'Marca', get: (r) => r.marca },
       { label: 'Modelo', get: (r) => r.modelo },
       { label: 'Ano', get: (r) => r.ano },

--- a/backend/src/features/admin-database/admin-database.service.spec.ts
+++ b/backend/src/features/admin-database/admin-database.service.spec.ts
@@ -657,3 +657,103 @@ describe('AdminDatabaseService — contratos', () => {
     expect(result.data[0][col(result.columns, 'Processo')]).toBe('João Silva');
   });
 });
+
+describe('AdminDatabaseService — imagem dos produtos', () => {
+  const carro = {
+    id: 'car-1',
+    marca: 'Porsche',
+    modelo: '911',
+    images: [{ image_url: 'cars/car-1/foto-principal.jpg' }],
+  };
+
+  async function listarProdutos(
+    entidade: 'cars' | 'boats' | 'aircrafts',
+    row: any,
+    s3 = mkS3(),
+  ) {
+    const model = { cars: 'car', boats: 'boat', aircrafts: 'aircraft' }[
+      entidade
+    ];
+    const prisma = mkPrisma({
+      [model]: {
+        count: jest.fn().mockResolvedValue(1),
+        findMany: jest.fn().mockResolvedValue([row]),
+      },
+    });
+    return {
+      prisma,
+      s3,
+      result: await mkSvc(prisma, s3).list(entidade, 1, 20),
+    };
+  }
+
+  it.each(['cars', 'boats', 'aircrafts'] as const)(
+    '%s expõe a coluna Imagem com a URL assinada',
+    async (entidade) => {
+      const { s3, result } = await listarProdutos(entidade, carro);
+
+      expect(result.data[0][col(result.columns, 'Imagem')]).toEqual({
+        kind: 'image',
+        url: 'https://s3.example/assinada',
+        alt: 'Foto de Porsche 911',
+      });
+      // A key do produto é assinada direto, sem a heurística de `companies/`
+      // que vale para logo de escritório.
+      expect(s3.getSignedUrl).toHaveBeenCalledWith(
+        'cars/car-1/foto-principal.jpg',
+      );
+    },
+  );
+
+  // Critério de aceite: a principal é preferida, senão a primeira disponível.
+  // A escolha é feita no banco — o serviço só lê images[0].
+  it('pede ao banco a principal primeiro e só uma imagem', async () => {
+    const { prisma } = await listarProdutos('cars', carro);
+
+    const { select } = prisma.car.findMany.mock.calls[0][0];
+    expect(select.images).toEqual({
+      select: { image_url: true },
+      orderBy: [{ is_primary: 'desc' }, { created_at: 'asc' }],
+      take: 1,
+    });
+  });
+
+  it('produto sem imagem devolve célula vazia sem chamar o S3', async () => {
+    const { s3, result } = await listarProdutos('cars', {
+      ...carro,
+      images: [],
+    });
+
+    expect(result.data[0][col(result.columns, 'Imagem')]).toEqual({
+      kind: 'image',
+      url: null,
+      alt: 'Foto de Porsche 911',
+    });
+    expect(s3.getSignedUrl).not.toHaveBeenCalled();
+  });
+
+  it('S3 fora do ar não derruba a listagem', async () => {
+    const s3 = {
+      getSignedUrl: jest.fn().mockRejectedValue(new Error('S3 fora do ar')),
+    } as any;
+    const { result } = await listarProdutos('cars', carro, s3);
+
+    expect(result.data[0][col(result.columns, 'Imagem')]).toMatchObject({
+      kind: 'image',
+      url: null,
+    });
+    // as demais colunas seguem preenchidas
+    expect(result.data[0][col(result.columns, 'Marca')]).toBe('Porsche');
+  });
+
+  it('alt não quebra quando o produto está sem marca e modelo', async () => {
+    const { result } = await listarProdutos('cars', {
+      id: 'car-2',
+      images: [{ image_url: 'cars/car-2/foto.jpg' }],
+    });
+
+    expect(result.data[0][col(result.columns, 'Imagem')]).toMatchObject({
+      alt: 'Foto de produto',
+    });
+  });
+});

--- a/backend/src/features/admin-database/admin-database.service.ts
+++ b/backend/src/features/admin-database/admin-database.service.ts
@@ -109,10 +109,16 @@ export class AdminDatabaseService {
         const raw = col.get(row);
 
         if (col.image) {
-          const key = typeof raw === 'string' ? raw : null;
+          const key = typeof raw === 'string' && raw ? raw : null;
           let url: string | null = null;
           try {
-            url = await resolveCompanyLogoUrl(this.s3, key);
+            // Imagem de produto guarda a key crua; logo de empresa passa pela
+            // heurística de prefixo, que descarta os logos legados em base64.
+            if (col.imageSource === 's3-key') {
+              url = key ? await this.s3.getSignedUrl(key) : null;
+            } else {
+              url = await resolveCompanyLogoUrl(this.s3, key);
+            }
           } catch {
             // célula feia (sem logo) é infinitamente melhor que uma página de 500.
           }


### PR DESCRIPTION
# Changelog

- Adiciona a coluna Imagem nas abas de Carros, Barcos e Aeronaves da Base de Dados;
- Prefere a imagem principal e cai para a primeira disponível quando não há principal;
- Permite que a célula de imagem assine keys do S3 sem o prefixo `companies/`;
- Adiciona 8 testes.

closes: [BE] TASK 3.11 — Exibir imagens dos produtos na Base de Dados administrativa

---

## A preferência é resolvida no banco

```ts
const imagemDeCapa = {
  select: { image_url: true },
  orderBy: [{ is_primary: 'desc' }, { created_at: 'asc' }],
  take: 1,
};
```

`is_primary desc` traz a principal primeiro; sem nenhuma marcada, `created_at asc` devolve a mais antiga — a "primeira disponível" do critério. O serviço só lê `images[0]`, sem ramificação em JavaScript.

`take: 1` importa: sem ele, uma listagem de 20 produtos arrastaria a galeria inteira de cada um só para mostrar uma miniatura.

## Por que a célula de imagem precisou mudar

O padrão de imagem já existia (logo de escritório), mas o resolvedor era específico: `resolveCompanyLogoUrl` só assina keys que começam com `companies/` — uma heurística deliberada, para descartar logos legados gravados em base64.

Key de imagem de produto não tem esse prefixo. Reaproveitar o resolvedor como estava deixaria **toda** imagem de produto como célula vazia, sem erro nenhum — o tipo de falha que passa despercebida.

Então a coluna ganhou `imageSource`:

| Valor | Comportamento |
|---|---|
| `'company-logo'` (padrão) | heurística de prefixo — comportamento do logo, inalterado |
| `'s3-key'` | assina a key direto |

Apesar do nome, `Car_image.image_url` guarda a key do S3, não uma URL — é assim que os endpoints de catálogo já a tratam (`cars.service.ts` faz `getSignedUrl(image.image_url)`).

## Frontend: nada a fazer

Confirmei antes de mexer. `DatabasePage.tsx` já renderiza `<img>` quando a célula tem `url`, e o `cellText` já converte imagem em `"Sim"` / `"—"` para CSV e PDF. Produto sem imagem devolve `url: null`, que é exatamente o caminho que o escritório sem logo já exercita hoje.

Ou seja, o terceiro critério de aceite (não quebrar listagem, CSV ou PDF) sai de graça pelo padrão existente — foi por isso que a task é `[BE]`.

## Testes

8 testes novos em `admin-database.service.spec.ts`, seguindo o helper `col()` que o arquivo já usa para não depender da ordem das colunas:

- as três abas expõem a coluna Imagem com a URL assinada, e a key vai ao S3 sem passar pela heurística de `companies/`;
- o `select` enviado ao Prisma pede a principal primeiro e uma imagem só (trava a regra na query, que é onde ela vive);
- produto sem imagem devolve `url: null` **sem chamar o S3**;
- S3 fora do ar não derruba a listagem — a célula fica vazia e as demais colunas seguem preenchidas;
- `alt` não quebra em produto sem marca e modelo (vira "Foto de produto").

Suíte completa: **329 passando**, 35 suítes, nada falhando. `nest build` passa.

## O que não foi verificado

Não abri a Base de Dados no navegador: exige backend, banco com produtos e imagens no S3, e sessão de admin. A verificação é unitária, com Prisma e S3 mockados.

O que vale conferir na revisão, e que os mocks não alcançam: se a miniatura (`h-8`, renderizada pelo frontend) fica legível para foto de produto — o tamanho foi escolhido para logo de escritório, que tem proporção diferente. Se ficar apertada, é ajuste de uma linha no `DatabasePage`.
