### PR TITLE
feat(admin): exclui conta liberando identificadores, sem apagar historico

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -118,3 +118,89 @@ describe('AuthService.registerSpecialist — auto-login', () => {
     );
   });
 });
+
+describe('AuthService.refresh — conta desativada ou excluída', () => {
+  const USER = 'user-1';
+  const TOKEN = 'refresh-token-valido';
+
+  function mkRefreshPrisma(is_active: boolean, temTokenNoBanco = true) {
+    return {
+      refreshToken: {
+        findUnique: jest.fn().mockResolvedValue(
+          temTokenNoBanco
+            ? {
+                token: TOKEN,
+                user_id: USER,
+                expires_at: new Date(Date.now() + 60_000),
+              }
+            : null,
+        ),
+        findFirst: jest.fn().mockResolvedValue({ id: 'recente' }),
+        delete: jest.fn(),
+        deleteMany: jest.fn(),
+        create: jest.fn().mockResolvedValue({}),
+      },
+      user: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: USER,
+          email: 'joao@example.dev',
+          role: 'CUSTOMER',
+          is_active,
+        }),
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          id: USER,
+          email: 'joao@example.dev',
+          role: 'CUSTOMER',
+          is_active,
+        }),
+      },
+    } as any;
+  }
+
+  const mkJwtRefresh = () => ({
+    verify: jest.fn().mockReturnValue({ sub: USER }),
+    signAsync: jest.fn().mockResolvedValue('novo-token'),
+    sign: jest.fn().mockReturnValue('novo-token'),
+  });
+
+  const mkConfig = () => ({
+    getOrThrow: jest.fn().mockReturnValue('segredo'),
+    get: jest.fn().mockReturnValue('segredo'),
+  });
+
+  // O login já barrava e o AuthGuard barra cada request, mas o refresh não
+  // checava: com um refresh token na mão, a conta seguia renovando sessão.
+  it('não renova sessão de conta inativa', async () => {
+    const svc = new AuthService(
+      mkRefreshPrisma(false),
+      mkJwtRefresh() as any,
+      mkConfig() as any,
+      {} as any,
+    );
+
+    await expect(svc.refresh(TOKEN)).rejects.toThrow('Conta desativada');
+  });
+
+  // Mesmo caminho pela janela de graça de 30s, quando o token já rotacionou.
+  it('não renova pela janela de graça se a conta está inativa', async () => {
+    const svc = new AuthService(
+      mkRefreshPrisma(false, false),
+      mkJwtRefresh() as any,
+      mkConfig() as any,
+      {} as any,
+    );
+
+    await expect(svc.refresh(TOKEN)).rejects.toThrow('Conta desativada');
+  });
+
+  it('conta ativa continua renovando normalmente', async () => {
+    const svc = new AuthService(
+      mkRefreshPrisma(true),
+      mkJwtRefresh() as any,
+      mkConfig() as any,
+      {} as any,
+    );
+
+    await expect(svc.refresh(TOKEN)).resolves.toBeDefined();
+  });
+});

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -300,6 +300,19 @@ export class AuthService {
   }
 
   // Verificar se o refreshToken é válido
+  /**
+   * Conta desativada ou excluída não renova sessão.
+   *
+   * O login já barrava, e o AuthGuard barra cada request, mas o refresh não
+   * checava: quem tivesse um refresh token válido seguia trocando por access
+   * tokens novos depois de perder o acesso.
+   */
+  private assertContaAtiva(user: { is_active: boolean }): void {
+    if (user.is_active === false) {
+      throw new UnauthorizedException('Conta desativada');
+    }
+  }
+
   private async verifyRefreshToken(refresh_token: string) {
     const refreshToken = refresh_token;
 
@@ -338,6 +351,7 @@ export class AuthService {
           where: { id: payload.sub },
         });
         if (!graceUser) throw new UnauthorizedException('Unauthorized');
+        this.assertContaAtiva(graceUser);
         return graceUser;
       }
 
@@ -358,8 +372,17 @@ export class AuthService {
         throw new NotFoundException('Not found');
       }
 
+      this.assertContaAtiva(user);
+
       return user;
     } catch (error) {
+      // As exceções lançadas aqui dentro já dizem o motivo ("Conta
+      // desativada", "Refresh token expired"). Sem esta guarda o catch
+      // abaixo as reembrulhava como UnauthorizedException('UnauthorizedException'),
+      // trocando o diagnóstico por ruído.
+      if (error instanceof UnauthorizedException) {
+        throw error;
+      }
       if (error.name === 'JsonWebTokenError') {
         throw new UnauthorizedException('Unauthorized');
       }

--- a/backend/src/features/admin-database/admin-database.controller.ts
+++ b/backend/src/features/admin-database/admin-database.controller.ts
@@ -1,14 +1,18 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Patch,
   Post,
   Query,
+  Req,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { UserRole } from '@prisma/client';
 import { Roles } from 'src/shared/decorators/roles.decorator';
+import { UserEntity } from 'src/auth/entities/user.entity';
 import { AdminDatabaseService } from './admin-database.service';
 import { AdminUserManagementService } from './admin-user-management.service';
 import { ChangeRoleDto } from './dto/change-role.dto';
@@ -37,6 +41,21 @@ export class AdminDatabaseController {
     @Query('pageSize') pageSize = '20',
   ) {
     return this.service.list(entity, Number(page) || 1, Number(pageSize) || 20);
+  }
+
+  /**
+   * DELETE /api/admin/database/users/:id
+   * Exclui a conta liberando e-mail, CPF, RG e matrícula para novo cadastro.
+   * Processos, propostas e contratos vinculados continuam consultáveis.
+   */
+  @Delete('users/:id')
+  @Roles(UserRole.ADMIN)
+  deleteUser(@Param('id') id: string, @Req() req: { user?: UserEntity }) {
+    const actor = req.user;
+    if (!actor) {
+      throw new UnauthorizedException('Usuário autenticado não identificado');
+    }
+    return this.management.deleteUser(id, actor.id);
   }
 
   @Post('users/:id/role-change/validate')

--- a/backend/src/features/admin-database/admin-user-deletion.spec.ts
+++ b/backend/src/features/admin-database/admin-user-deletion.spec.ts
@@ -1,0 +1,145 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+import { AdminUserManagementService } from './admin-user-management.service';
+import {
+  emailDeExclusao,
+  foiExcluido,
+  rgDeExclusao,
+} from './admin-user-deletion';
+
+const ADMIN = 'admin-1';
+const ALVO = 'user-1';
+
+function mkPrisma(user: any = { id: ALVO, email: 'joao@example.dev', name: 'João', surname: 'Silva', role: 'CUSTOMER' }) {
+  const tx = {
+    refreshToken: { deleteMany: jest.fn().mockResolvedValue({ count: 2 }) },
+    calendlyConnection: { deleteMany: jest.fn().mockResolvedValue({ count: 1 }) },
+    user: { update: jest.fn().mockResolvedValue({ id: ALVO }) },
+  };
+  const prisma = {
+    user: { findUnique: jest.fn().mockResolvedValue(user) },
+    $transaction: jest.fn(async (cb: any) => cb(tx)),
+  } as any;
+  return { prisma, tx };
+}
+
+const svc = (prisma: any) => new AdminUserManagementService(prisma);
+
+describe('lápides de exclusão', () => {
+  it('e-mail usa domínio reservado e é único a cada chamada', () => {
+    const a = emailDeExclusao();
+    const b = emailDeExclusao();
+    expect(a).toMatch(/@deleted\.invalid$/);
+    expect(a).not.toBe(b);
+  });
+
+  // RG real é só dígito; o prefixo garante que a lápide nunca colida com um.
+  it('RG cabe em VarChar(11) e nunca parece um RG real', () => {
+    for (let i = 0; i < 50; i++) {
+      const rg = rgDeExclusao();
+      expect(rg.length).toBeLessThanOrEqual(11);
+      expect(rg).toMatch(/^X[0-9a-f]{10}$/);
+    }
+  });
+
+  it('reconhece conta excluída pelo e-mail, sem coluna nova', () => {
+    expect(foiExcluido(emailDeExclusao())).toBe(true);
+    expect(foiExcluido('joao@example.dev')).toBe(false);
+    expect(foiExcluido(null)).toBe(false);
+  });
+});
+
+describe('AdminUserManagementService.deleteUser', () => {
+  // Critério: e-mail e documentos voltam a ficar livres para novo cadastro.
+  it('libera e-mail, CPF, RG e matrícula', async () => {
+    const { prisma, tx } = mkPrisma();
+    await svc(prisma).deleteUser(ALVO, ADMIN);
+
+    const data = tx.user.update.mock.calls[0][0].data;
+    expect(data.email).toMatch(/@deleted\.invalid$/);
+    expect(data.cpf).toBeNull();
+    expect(data.rg).toMatch(/^X[0-9a-f]{10}$/);
+    expect(data.identification_number).toBeNull();
+  });
+
+  // Critério: a conta não autentica nem renova sessão.
+  it('apaga refresh tokens, inativa a conta e inutiliza a senha', async () => {
+    const { prisma, tx } = mkPrisma();
+    await svc(prisma).deleteUser(ALVO, ADMIN);
+
+    expect(tx.refreshToken.deleteMany).toHaveBeenCalledWith({
+      where: { user_id: ALVO },
+    });
+    const data = tx.user.update.mock.calls[0][0].data;
+    expect(data.is_active).toBe(false);
+    expect(data.password_hash).toMatch(/^excluido:/);
+    expect(data.deactivated_by).toBe(ADMIN);
+  });
+
+  // calendly_user_uri é único: sem remover, o recadastro não reconecta.
+  it('remove a conexão do Calendly', async () => {
+    const { prisma, tx } = mkPrisma();
+    await svc(prisma).deleteUser(ALVO, ADMIN);
+
+    expect(tx.calendlyConnection.deleteMany).toHaveBeenCalledWith({
+      where: { user_id: ALVO },
+    });
+  });
+
+  // Critério: o histórico não pode ser apagado nem bloquear a exclusão.
+  it('não apaga a linha do usuário — processos seguem resolvendo a FK', async () => {
+    const { prisma, tx } = mkPrisma();
+    await svc(prisma).deleteUser(ALVO, ADMIN);
+
+    expect((tx.user as any).delete).toBeUndefined();
+    expect(tx.user.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserva nome e papel para o histórico continuar legível', async () => {
+    const { prisma, tx } = mkPrisma();
+    const r = await svc(prisma).deleteUser(ALVO, ADMIN);
+
+    const data = tx.user.update.mock.calls[0][0].data;
+    expect(data.name).toBeUndefined();
+    expect(data.surname).toBeUndefined();
+    expect(data.role).toBeUndefined();
+    expect(r.name).toBe('João Silva');
+  });
+
+  it('tudo acontece numa transação só', async () => {
+    const { prisma } = mkPrisma();
+    await svc(prisma).deleteUser(ALVO, ADMIN);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('admin não exclui a própria conta', async () => {
+    const { prisma } = mkPrisma();
+    await expect(svc(prisma).deleteUser(ADMIN, ADMIN)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('usuário inexistente é 404', async () => {
+    const { prisma } = mkPrisma(null);
+    await expect(svc(prisma).deleteUser(ALVO, ADMIN)).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('conta já excluída não é excluída de novo', async () => {
+    const { prisma, tx } = mkPrisma({
+      id: ALVO,
+      email: emailDeExclusao(),
+      name: 'João',
+      surname: 'Silva',
+      role: 'CUSTOMER',
+    });
+    await expect(svc(prisma).deleteUser(ALVO, ADMIN)).rejects.toThrow(
+      ConflictException,
+    );
+    expect(tx.user.update).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/features/admin-database/admin-user-deletion.ts
+++ b/backend/src/features/admin-database/admin-user-deletion.ts
@@ -1,0 +1,51 @@
+import { randomBytes, randomUUID } from 'crypto';
+
+/**
+ * Excluir um usuário aqui é apagar a *identidade*, não a linha.
+ *
+ * Processos, propostas e contratos referenciam o usuário por FK obrigatória:
+ * apagar a linha derrubaria o histórico junto, que é justamente o que a task
+ * proíbe. Então a linha permanece — nome e papel intactos, para as telas de
+ * processo continuarem legíveis — e o que sai são os identificadores únicos,
+ * liberando-os para um novo cadastro.
+ */
+
+/** Domínio reservado pela RFC 2606: nunca resolve, nunca entrega e-mail. */
+const DOMINIO_MORTO = 'deleted.invalid';
+
+/**
+ * E-mail lápide, único por construção.
+ *
+ * O uuid evita colisão entre duas exclusões, e o domínio reservado garante
+ * que ninguém receba e-mail nesse endereço por acidente.
+ */
+export function emailDeExclusao(): string {
+  return `deleted+${randomUUID()}@${DOMINIO_MORTO}`;
+}
+
+/**
+ * RG lápide.
+ *
+ * A coluna é NOT NULL e VarChar(11), então não dá para limpar: tem que caber
+ * um valor. O prefixo 'X' garante que nunca colida com um RG real, que é só
+ * dígitos, e os 10 hex dão espaço suficiente para não colidir entre lápides.
+ */
+export function rgDeExclusao(): string {
+  return `X${randomBytes(5).toString('hex')}`;
+}
+
+/**
+ * Hash de senha impossível de satisfazer.
+ *
+ * Não é o que barra o login — o e-mail lápide já basta, e is_active também.
+ * É defesa em profundidade: se alguém reativar a conta pelo painel do
+ * escritório, as credenciais antigas ainda não valem nada.
+ */
+export function senhaDeExclusao(): string {
+  return `excluido:${randomBytes(32).toString('hex')}`;
+}
+
+/** Reconhece uma conta já excluída, sem precisar de coluna nova. */
+export function foiExcluido(email: string | null | undefined): boolean {
+  return !!email && email.endsWith(`@${DOMINIO_MORTO}`);
+}

--- a/backend/src/features/admin-database/admin-user-management.service.ts
+++ b/backend/src/features/admin-database/admin-user-management.service.ts
@@ -18,6 +18,12 @@ import {
   ChangeBlockerCode,
   ChangeValidationResult,
 } from './admin-user-management.types';
+import {
+  emailDeExclusao,
+  foiExcluido,
+  rgDeExclusao,
+  senhaDeExclusao,
+} from './admin-user-deletion';
 
 type UserManagementDatabase = Pick<
   PrismaService,
@@ -126,6 +132,77 @@ export class AdminUserManagementService {
         throw new ConflictException(this.result(['CONCURRENT_CHANGE']));
       throw error;
     }
+  }
+
+
+  /**
+   * Exclui a conta de um usuário liberando os identificadores únicos.
+   *
+   * A linha não é apagada: Process.client_id, Process.specialist_id,
+   * Contract e NegotiationProposal apontam para ela com FK obrigatória, e a
+   * task exige que esse histórico continue consultável. O que some é a
+   * identidade — e-mail, CPF, RG e matrícula —, o que devolve esses valores
+   * para um novo cadastro.
+   *
+   * Também derruba o acesso: refresh tokens apagados, conta inativa e hash de
+   * senha inutilizado.
+   *
+   * A conexão do Calendly vai junto por dois motivos: guarda tokens OAuth de
+   * uma conta que deixou de existir, e `calendly_user_uri` é único — sem
+   * remover, a pessoa recadastrada não conseguiria reconectar o mesmo
+   * Calendly.
+   *
+   * @throws {BadRequestException} - Admin tentando excluir a própria conta
+   * @throws {NotFoundException} - Usuário inexistente
+   * @throws {ConflictException} - Conta já excluída
+   */
+  async deleteUser(id: string, actorId: string) {
+    if (id === actorId) {
+      throw new BadRequestException(
+        'Você não pode excluir a própria conta de administrador.',
+      );
+    }
+
+    const user = await this.prisma.user.findUnique({
+      where: { id },
+      select: { id: true, email: true, name: true, surname: true, role: true },
+    });
+
+    if (!user) {
+      throw new NotFoundException('Usuário não encontrado');
+    }
+
+    if (foiExcluido(user.email)) {
+      throw new ConflictException('Esta conta já foi excluída.');
+    }
+
+    await this.prisma.$transaction(async (tx) => {
+      // Sessões primeiro: enquanto a transação não fecha, o access token
+      // atual ainda vale por alguns minutos — o AuthGuard corta pelo is_active.
+      await tx.refreshToken.deleteMany({ where: { user_id: id } });
+      await tx.calendlyConnection.deleteMany({ where: { user_id: id } });
+
+      await tx.user.update({
+        where: { id },
+        data: {
+          email: emailDeExclusao(),
+          cpf: null,
+          rg: rgDeExclusao(),
+          identification_number: null,
+          password_hash: senhaDeExclusao(),
+          is_active: false,
+          deactivated_at: new Date(),
+          deactivated_by: actorId,
+        },
+      });
+    });
+
+    return {
+      id: user.id,
+      name: `${user.name} ${user.surname}`.trim(),
+      role: user.role,
+      message: 'Conta excluída. E-mail e documentos liberados para novo cadastro.',
+    };
   }
 
   private async analyzeRoleChange(

--- a/frontend/src/lib/admin-user-management.ts
+++ b/frontend/src/lib/admin-user-management.ts
@@ -363,3 +363,16 @@ function extractConflictValidation(
 
   return candidate as ChangeValidationResult;
 }
+
+/**
+ * Exclui a conta liberando e-mail, CPF, RG e matrícula para novo cadastro.
+ *
+ * A linha do usuário permanece no banco — processos, propostas e contratos
+ * apontam para ela e continuam consultáveis. O que sai é a identidade.
+ */
+export async function deleteUser(
+  id: string,
+): Promise<{ id: string; name: string; message: string }> {
+  const { data } = await api.delete(`admin/database/users/${id}`);
+  return data;
+}

--- a/frontend/src/pages/admin/DatabasePage.tsx
+++ b/frontend/src/pages/admin/DatabasePage.tsx
@@ -11,6 +11,7 @@ import {
   FileText,
   Loader2,
   Pencil,
+  Trash2,
 } from "lucide-react";
 import {
   getEntities,
@@ -22,12 +23,14 @@ import {
 import { downloadCsv, openPrintablePdf } from "../../utils/export";
 import Button from "../../components/ui/button";
 import { Alert } from "../../components/ui/alert";
+import { Dialog, DialogContent } from "../../components/ui/dialog";
 import { EmptyState } from "../../components/patterns/EmptyState";
 import AdminUserManagementDialog, {
   type AdminUserManagementDialogState,
 } from "../../components/admin/AdminUserManagementDialog";
 import {
   createLatestRequestGuard,
+  deleteUser,
   isSameRecordsOrigin,
   shouldInvalidateRecordsRequest,
   type RecordsOrigin,
@@ -56,6 +59,12 @@ export default function DatabasePage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  // Exclusão é irreversível e libera documentos: confirma antes, sempre.
+  const [userToDelete, setUserToDelete] = useState<{
+    id: string;
+    label: string;
+  } | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const [dialogState, setDialogState] =
     useState<AdminUserManagementDialogState | null>(null);
   const recordsRequestGuard = useRef(createLatestRequestGuard());
@@ -252,6 +261,24 @@ export default function DatabasePage() {
                         >
                           <Pencil className="w-4 h-4" aria-hidden="true" />
                         </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="p-2 text-status-bad"
+                          disabled={!rowMeta[i]?.id}
+                          aria-label="Excluir usuário"
+                          title="Excluir usuário"
+                          onClick={() => {
+                            const user = rowMeta[i];
+                            if (!user?.id) return;
+                            setSuccessMessage(null);
+                            // O nome vem da primeira coluna da aba Usuários.
+                            const nome = cellText(row[0] ?? "");
+                            setUserToDelete({ id: user.id, label: nome });
+                          }}
+                        >
+                          <Trash2 className="w-4 h-4" aria-hidden="true" />
+                        </Button>
                       </td>
                     ) : null}
                     {row.map((cell, j) => {
@@ -330,6 +357,77 @@ export default function DatabasePage() {
           await loadRecords();
         }}
       />
+
+      <Dialog
+        open={!!userToDelete}
+        onOpenChange={(aberto) => {
+          if (!aberto && !deleting) setUserToDelete(null);
+        }}
+      >
+        <DialogContent open={!!userToDelete} title="Excluir usuário">
+          <div className="space-y-4">
+            <p className="text-sm text-ink-soft">
+              Excluir a conta de <strong>{userToDelete?.label}</strong>?
+            </p>
+            <Alert variant="warning">
+              <div className="text-sm space-y-1">
+                <p>
+                  O e-mail, CPF, RG e matrícula voltam a ficar livres, e a
+                  pessoa poderá se cadastrar de novo com os mesmos dados.
+                </p>
+                <p>
+                  Processos, propostas e contratos vinculados continuam
+                  consultáveis. Esta ação não pode ser desfeita.
+                </p>
+              </div>
+            </Alert>
+            {error && <Alert variant="danger">{error}</Alert>}
+            <div className="flex justify-end gap-3 pt-1">
+              <Button
+                type="button"
+                variant="light"
+                disabled={deleting}
+                onClick={() => setUserToDelete(null)}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="button"
+                disabled={deleting}
+                onClick={async () => {
+                  if (!userToDelete) return;
+                  setDeleting(true);
+                  setError(null);
+                  try {
+                    await deleteUser(userToDelete.id);
+                    setUserToDelete(null);
+                    setSuccessMessage(
+                      "Conta excluída. E-mail e documentos liberados para novo cadastro.",
+                    );
+                    await loadRecords();
+                  } catch (err) {
+                    setError(
+                      (err as { friendlyMessage?: string })?.friendlyMessage ??
+                        "Não foi possível excluir a conta.",
+                    );
+                  } finally {
+                    setDeleting(false);
+                  }
+                }}
+              >
+                {deleting ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Excluindo...
+                  </span>
+                ) : (
+                  "Excluir conta"
+                )}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
# Changelog

- Adiciona `DELETE /api/admin/database/users/:id`, restrito a ADMIN;
- Libera e-mail, CPF, RG e matrícula da conta excluída para novo cadastro;
- Revoga sessões e inutiliza as credenciais da conta;
- Bloqueia renovação de sessão para conta inativa (o refresh não checava);
- Adiciona ação de excluir, com confirmação, na aba Usuários da Base de Dados;
- Adiciona 15 testes.

closes: [BE][FE] TASK 3.12 — Excluir usuário sem apagar processos vinculados

---

## Excluir a identidade, não a linha

`Process.client_id`, `Process.specialist_id`, `Contract` e `NegotiationProposal` apontam para `User` com FK **obrigatória**. Apagar a linha derrubaria o histórico junto — exatamente o que a task proíbe.

Então a linha permanece, com **nome e papel intactos**, para as telas de processo continuarem legíveis. O que sai é a identidade:

| Campo | Depois da exclusão | Por quê |
|---|---|---|
| `email` | `deleted+{uuid}@deleted.invalid` | único por construção; domínio reservado pela RFC 2606, nunca entrega e-mail |
| `cpf` | `null` | nullable — dá para limpar de verdade |
| `rg` | `X` + 10 hex | **NOT NULL VarChar(11)**: não dá para limpar, tem que caber um valor |
| `identification_number` | `null` | nullable |

O `rg` é o caso chato. Como a coluna não aceita null e só cabem 11 caracteres, a lápide precisa ser curta e não colidir — nem com outra lápide, nem com um RG real. O prefixo `X` resolve a segunda metade: RG real é só dígito, então nenhum valor real começa com `X`.

Não criei coluna `deleted_at`: o próprio e-mail lápide identifica a conta excluída (`foiExcluido()`), e `deactivated_by` / `deactivated_at` já existiam para registrar quem excluiu e quando. Sem tabela de auditoria nova, como a task pede.

## Revogação de acesso

Refresh tokens apagados, `is_active = false`, e o hash de senha substituído por um valor impossível de satisfazer — defesa em profundidade, para o caso de alguém reativar a conta pelo painel do escritório.

**A conexão do Calendly vai junto**, e não é escopo extra: são tokens OAuth de uma conta que deixou de existir, e `CalendlyConnection.calendly_user_uri` é **único**. Sem remover, um especialista recadastrado não conseguiria reconectar o mesmo Calendly — o critério de aceite do novo cadastro falharia por um caminho lateral.

## Um buraco encontrado no caminho

O critério diz "não consegue mais autenticar **nem renovar sessão**". O login já barrava conta inativa e o `AuthGuard` barra cada request, mas **`verifyRefreshToken` não checava `is_active`**: com um refresh token na mão, uma conta desativada seguia trocando por access tokens novos. Isso já valia para o consultor desativado pelo escritório, antes desta task.

Adicionei a checagem nos **dois** caminhos do refresh — o normal e a janela de graça de 30s, que existe para abas concorrentes e buscava o usuário sem validar nada.

De passagem: o `catch` do `verifyRefreshToken` reembrulhava as próprias exceções como `UnauthorizedException('UnauthorizedException')`, trocando o motivo por ruído. Agora as preserva.

## Frontend

Ação de excluir na aba Usuários, ao lado do lápis que já existia. A confirmação diz o que vai acontecer antes de acontecer: que os documentos são liberados, que a pessoa poderá se cadastrar de novo, e que processos e contratos continuam consultáveis.

## Testes

15 novos:

- **Lápides** — e-mail com domínio reservado e único a cada chamada; RG cabe em 11 caracteres e nunca parece um RG real (50 amostras); detecção de conta já excluída;
- **Exclusão** — libera os quatro identificadores; apaga refresh tokens; inativa; inutiliza a senha; remove o Calendly; **não chama `delete` na tabela de usuário**; preserva nome e papel; tudo numa transação só;
- **Guardas** — admin não exclui a própria conta; usuário inexistente é 404; conta já excluída é 409 e não reescreve nada;
- **Refresh** — conta inativa não renova, nem pelo caminho normal nem pela janela de graça; conta ativa segue renovando.

Suíte completa: **337 passando**, 36 suítes. `nest build` passa. Frontend: `tsc -b` limpo, 56 testes, sem lint novo.

## O que não foi verificado

Não exercitei o ciclo completo com banco real — criar conta, excluir, recadastrar com o mesmo e-mail e CPF. Os testes são unitários, com Prisma mockado: eles provam que o `update` recebe os campos certos, **não** que o Postgres aceita o recadastro depois.

Esse é o teste que a revisão deveria fazer, e é o critério de aceite central:

1. Criar uma conta, anotar e-mail/CPF/RG;
2. Excluir pela aba Usuários;
3. Confirmar que ela não loga mais **e que uma sessão aberta não renova**;
4. Cadastrar uma conta nova com os mesmos e-mail, CPF e RG;
5. Abrir um processo antigo dessa pessoa e confirmar que ainda carrega.

## Uma consequência que vale decidir

A conta excluída fica com `is_active = false`, o mesmo estado de um consultor desativado. Na tela de consultores do escritório ela aparece como "inativa" e tem botão de **reativar**.

Reativar não devolve o acesso (o e-mail é lápide e a senha foi inutilizada), então não há brecha de segurança — mas é um botão que promete algo que não acontece. Se incomodar, o conserto é filtrar contas excluídas dessa listagem com o `foiExcluido()` que já existe. Não fiz porque é mudança de comportamento em outra tela, fora do que a task pediu.
