### PR TITLE
feat(produtos): tipo/classificacao especifica aceita valor livre

### DIFF
--- a/backend/src/features/product-free-type.spec.ts
+++ b/backend/src/features/product-free-type.spec.ts
@@ -1,0 +1,70 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateCarDto } from './cars/dto/create-car.dto';
+import { UpdateCarDto } from './cars/dto/update-car.dto';
+import { CreateBoatDto } from './boats/dto/create-boat.dto';
+import { CreateAircraftDto } from './aircrafts/dto/create-aircraft.dto';
+
+/**
+ * Critério de aceite: a API aceita tipo/classificação fora da lista sugerida.
+ *
+ * O tipo específico de produto é texto livre — existem produtos fora das
+ * classificações previstas, e travar a validação impediria o cadastro. Este
+ * spec existe para que ninguém "conserte" isso reintroduzindo um @IsIn.
+ */
+async function errosDe(cls: any, payload: Record<string, unknown>) {
+  return validate(plainToInstance(cls, payload), {
+    skipMissingProperties: true,
+  });
+}
+
+const erroNoCampo = (erros: any[], campo: string) =>
+  erros.some((e) => e.property === campo);
+
+describe('tipo de produto livre', () => {
+  it.each([
+    ['anfíbio', 'carro anfíbio, fora da lista'],
+    ['hot rod', 'com espaço'],
+    ['Fórmula 1', 'com acento e número'],
+  ])('CreateCarDto aceita tipo_categoria "%s" (%s)', async (valor) => {
+    const erros = await errosDe(CreateCarDto, { tipo_categoria: valor });
+    expect(erroNoCampo(erros, 'tipo_categoria')).toBe(false);
+  });
+
+  it('UpdateCarDto também aceita — a edição não pode ser mais restrita', async () => {
+    const erros = await errosDe(UpdateCarDto, { tipo_categoria: 'anfíbio' });
+    expect(erroNoCampo(erros, 'tipo_categoria')).toBe(false);
+  });
+
+  it('CreateBoatDto aceita tipo_embarcacao fora da lista', async () => {
+    const erros = await errosDe(CreateBoatDto, {
+      tipo_embarcacao: 'traineira',
+    });
+    expect(erroNoCampo(erros, 'tipo_embarcacao')).toBe(false);
+  });
+
+  it('CreateAircraftDto aceita tipo_aeronave e categoria fora da lista', async () => {
+    const erros = await errosDe(CreateAircraftDto, {
+      tipo_aeronave: 'dirigível',
+      categoria: 'Agrícola',
+    });
+    expect(erroNoCampo(erros, 'tipo_aeronave')).toBe(false);
+    expect(erroNoCampo(erros, 'categoria')).toBe(false);
+  });
+
+  // Livre não é "aceita qualquer coisa": continua sendo texto.
+  it('rejeita valor que não é texto', async () => {
+    const erros = await errosDe(CreateCarDto, { tipo_categoria: 42 });
+    expect(erroNoCampo(erros, 'tipo_categoria')).toBe(true);
+  });
+
+  // Os valores sugeridos seguem válidos — nada foi quebrado ao abrir.
+  it.each(['SUV', 'sedan', 'coupe', 'conversivel', 'esportivo', 'supercarro'])(
+    'sugestão "%s" continua aceita',
+    async (valor) => {
+      const erros = await errosDe(CreateCarDto, { tipo_categoria: valor });
+      expect(erroNoCampo(erros, 'tipo_categoria')).toBe(false);
+    },
+  );
+});

--- a/backend/src/shared/dto/filters.dto.ts
+++ b/backend/src/shared/dto/filters.dto.ts
@@ -2,14 +2,11 @@
 //Carro
 // Substituto do tipo ENUM nos postgres
 export type estadoValues = ['novo', 'seminovo', 'colecao'];
-export type tipoCategoriaCarValues = [
-  'SUV',
-  'sedan',
-  'coupe',
-  'conversivel',
-  'esportivo',
-  'supercarro',
-];
+// Tipo/classificação específica é texto livre — o especialista pode cadastrar
+// um tipo fora da lista. As listas antigas viram sugestão no formulário, não
+// restrição de tipo. (Eram tuplas, não uniões: o campo acabava tipado como um
+// array de 6 posições, que nunca correspondeu ao valor real.)
+export type tipoCategoriaCarValues = string;
 export type cambioCarValues = ['manual', 'automatico', 'cvt'];
 export type combustivelCarValues = [
   'gasolina',
@@ -63,14 +60,7 @@ export type combustivelBoatValues = [
   'eletrico',
   'hibrido',
 ];
-export type tipoEmbarcacaoBoatValues = [
-  'iate',
-  'lancha',
-  'catamara',
-  'veleiro',
-  'jet_boat',
-  'outro',
-];
+export type tipoEmbarcacaoBoatValues = string;
 export type tamanhoBoatValues = ['ate_30_pes', '30_50_pes', 'acima_50_pes'];
 export class FiltersBoatMeta {
   marca?: string;
@@ -109,13 +99,7 @@ export class RangeBoatFilters {
 }
 
 // Aeronaves
-export type tipoAeronaveValues = [
-  'VLJ',
-  'executivo_medio',
-  'intercontinental',
-  'turbohelice',
-  'helicoptero',
-];
+export type tipoAeronaveValues = string;
 export class FiltersAircraftMeta {
   marca?: string;
   modelo?: string;

--- a/frontend/src/components/specialist/AircraftFields.tsx
+++ b/frontend/src/components/specialist/AircraftFields.tsx
@@ -1,3 +1,4 @@
+import TipoComSugestoes from "./TipoComSugestoes";
 import type { UseFormRegister, FieldErrors } from "react-hook-form";
 
 interface AircraftFieldsProps {
@@ -8,26 +9,18 @@ interface AircraftFieldsProps {
 export default function AircraftFields({ register, errors }: AircraftFieldsProps) {
   return (
     <>
-      {/* Categoria */}
-      <div className="flex flex-col gap-2">
-        <label htmlFor="categoria" className="text-sm font-medium text-text-primary">
-          Categoria
-        </label>
-        <select
-          id="categoria"
-          {...register("categoria")}
-          className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="">Selecione a categoria</option>
-          <option value="Executivo">Executivo</option>
-          <option value="Particular">Particular</option>
-          <option value="Comercial">Comercial</option>
-          <option value="Utilitário">Utilitário</option>
-        </select>
-        {errors.categoria && (
-          <span className="text-sm text-red-500">{errors.categoria.message as string}</span>
-        )}
-      </div>
+      <TipoComSugestoes
+        id="categoria"
+        label="Categoria"
+        opcoes={[
+          { value: "Executivo", label: "Executivo" },
+          { value: "Particular", label: "Particular" },
+          { value: "Comercial", label: "Comercial" },
+          { value: "Utilitário", label: "Utilitário" },
+        ]}
+        registro={register("categoria")}
+        erro={errors.categoria?.message as string | undefined}
+      />
 
       {/* Assentos */}
       <div className="flex flex-col gap-2">
@@ -48,27 +41,19 @@ export default function AircraftFields({ register, errors }: AircraftFieldsProps
         )}
       </div>
 
-      {/* Tipo de Aeronave */}
-      <div className="flex flex-col gap-2">
-        <label htmlFor="tipo_aeronave" className="text-sm font-medium text-text-primary">
-          Tipo de Aeronave
-        </label>
-        <select
-          id="tipo_aeronave"
-          {...register("tipo_aeronave")}
-          className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="">Selecione o tipo</option>
-          <option value="VLJ">VLJ (Very Light Jet)</option>
-          <option value="executivo_medio">Executivo Médio</option>
-          <option value="intercontinental">Intercontinental</option>
-          <option value="turbohelice">Turboélice</option>
-          <option value="helicoptero">Helicóptero</option>
-        </select>
-        {errors.tipo_aeronave && (
-          <span className="text-sm text-red-500">{errors.tipo_aeronave.message as string}</span>
-        )}
-      </div>
+      <TipoComSugestoes
+        id="tipo_aeronave"
+        label="Tipo de Aeronave"
+        opcoes={[
+          { value: "VLJ", label: "VLJ (Very Light Jet)" },
+          { value: "executivo_medio", label: "Executivo Médio" },
+          { value: "intercontinental", label: "Intercontinental" },
+          { value: "turbohelice", label: "Turboélice" },
+          { value: "helicoptero", label: "Helicóptero" },
+        ]}
+        registro={register("tipo_aeronave")}
+        erro={errors.tipo_aeronave?.message as string | undefined}
+      />
 
       {/* Descrição */}
       <div className="flex flex-col gap-2 col-span-2">

--- a/frontend/src/components/specialist/BoatFields.tsx
+++ b/frontend/src/components/specialist/BoatFields.tsx
@@ -1,3 +1,4 @@
+import TipoComSugestoes from "./TipoComSugestoes";
 import type { UseFormRegister, FieldErrors } from "react-hook-form";
 
 interface BoatFieldsProps {
@@ -126,28 +127,20 @@ export default function BoatFields({ register, errors }: BoatFieldsProps) {
         )}
       </div>
 
-      {/* Tipo de Embarcação */}
-      <div className="flex flex-col gap-2">
-        <label htmlFor="tipo_embarcacao" className="text-sm font-medium text-text-primary">
-          Tipo de Embarcação
-        </label>
-        <select
-          id="tipo_embarcacao"
-          {...register("tipo_embarcacao")}
-          className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="">Selecione o tipo</option>
-          <option value="iate">Iate</option>
-          <option value="lancha">Lancha</option>
-          <option value="catamara">Catamarã</option>
-          <option value="veleiro">Veleiro</option>
-          <option value="jet_boat">Jet Boat</option>
-          <option value="outro">Outro</option>
-        </select>
-        {errors.tipo_embarcacao && (
-          <span className="text-sm text-red-500">{errors.tipo_embarcacao.message as string}</span>
-        )}
-      </div>
+      <TipoComSugestoes
+        id="tipo_embarcacao"
+        label="Tipo"
+        opcoes={[
+          { value: "iate", label: "Iate" },
+          { value: "lancha", label: "Lancha" },
+          { value: "catamara", label: "Catamarã" },
+          { value: "veleiro", label: "Veleiro" },
+          { value: "jet_boat", label: "Jet Boat" },
+          { value: "outro", label: "Outro" },
+        ]}
+        registro={register("tipo_embarcacao")}
+        erro={errors.tipo_embarcacao?.message as string | undefined}
+      />
 
       {/* Descrição Completa */}
       <div className="flex flex-col gap-2 col-span-2">

--- a/frontend/src/components/specialist/CarFields.tsx
+++ b/frontend/src/components/specialist/CarFields.tsx
@@ -1,3 +1,4 @@
+import TipoComSugestoes from "./TipoComSugestoes";
 import type { UseFormRegister, FieldErrors } from "react-hook-form";
 
 interface CarFieldsProps {
@@ -98,28 +99,20 @@ export default function CarFields({ register, errors }: CarFieldsProps) {
         )}
       </div>
 
-      {/* Tipo/Categoria */}
-      <div className="flex flex-col gap-2">
-        <label htmlFor="tipo_categoria" className="text-sm font-medium text-text-primary">
-          Tipo/Categoria
-        </label>
-        <select
-          id="tipo_categoria"
-          {...register("tipo_categoria")}
-          className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="">Selecione a categoria</option>
-          <option value="SUV">SUV</option>
-          <option value="sedan">Sedan</option>
-          <option value="coupe">Coupé</option>
-          <option value="conversivel">Conversível</option>
-          <option value="esportivo">Esportivo</option>
-          <option value="supercarro">Supercarro</option>
-        </select>
-        {errors.tipo_categoria && (
-          <span className="text-sm text-red-500">{errors.tipo_categoria.message as string}</span>
-        )}
-      </div>
+      <TipoComSugestoes
+        id="tipo_categoria"
+        label="Tipo/Categoria"
+        opcoes={[
+          { value: "SUV", label: "SUV" },
+          { value: "sedan", label: "Sedan" },
+          { value: "coupe", label: "Coupé" },
+          { value: "conversivel", label: "Conversível" },
+          { value: "esportivo", label: "Esportivo" },
+          { value: "supercarro", label: "Supercarro" },
+        ]}
+        registro={register("tipo_categoria")}
+        erro={errors.tipo_categoria?.message as string | undefined}
+      />
 
       {/* Descrição */}
       <div className="flex flex-col gap-2 col-span-2">

--- a/frontend/src/components/specialist/TipoComSugestoes.tsx
+++ b/frontend/src/components/specialist/TipoComSugestoes.tsx
@@ -1,0 +1,70 @@
+import type { UseFormRegisterReturn } from "react-hook-form";
+
+/**
+ * Campo de tipo/classificação com sugestões, mas sem trancar o especialista
+ * nelas.
+ *
+ * Era um <select>: o que não estava na lista não existia, e produto fora das
+ * classificações previstas simplesmente não entrava. Aqui vira input com
+ * <datalist>, que aceita texto livre e continua oferecendo as opções de sempre.
+ *
+ * As opções mantêm os mesmos `value` de antes, e não o rótulo humano. Isso é
+ * de propósito: o banco já tem registros gravados com esses valores
+ * ('sedan', 'iate', 'VLJ'), e trocar o que a lista grava criaria duas grafias
+ * para a mesma coisa. O rótulo vai como texto da opção — o navegador o mostra
+ * como dica ao lado do valor.
+ */
+export interface OpcaoTipo {
+  /** Valor gravado no banco. */
+  value: string;
+  /** Como explicar esse valor para quem está preenchendo. */
+  label: string;
+}
+
+interface Props {
+  id: string;
+  label: string;
+  opcoes: OpcaoTipo[];
+  registro: UseFormRegisterReturn;
+  erro?: string;
+  placeholder?: string;
+}
+
+export default function TipoComSugestoes({
+  id,
+  label,
+  opcoes,
+  registro,
+  erro,
+  placeholder = "Selecione ou digite um tipo",
+}: Props) {
+  const listId = `${id}-sugestoes`;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <label htmlFor={id} className="text-sm font-medium text-text-primary">
+        {label}
+      </label>
+      <input
+        id={id}
+        list={listId}
+        type="text"
+        autoComplete="off"
+        placeholder={placeholder}
+        {...registro}
+        className="px-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+      />
+      <datalist id={listId}>
+        {opcoes.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </datalist>
+      <span className="text-xs text-gray-500">
+        Não achou na lista? Digite o tipo do produto.
+      </span>
+      {erro && <span className="text-sm text-red-500">{erro}</span>}
+    </div>
+  );
+}

--- a/frontend/src/types/types.ts
+++ b/frontend/src/types/types.ts
@@ -1,15 +1,19 @@
 // Substituto do tipo ENUM nos postgres
 // Carro
 export type estadoValues = 'novo'| 'seminovo'| 'colecao';
-export type tipoCategoriaCarValues = 'SUV'| 'sedan'| 'coupe'| 'conversivel'| 'esportivo'| 'supercarro';
+// Tipo/classificação específica é texto livre: existem produtos fora das
+// classificações previstas, e travar a união rejeitaria em tempo de
+// compilação um valor que o banco e a API aceitam. Os valores abaixo seguem
+// como sugestão nos formulários (ver TipoComSugestoes), não como limite.
+export type tipoCategoriaCarValues = string;
 export type cambioCarValues = 'manual'| 'automatico'| 'cvt';
 export type combustivelCarValues = 'gasolina'| 'alcool'| 'flex'| 'diesel'| 'eletrico'| 'hibrido';
 // Barco
 export type combustivelBoatsValues = 'diesel'| 'gasolina'| 'eletrico'| 'hibrido';
-export type tipoEmbarcacaoBoatsValues = 'iate'| 'lancha'| 'catamara'| 'veleiro'| 'jet_boat'| 'outro';
+export type tipoEmbarcacaoBoatsValues = string;
 export type tamanhoBoatsValues = 'ate_30_pes'|'30_50_pes'|'acima_50_pes';
 // Aeronave
-export type tipoAeronaveValues = 'VLJ'| 'executivo_medio'| 'intercontinental'| 'turbohelice'| 'helicoptero'
+export type tipoAeronaveValues = string
 
 // Filtros
 // Carro


### PR DESCRIPTION
# Changelog

- Os quatro campos de tipo/classificação específica passam a aceitar texto livre;
- Selects viram input com `datalist` — as opções de sempre continuam como sugestão;
- Abre os tipos que restringiam o valor no frontend e no backend;
- Adiciona 13 testes travando a permissividade da API.

closes: [BE][FE] TASK 3.13 — Permitir tipo de produto livre nas informações específicas

---

## Onde a restrição estava (e onde não estava)

Comecei mapeando, porque a task pede para identificar todos os pontos. O resultado foi mais simples do que parecia:

| Camada | Situação |
|---|---|
| Banco | `String?` nos quatro campos — **sem enum, sem migration** |
| DTOs de criação e edição | `@IsOptional() @IsString()` — **já aceitavam livre** |
| Importação em lote | passa o valor direto — já aceitava |
| Exibição | `ProductDetails` mostra o valor cru; `enumLabel` cai para a chave — já aguentava |
| **Formulários** | `<select>` com opções fixas — **aqui travava** |
| **Tipos TS** | uniões (front) e tuplas (back) — **restrição em tempo de compilação** |

São quatro campos, não três: aeronave tem `categoria` **e** `tipo_aeronave`.

## A troca: select vira input com datalist

`<input list>` + `<datalist>` dá as duas coisas ao mesmo tempo — digita qualquer valor, e as sugestões continuam a um clique. Sem biblioteca nova e sem mudar a ligação com o react-hook-form.

**Uma decisão que vale conferir:** as sugestões mantêm os `value` antigos (`sedan`, `iate`, `VLJ`) em vez do rótulo humano (`Sedan`, `Iate`). O banco já tem registros gravados com esses valores; se a lista passasse a gravar o rótulo, a mesma categoria existiria em duas grafias. O rótulo vai como texto da `<option>` — o navegador o mostra como dica ao lado do valor.

O custo é que quem escolher "sedan" pela lista vê `sedan` no campo, não `Sedan`. Achei o mal menor perto de espalhar duas grafias pela base. Se o time preferir o inverso, é trocar `value` por `label` no componente — e aí vale um script para normalizar o que já está gravado.

## Os tipos eram a outra metade

No frontend eram uniões de literais (`'SUV' | 'sedan' | ...`): um valor livre vindo da API seria erro de compilação em qualquer tela que usasse o tipo.

No backend era mais estranho — **tuplas**, não uniões:

```ts
export type tipoCategoriaCarValues = ['SUV', 'sedan', 'coupe', ...];
```

Isso tipa o campo como um array de 6 posições, algo que nunca correspondeu ao valor real (uma string). Não fazia mal em runtime porque não há validador nesses filtros, mas era o TypeScript descrevendo errado a realidade. Os três viraram `string`.

Deixei `estado`, `cambio` e `combustivel` como estavam: são conjuntos genuinamente fechados e não fazem parte desta task.

## Testes

13 novos em `product-free-type.spec.ts`, cobrindo o quarto critério de aceite direto no contrato da API:

- carro aceita `anfíbio`, `hot rod`, `Fórmula 1` (acento, espaço, número);
- a **edição** aceita igual — não adianta liberar só a criação;
- barco aceita `traineira`; aeronave aceita `dirigível` e categoria `Agrícola`;
- as seis sugestões antigas continuam válidas — abrir não quebrou nada;
- livre não é "qualquer coisa": número ainda é rejeitado, o campo segue sendo texto.

O spec existe principalmente para que ninguém "conserte" isso reintroduzindo um `@IsIn`.

Suíte completa: **335 passando**, 36 suítes. `nest build` passa. Frontend: `tsc -b` limpo, 56 testes, componente novo sem avisos de lint.

## O que não foi verificado

Não cadastrei um produto pela tela. O caminho é longo (login de especialista, banco, S3 para as imagens) e a verificação aqui é de DTO e de tipos.

O que a revisão deveria fazer, que é o terceiro critério e o que os testes não alcançam:

1. Cadastrar um carro com tipo `anfíbio`;
2. Reabrir a edição e confirmar que o campo volta preenchido com `anfíbio`;
3. Conferir a exibição na página do produto e na aba Carros da Base de Dados.

Vale checar também o `datalist` no navegador que vocês usam — o comportamento visual (mostrar valor com o rótulo como dica) varia um pouco entre Chrome, Firefox e Safari, embora o valor gravado seja o mesmo nos três.
