### PR TITLE
fix: corrige sidebar mobile do white-label

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.6",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19.1.9",
         "@types/react-image-gallery": "^1.2.4",
@@ -38,11 +40,63 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.20",
         "globals": "^16.4.0",
+        "jsdom": "^29.1.1",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.44.0",
         "vite": "^7.1.7",
         "vitest": "^4.1.10"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -278,6 +332,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -324,6 +388,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+      "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -897,6 +1114,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1925,6 +2160,77 @@
       "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2564,6 +2870,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2597,6 +2914,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -2641,6 +2969,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2859,6 +3197,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2975,6 +3327,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2992,6 +3358,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -3014,6 +3387,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3028,6 +3412,14 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3061,6 +3453,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -3717,6 +4122,19 @@
         "react-is": "^16.7.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3794,6 +4212,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3827,6 +4252,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -4181,6 +4657,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4198,6 +4685,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoize": {
       "version": "10.1.0",
@@ -4410,6 +4904,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4492,6 +4999,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -4792,6 +5337,16 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
@@ -4846,6 +5401,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.52.5",
         "@rollup/rollup-win32-x64-msvc": "4.52.5",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4948,6 +5516,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -5068,6 +5643,52 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -5136,6 +5757,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/universal-cookie": {
@@ -5441,6 +6072,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -5448,6 +6092,41 @@
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -5492,6 +6171,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.6",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
     "@types/react-image-gallery": "^1.2.4",
@@ -41,6 +43,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.4.0",
+    "jsdom": "^29.1.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.44.0",
     "vite": "^7.1.7",

--- a/frontend/src/hooks/use-is-mobile.test.ts
+++ b/frontend/src/hooks/use-is-mobile.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { isMobileViewport } from "./use-is-mobile";
+
+describe("isMobileViewport", () => {
+  it("classifica o viewport antes do primeiro efeito do React", () => {
+    expect(isMobileViewport(767)).toBe(true);
+    expect(isMobileViewport(768)).toBe(false);
+  });
+
+  it("é seguro quando não existe window durante renderização no servidor", () => {
+    expect(isMobileViewport(undefined)).toBe(false);
+  });
+});

--- a/frontend/src/hooks/use-is-mobile.tsx
+++ b/frontend/src/hooks/use-is-mobile.tsx
@@ -1,23 +1,34 @@
 import { useEffect, useState } from "react";
 
+export function isMobileViewport(
+  viewportWidth: number | undefined,
+  breakpoint = 768,
+): boolean {
+  return viewportWidth !== undefined && viewportWidth < breakpoint;
+}
+
 export function useIsMobile(MOBILE_BREAKPOINT = 768) {
-  const [isMobile, setIsMobile] = useState<null | boolean>(null);
+  const [isMobile, setIsMobile] = useState(() =>
+    isMobileViewport(
+      typeof window === "undefined" ? undefined : window.innerWidth,
+      MOBILE_BREAKPOINT,
+    ),
+  );
 
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(isMobileViewport(window.innerWidth, MOBILE_BREAKPOINT));
     };
 
     mql.addEventListener("change", onChange);
-
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    onChange();
 
     return () => {
       mql.removeEventListener("change", onChange);
     };
   }, [MOBILE_BREAKPOINT]);
 
-  return !!isMobile;
+  return isMobile;
 }

--- a/frontend/src/layouts/Header.test.tsx
+++ b/frontend/src/layouts/Header.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { CompanyBranding } from "../types/types";
+import { AppContext, type AppContextProps } from "../contexts/AppContext";
+import Header from "./Header";
+
+const state = vi.hoisted(() => ({
+  whitelabelCompany: {
+    id: "company-1",
+    name: "AXBR Investimentos",
+    logoUrl: "https://cdn.example.com/axbr.png",
+  } as CompanyBranding,
+}));
+
+vi.mock("../hooks/use-is-mobile", () => ({ useIsMobile: () => true }));
+vi.mock("../store/authStateManager", () => ({
+  useAuth: () => ({ user: null }),
+}));
+vi.mock("../store/whitelabelStore", () => ({
+  useWhitelabel: (
+    selector: (value: { company: CompanyBranding | null }) => unknown,
+  ) => selector({ company: state.whitelabelCompany }),
+}));
+
+const appContext: AppContextProps = {
+  isSidebarCollapsed: false,
+  setSidebarCollapsed: vi.fn(),
+  isSidebarDesktopCollapsed: false,
+  toggleSidebarDesktopCollapsed: vi.fn(),
+  searchTerm: "",
+  setSearchTerm: vi.fn(),
+};
+
+describe("Header mobile", () => {
+  it("expõe um botão acessível para abrir o drawer", () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <AppContext.Provider value={appContext}>
+          <Header />
+        </AppContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(html).toContain('aria-label="Abrir menu"');
+    expect(html).toContain('aria-expanded="false"');
+    expect(html).toContain('aria-controls="main-sidebar"');
+    expect(html).toContain('alt="AXBR Investimentos"');
+  });
+});

--- a/frontend/src/layouts/Header.tsx
+++ b/frontend/src/layouts/Header.tsx
@@ -6,9 +6,10 @@ import { useAuth } from "../store/authStateManager";
 import { AppContext } from "../contexts/AppContext";
 import { useNavigate } from "react-router-dom";
 import UserDropdown from "../components/ui/UserDropdown";
-import { resolveCompanyLogo, getUserCompany } from "../utils/branding";
+import { getActiveCompany, resolveCompanyLogo } from "../utils/branding";
 import { useWhitelabel } from "../store/whitelabelStore";
 import { getRoleBasedRoute } from "../utils/roleUtils";
+import { PUBLIC_CATALOG_LINKS } from "../lib/navigation";
 
 export default function Header() {
   const { isSidebarCollapsed, setSidebarCollapsed } = useContext(AppContext);
@@ -16,18 +17,11 @@ export default function Header() {
   const { user } = useAuth();
   const navigate = useNavigate();
   const whitelabelCompany = useWhitelabel((s) => s.company);
-  const company = getUserCompany(user) ?? whitelabelCompany;
+  const company = getActiveCompany(user, whitelabelCompany);
   const brandLogo = resolveCompanyLogo(company) ?? Logo;
   const handleLogoClick = () => {
     navigate(user ? getRoleBasedRoute(user.role) : "/");
   };
-
-  // Lista de itens do menu para visitantes
-  const menuItems = [
-    { label: "Aeronaves", path: "/catalog/aircrafts" },
-    { label: "Embarcações", path: "/catalog/boats" },
-    { label: "Carros", path: "/catalog/cars" },
-  ];
 
   return (
     <>
@@ -53,11 +47,11 @@ export default function Header() {
               {/* Navegação nos links */}
               <nav>
                 <ul className="flex gap-2">
-                  {menuItems.map((item) => (
+                  {PUBLIC_CATALOG_LINKS.map((item) => (
                     <li
-                      key={item.path}
+                      key={item.to}
                       className="flex items-center p-2 gap-0.5 cursor-pointer"
-                      onClick={() => navigate(item.path)}
+                      onClick={() => navigate(item.to)}
                     >
                       <span>{item.label}</span>
                       <ChevronDown size={20} />

--- a/frontend/src/layouts/Header.tsx
+++ b/frontend/src/layouts/Header.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, TextAlignJustifyIcon, UserCircle2 } from "lucide-react";
 import Logo from "../assets/logo_brokerage.png";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { useIsMobile } from "../hooks/use-is-mobile";
 import { useAuth } from "../store/authStateManager";
 import { AppContext } from "../contexts/AppContext";
@@ -23,6 +23,12 @@ export default function Header() {
     navigate(user ? getRoleBasedRoute(user.role) : "/");
   };
 
+  useEffect(() => {
+    if (!isMobile && isSidebarCollapsed) {
+      setSidebarCollapsed(false);
+    }
+  }, [isMobile, isSidebarCollapsed, setSidebarCollapsed]);
+
   return (
     <>
       <header
@@ -34,13 +40,19 @@ export default function Header() {
       >
         <div className="flex w-full justify-between sm:flex-row-reverse items-center">
           {isMobile && (
-            // Abrir a sidebar do header em mobiles
-            <TextAlignJustifyIcon
-              size={35}
+            <button
+              id="sidebar-menu-trigger"
+              type="button"
+              aria-label={isSidebarCollapsed ? "Fechar menu" : "Abrir menu"}
+              aria-expanded={isSidebarCollapsed}
+              aria-controls="main-sidebar"
               onClick={() => {
                 setSidebarCollapsed(!isSidebarCollapsed);
               }}
-            />
+              className="flex items-center justify-center"
+            >
+              <TextAlignJustifyIcon size={35} />
+            </button>
           )}
           {!isMobile && !user && (
             <div className="flex justify-between items-center text-base w-full pl-12">
@@ -104,7 +116,11 @@ export default function Header() {
               className="cursor-pointer"
               aria-label="Ir para a página inicial"
             >
-              <img src={brandLogo} alt="BMF Lux Brokerage" className="w-25 sm:w-35 h-auto" />
+              <img
+                src={brandLogo}
+                alt={company?.name ?? "BMF Lux Brokerage"}
+                className="w-25 sm:w-35 h-auto"
+              />
             </button>
           )}
         </div>

--- a/frontend/src/layouts/Sidebar.interaction.test.tsx
+++ b/frontend/src/layouts/Sidebar.interaction.test.tsx
@@ -1,0 +1,108 @@
+/** @vitest-environment jsdom */
+
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { AppContext, type AppContextProps } from "../contexts/AppContext";
+import type { CompanyBranding, UserProps } from "../types/types";
+import Header from "./Header";
+import Sidebar from "./Sidebar";
+
+const state = vi.hoisted(() => ({
+  user: null as UserProps | null,
+  whitelabelCompany: {
+    id: "company-1",
+    name: "AXBR Investimentos",
+    logoUrl: "https://cdn.example.com/axbr.png",
+  } as CompanyBranding | null,
+}));
+
+vi.mock("../hooks/use-is-mobile", () => ({ useIsMobile: () => true }));
+vi.mock("../store/authStateManager", () => ({
+  useAuth: (selector?: (value: { user: UserProps | null }) => unknown) => {
+    const value = { user: state.user };
+    return selector ? selector(value) : value;
+  },
+}));
+vi.mock("../store/whitelabelStore", () => ({
+  useWhitelabel: (
+    selector: (value: { company: CompanyBranding | null }) => unknown,
+  ) => selector({ company: state.whitelabelCompany }),
+}));
+
+function MobileNavigationHarness() {
+  const [isSidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const appContext: AppContextProps = {
+    isSidebarCollapsed,
+    setSidebarCollapsed,
+    isSidebarDesktopCollapsed: false,
+    toggleSidebarDesktopCollapsed: vi.fn(),
+    searchTerm: "",
+    setSearchTerm: vi.fn(),
+  };
+
+  return (
+    <MemoryRouter initialEntries={["/catalog/cars"]}>
+      <AppContext.Provider value={appContext}>
+        <Header />
+        <Sidebar />
+      </AppContext.Provider>
+    </MemoryRouter>
+  );
+}
+
+describe("Sidebar mobile interactions", () => {
+  beforeEach(() => {
+    document.body.style.overflow = "clip";
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = "";
+  });
+
+  it("gerencia foco, teclado, estado inerte e scroll durante o drawer", async () => {
+    const user = userEvent.setup();
+    render(<MobileNavigationHarness />);
+
+    const trigger = screen.getByRole("button", { name: "Abrir menu" });
+    const sidebar = document.getElementById("main-sidebar");
+
+    expect(sidebar?.getAttribute("aria-hidden")).toBe("true");
+    expect(sidebar?.hasAttribute("inert")).toBe(true);
+
+    await user.click(trigger);
+
+    const dialog = screen.getByRole("dialog", { name: "Menu principal" });
+    const closeButton = within(dialog).getByRole("button", {
+      name: "Fechar menu",
+    });
+    const lastLink = within(dialog).getByRole("link", { name: "Login" });
+
+    await waitFor(() => expect(document.activeElement).toBe(closeButton));
+    expect(dialog.hasAttribute("aria-hidden")).toBe(false);
+    expect(dialog.hasAttribute("inert")).toBe(false);
+    expect(document.body.style.overflow).toBe("hidden");
+
+    lastLink.focus();
+    await user.tab();
+    expect(document.activeElement).toBe(closeButton);
+
+    closeButton.focus();
+    await user.tab({ shift: true });
+    expect(document.activeElement).toBe(lastLink);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(sidebar?.getAttribute("aria-hidden")).toBe("true");
+      expect(document.activeElement).toBe(
+        screen.getByRole("button", { name: "Abrir menu" }),
+      );
+    });
+    expect(sidebar?.hasAttribute("inert")).toBe(true);
+    expect(document.body.style.overflow).toBe("clip");
+  });
+});

--- a/frontend/src/layouts/Sidebar.test.tsx
+++ b/frontend/src/layouts/Sidebar.test.tsx
@@ -21,16 +21,16 @@ vi.mock("../store/whitelabelStore", () => ({
   ) => selector({ company: state.whitelabelCompany }),
 }));
 
-const appContext: AppContextProps = {
-  isSidebarCollapsed: true,
-  setSidebarCollapsed: vi.fn(),
-  isSidebarDesktopCollapsed: false,
-  toggleSidebarDesktopCollapsed: vi.fn(),
-  searchTerm: "",
-  setSearchTerm: vi.fn(),
-};
+function renderSidebar(isOpen = true) {
+  const appContext: AppContextProps = {
+    isSidebarCollapsed: isOpen,
+    setSidebarCollapsed: vi.fn(),
+    isSidebarDesktopCollapsed: false,
+    toggleSidebarDesktopCollapsed: vi.fn(),
+    searchTerm: "",
+    setSearchTerm: vi.fn(),
+  };
 
-function renderSidebar() {
   return renderToStaticMarkup(
     <MemoryRouter initialEntries={["/catalog/cars"]}>
       <AppContext.Provider value={appContext}>
@@ -84,5 +84,13 @@ describe("Sidebar", () => {
     expect(html).toContain('href="/office/processes"');
     expect(html).toContain('href="/office/company"');
     expect(html).not.toContain('href="/login"');
+  });
+
+  it("remove o drawer mobile fechado da navegação assistiva", () => {
+    const html = renderSidebar(false);
+
+    expect(html).toContain('id="main-sidebar"');
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain("inert");
   });
 });

--- a/frontend/src/layouts/Sidebar.test.tsx
+++ b/frontend/src/layouts/Sidebar.test.tsx
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { CompanyBranding, UserProps } from "../types/types";
+import { AppContext, type AppContextProps } from "../contexts/AppContext";
+import Sidebar from "./Sidebar";
+
+const state = vi.hoisted(() => ({
+  user: null as UserProps | null,
+  whitelabelCompany: null as CompanyBranding | null,
+}));
+
+vi.mock("../hooks/use-is-mobile", () => ({ useIsMobile: () => true }));
+vi.mock("../store/authStateManager", () => ({
+  useAuth: (selector: (value: { user: UserProps | null }) => unknown) =>
+    selector({ user: state.user }),
+}));
+vi.mock("../store/whitelabelStore", () => ({
+  useWhitelabel: (
+    selector: (value: { company: CompanyBranding | null }) => unknown,
+  ) => selector({ company: state.whitelabelCompany }),
+}));
+
+const appContext: AppContextProps = {
+  isSidebarCollapsed: true,
+  setSidebarCollapsed: vi.fn(),
+  isSidebarDesktopCollapsed: false,
+  toggleSidebarDesktopCollapsed: vi.fn(),
+  searchTerm: "",
+  setSearchTerm: vi.fn(),
+};
+
+function renderSidebar() {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={["/catalog/cars"]}>
+      <AppContext.Provider value={appContext}>
+        <Sidebar />
+      </AppContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    state.user = null;
+    state.whitelabelCompany = null;
+    vi.clearAllMocks();
+  });
+
+  it("renderiza marca e destinos públicos para visitante white-label", () => {
+    state.whitelabelCompany = {
+      id: "company-1",
+      name: "AXBR Investimentos",
+      logoUrl: "https://cdn.example.com/axbr.png",
+    };
+
+    const html = renderSidebar();
+
+    expect(html).toContain('src="https://cdn.example.com/axbr.png"');
+    expect(html).toContain('href="/catalog/cars"');
+    expect(html).toContain('href="/catalog/boats"');
+    expect(html).toContain('href="/catalog/aircrafts"');
+    expect(html).toContain('href="/register"');
+    expect(html).toContain('href="/login"');
+  });
+
+  it("mantém os destinos autenticados do usuário OFFICE", () => {
+    state.user = {
+      id: "office-1",
+      name: "Gerente",
+      surname: "Teste",
+      email: "office@example.com",
+      cpf: "00000000000",
+      rg: "000000000",
+      role: "OFFICE",
+      company: { id: "company-1", name: "AXBR Investimentos" },
+    };
+
+    const html = renderSidebar();
+
+    expect(html).toContain('href="/office/dashboard"');
+    expect(html).toContain('href="/office/consultants"');
+    expect(html).toContain('href="/office/clients"');
+    expect(html).toContain('href="/office/processes"');
+    expect(html).toContain('href="/office/company"');
+    expect(html).not.toContain('href="/login"');
+  });
+});

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -85,6 +85,8 @@ export default function Sidebar() {
 
     wasOpenRef.current = true;
     closeButtonRef.current?.focus();
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -114,7 +116,10 @@ export default function Sidebar() {
     };
 
     document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousBodyOverflow;
+    };
   }, [isMobile, isSidebarCollapsed, setSidebarCollapsed]);
 
   return (

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -20,7 +20,7 @@ import {
   LogIn,
   type LucideIcon,
 } from "lucide-react";
-import { useContext } from "react";
+import { useContext, useEffect, useRef } from "react";
 import { Link, useLocation } from "react-router-dom";
 import Logo from "../assets/logo_brokerage.png";
 import { AppContext } from "../contexts/AppContext";
@@ -68,6 +68,54 @@ export default function Sidebar() {
   const brandLogo = resolveCompanyLogo(company) ?? Logo;
   const isDesktopCollapsed = !isMobile && isSidebarDesktopCollapsed;
   const links = getSidebarLinks(user?.role);
+  const sidebarRef = useRef<HTMLElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const wasOpenRef = useRef(false);
+
+  useEffect(() => {
+    if (!isMobile) return;
+
+    if (!isSidebarCollapsed) {
+      if (wasOpenRef.current) {
+        document.getElementById("sidebar-menu-trigger")?.focus();
+      }
+      wasOpenRef.current = false;
+      return;
+    }
+
+    wasOpenRef.current = true;
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setSidebarCollapsed(false);
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const focusableElements = Array.from(
+        sidebarRef.current?.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled])',
+        ) ?? [],
+      );
+      const first = focusableElements[0];
+      const last = focusableElements.at(-1);
+
+      if (!first || !last) return;
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isMobile, isSidebarCollapsed, setSidebarCollapsed]);
 
   return (
     <>
@@ -78,6 +126,13 @@ export default function Sidebar() {
         />
       )}
       <aside
+        ref={sidebarRef}
+        id="main-sidebar"
+        role={isMobile ? "dialog" : undefined}
+        aria-label={isMobile ? "Menu principal" : undefined}
+        aria-modal={isMobile && isSidebarCollapsed ? true : undefined}
+        aria-hidden={isMobile && !isSidebarCollapsed ? true : undefined}
+        inert={isMobile && !isSidebarCollapsed ? true : undefined}
         className={`
           ${
             isMobile
@@ -106,6 +161,9 @@ export default function Sidebar() {
         {isMobile && (
           <div className="flex flex-col">
             <button
+              ref={closeButtonRef}
+              type="button"
+              aria-label="Fechar menu"
               className="p-4 self-end"
               onClick={() => setSidebarCollapsed(!isSidebarCollapsed)}
             >

--- a/frontend/src/layouts/Sidebar.tsx
+++ b/frontend/src/layouts/Sidebar.tsx
@@ -16,14 +16,42 @@ import {
   Calculator,
   PanelLeft,
   ClipboardList,
+  UserPlus,
+  LogIn,
+  type LucideIcon,
 } from "lucide-react";
 import { useContext } from "react";
-import { AppContext } from "../contexts/AppContext";
-import Logo from "../assets/logo_brokerage.png";
-import { useIsMobile } from "../hooks/use-is-mobile";
 import { Link, useLocation } from "react-router-dom";
+import Logo from "../assets/logo_brokerage.png";
+import { AppContext } from "../contexts/AppContext";
+import { useIsMobile } from "../hooks/use-is-mobile";
+import {
+  getSidebarLinks,
+  type NavigationIcon,
+} from "../lib/navigation";
 import { useAuth } from "../store/authStateManager";
-import { resolveCompanyLogo, getUserCompany } from "../utils/branding";
+import { useWhitelabel } from "../store/whitelabelStore";
+import { getActiveCompany, resolveCompanyLogo } from "../utils/branding";
+
+const NAVIGATION_ICONS: Record<NavigationIcon, LucideIcon> = {
+  home: Home,
+  dashboard: LayoutDashboard,
+  building: Building2,
+  users: Users,
+  "user-cog": UserCog,
+  car: Car,
+  ship: Ship,
+  plane: Plane,
+  package: Package,
+  "file-pen": FilePen,
+  settings: Settings,
+  percent: Percent,
+  database: Database,
+  calculator: Calculator,
+  "clipboard-list": ClipboardList,
+  "user-plus": UserPlus,
+  "log-in": LogIn,
+};
 
 export default function Sidebar() {
   const {
@@ -35,182 +63,11 @@ export default function Sidebar() {
   const isMobile = useIsMobile();
   const location = useLocation();
   const user = useAuth((state) => state.user);
-  const company = getUserCompany(user);
+  const whitelabelCompany = useWhitelabel((state) => state.company);
+  const company = getActiveCompany(user, whitelabelCompany);
   const brandLogo = resolveCompanyLogo(company) ?? Logo;
   const isDesktopCollapsed = !isMobile && isSidebarDesktopCollapsed;
-
-  // Lista de links por cargo
-  const links = [];
-
-  if (user) {
-    switch (user.role) {
-      case "CUSTOMER":
-        links.push(
-          {
-            to: "/customer/home",
-            label: "Home",
-            icon: <Home size={20} />,
-          },
-          {
-            to: "/customer/consultoria",
-            label: "Consultoria",
-            icon: <Users size={20} />,
-          },
-          {
-            to: "/customer/processes",
-            label: "Meus Processos",
-            icon: <FilePen size={20} />,
-          },
-          {
-            to: "/catalog/cars",
-            label: "Carros",
-            icon: <Car size={20} />,
-          },
-          {
-            to: "/catalog/boats",
-            label: "Embarcações",
-            icon: <Ship size={20} />,
-          },
-          {
-            to: "/catalog/aircrafts",
-            label: "Aviões",
-            icon: <Plane size={20} />,
-          },
-        );
-        break;
-      case "CONSULTANT":
-        links.push(
-          {
-            to: "/consultant/dashboard",
-            label: "Dashboard",
-            icon: <LayoutDashboard size={20} />,
-          },
-          {
-            to: "/consultant/clients",
-            label: "Meus Clientes",
-            icon: <Users size={20} />,
-          },
-          {
-            to: "/consultant/processes",
-            label: "Processos",
-            icon: <FilePen size={20} />,
-          },
-          {
-            to: "/catalog/cars",
-            label: "Carros",
-            icon: <Car size={20} />,
-          },
-          {
-            to: "/catalog/boats",
-            label: "Embarcações",
-            icon: <Ship size={20} />,
-          },
-          {
-            to: "/catalog/aircrafts",
-            label: "Aviões",
-            icon: <Plane size={20} />,
-          },
-        );
-        break;
-      case "SPECIALIST":
-        links.push(
-          {
-            to: "/specialist/dashboard",
-            label: "Dashboard",
-            icon: <LayoutDashboard size={20} />,
-          },
-          {
-            to: "/specialist/products",
-            label: "Meus produtos",
-            icon: <Package size={20} />,
-          },
-          {
-            to: "/specialist/processes",
-            label: "Meus processos",
-            icon: <FilePen size={20} />,
-          },
-        );
-        break;
-      case "ADMIN":
-        links.push(
-          {
-            to: "/admin/dashboard",
-            label: "Dashboard",
-            icon: <LayoutDashboard size={20} />,
-          },
-          {
-            to: "/admin/companies",
-            label: "Escritórios",
-            icon: <Building2 size={20} />,
-          },
-          {
-            to: "/office/consultants",
-            label: "Consultores",
-            icon: <Users size={20} />,
-          },
-          {
-            to: "/admin/specialists",
-            label: "Especialistas",
-            icon: <UserCog size={20} />,
-          },
-          {
-            to: "/admin/commissions",
-            label: "Comissões",
-            icon: <Percent size={20} />,
-          },
-          {
-            to: "/admin/calculator",
-            label: "Calculadora",
-            icon: <Calculator size={20} />,
-          },
-          {
-            to: "/admin/database",
-            label: "Base de dados",
-            icon: <Database size={20} />,
-          },
-          {
-            to: "/admin/settings",
-            label: "Configurações",
-            icon: <Settings size={20} />,
-          },
-          {
-            to: "/admin/my-company",
-            label: "Minha Empresa",
-            icon: <Building2 size={20} />,
-          },
-        );
-        break;
-      case "OFFICE":
-        links.push(
-          {
-            to: "/office/dashboard",
-            label: "Dashboard",
-            icon: <LayoutDashboard size={20} />,
-          },
-          {
-            to: "/office/consultants",
-            label: "Consultores",
-            icon: <Users size={20} />,
-          },
-          {
-            to: "/office/clients",
-            label: "Clientes",
-            icon: <UserCog size={20} />,
-          },
-          {
-            to: "/office/processes",
-            label: "Processos",
-            icon: <ClipboardList size={20} />,
-          },
-          {
-            to: "/office/company",
-            label: "Minha Empresa",
-            icon: <Building2 size={20} />,
-          },
-        );
-        break;
-    }
-  }
+  const links = getSidebarLinks(user?.role);
 
   return (
     <>
@@ -229,9 +86,19 @@ export default function Sidebar() {
                 : "-translate-x-full opacity-0"
               : "translate-x-0 opacity-100"
           }
-          ${isMobile ? "w-2/5 fixed h-full" : isDesktopCollapsed ? "w-16 min-h-screen" : "w-64 min-h-screen"}
+          ${
+            isMobile
+              ? "w-72 max-w-[85vw] fixed h-full overflow-y-auto"
+              : isDesktopCollapsed
+                ? "w-16 min-h-screen"
+                : "w-64 min-h-screen"
+          }
           top-0 left-0 ease-out z-50 fixed text-brand-secondary-fg
-          ${isMobile ? "transition-normal duration-300" : "transition-[width] duration-200"}
+          ${
+            isMobile
+              ? "transition-normal duration-300"
+              : "transition-[width] duration-200"
+          }
         `}
         style={{ backgroundColor: "var(--brand-secondary)" }}
       >
@@ -249,10 +116,16 @@ export default function Sidebar() {
 
         {/* Botão de colapsar sidebar (desktop) */}
         {!isMobile && (
-          <div className={`flex p-3 ${isDesktopCollapsed ? "justify-center" : "justify-end"}`}>
+          <div
+            className={`flex p-3 ${
+              isDesktopCollapsed ? "justify-center" : "justify-end"
+            }`}
+          >
             <button
               onClick={toggleSidebarDesktopCollapsed}
-              aria-label={isDesktopCollapsed ? "Expandir menu" : "Recolher menu"}
+              aria-label={
+                isDesktopCollapsed ? "Expandir menu" : "Recolher menu"
+              }
               title={isDesktopCollapsed ? "Expandir menu" : undefined}
               className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-brand-secondary-fg/60 transition-colors hover:bg-brand-secondary-fg/10 hover:text-brand-secondary-fg"
             >
@@ -277,31 +150,35 @@ export default function Sidebar() {
             isDesktopCollapsed ? "px-2 items-center" : "px-6"
           }`}
         >
-          {links.map((link) => (
-            <Link
-              key={link.to}
-              to={link.to}
-              onClick={() => {
-                if (isMobile) setSidebarCollapsed(false);
-              }}
-              title={isDesktopCollapsed ? link.label : undefined}
-              className={`w-full flex gap-3 items-center p-3 rounded-md transition-colors ${
-                isDesktopCollapsed ? "justify-center px-2" : ""
-              } ${
-                location.pathname === link.to
-                  ? "text-brand-primary-fg"
-                  : "text-gray-300 hover:bg-white/10 hover:text-brand-secondary-fg"
-              }`}
-              style={
-                location.pathname === link.to
-                  ? { backgroundColor: "var(--brand-primary)" }
-                  : undefined
-              }
-            >
-              {link.icon}
-              {!isDesktopCollapsed && <p>{link.label}</p>}
-            </Link>
-          ))}
+          {links.map((link) => {
+            const Icon = NAVIGATION_ICONS[link.icon];
+
+            return (
+              <Link
+                key={link.to}
+                to={link.to}
+                onClick={() => {
+                  if (isMobile) setSidebarCollapsed(false);
+                }}
+                title={isDesktopCollapsed ? link.label : undefined}
+                className={`w-full flex gap-3 items-center p-3 rounded-md transition-colors ${
+                  isDesktopCollapsed ? "justify-center px-2" : ""
+                } ${
+                  location.pathname === link.to
+                    ? "text-brand-primary-fg"
+                    : "text-gray-300 hover:bg-white/10 hover:text-brand-secondary-fg"
+                }`}
+                style={
+                  location.pathname === link.to
+                    ? { backgroundColor: "var(--brand-primary)" }
+                    : undefined
+                }
+              >
+                <Icon size={20} />
+                {!isDesktopCollapsed && <p>{link.label}</p>}
+              </Link>
+            );
+          })}
         </nav>
       </aside>
     </>

--- a/frontend/src/lib/navigation.test.ts
+++ b/frontend/src/lib/navigation.test.ts
@@ -15,26 +15,66 @@ describe("getSidebarLinks", () => {
     ]);
   });
 
-  it("preserva todas as rotas do gerente de escritório", () => {
-    expect(getSidebarLinks("OFFICE").map(({ to }) => to)).toEqual([
-      "/office/dashboard",
-      "/office/consultants",
-      "/office/clients",
-      "/office/processes",
-      "/office/company",
-    ]);
+  it.each<[UserRole, Array<{ to: string; label: string }>]>([
+    [
+      "CUSTOMER",
+      [
+        { to: "/customer/home", label: "Home" },
+        { to: "/customer/consultoria", label: "Consultoria" },
+        { to: "/customer/processes", label: "Meus Processos" },
+        { to: "/catalog/cars", label: "Carros" },
+        { to: "/catalog/boats", label: "Embarcações" },
+        { to: "/catalog/aircrafts", label: "Aviões" },
+      ],
+    ],
+    [
+      "CONSULTANT",
+      [
+        { to: "/consultant/dashboard", label: "Dashboard" },
+        { to: "/consultant/clients", label: "Meus Clientes" },
+        { to: "/consultant/processes", label: "Processos" },
+        { to: "/catalog/cars", label: "Carros" },
+        { to: "/catalog/boats", label: "Embarcações" },
+        { to: "/catalog/aircrafts", label: "Aviões" },
+      ],
+    ],
+    [
+      "SPECIALIST",
+      [
+        { to: "/specialist/dashboard", label: "Dashboard" },
+        { to: "/specialist/products", label: "Meus produtos" },
+        { to: "/specialist/processes", label: "Meus processos" },
+      ],
+    ],
+    [
+      "ADMIN",
+      [
+        { to: "/admin/dashboard", label: "Dashboard" },
+        { to: "/admin/companies", label: "Escritórios" },
+        { to: "/office/consultants", label: "Consultores" },
+        { to: "/admin/specialists", label: "Especialistas" },
+        { to: "/admin/commissions", label: "Comissões" },
+        { to: "/admin/calculator", label: "Calculadora" },
+        { to: "/admin/database", label: "Base de dados" },
+        { to: "/admin/settings", label: "Configurações" },
+        { to: "/admin/my-company", label: "Minha Empresa" },
+      ],
+    ],
+    [
+      "OFFICE",
+      [
+        { to: "/office/dashboard", label: "Dashboard" },
+        { to: "/office/consultants", label: "Consultores" },
+        { to: "/office/clients", label: "Clientes" },
+        { to: "/office/processes", label: "Processos" },
+        { to: "/office/company", label: "Minha Empresa" },
+      ],
+    ],
+  ])("preserva toda a navegação autenticada de %s", (role, expected) => {
+    expect(getSidebarLinks(role).map(({ to, label }) => ({ to, label }))).toEqual(
+      expected,
+    );
   });
-
-  it.each(["CUSTOMER", "CONSULTANT"] as const)(
-    "preserva o rótulo autenticado de aeronaves para %s",
-    (role) => {
-      const aircraft = getSidebarLinks(role).find(
-        ({ to }) => to === "/catalog/aircrafts",
-      );
-
-      expect(aircraft?.label).toBe("Aviões");
-    },
-  );
 
   it("não concede rotas privilegiadas a papel desconhecido", () => {
     expect(getSidebarLinks("UNKNOWN" as UserRole)).toEqual([]);

--- a/frontend/src/lib/navigation.test.ts
+++ b/frontend/src/lib/navigation.test.ts
@@ -25,6 +25,17 @@ describe("getSidebarLinks", () => {
     ]);
   });
 
+  it.each(["CUSTOMER", "CONSULTANT"] as const)(
+    "preserva o rótulo autenticado de aeronaves para %s",
+    (role) => {
+      const aircraft = getSidebarLinks(role).find(
+        ({ to }) => to === "/catalog/aircrafts",
+      );
+
+      expect(aircraft?.label).toBe("Aviões");
+    },
+  );
+
   it("não concede rotas privilegiadas a papel desconhecido", () => {
     expect(getSidebarLinks("UNKNOWN" as UserRole)).toEqual([]);
   });

--- a/frontend/src/lib/navigation.test.ts
+++ b/frontend/src/lib/navigation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import type { UserRole } from "../types/types";
+import { getSidebarLinks } from "./navigation";
+
+describe("getSidebarLinks", () => {
+  it("oferece catálogo, cadastro e login ao visitante", () => {
+    expect(
+      getSidebarLinks(null).map(({ to, label }) => ({ to, label })),
+    ).toEqual([
+      { to: "/catalog/cars", label: "Carros" },
+      { to: "/catalog/boats", label: "Embarcações" },
+      { to: "/catalog/aircrafts", label: "Aeronaves" },
+      { to: "/register", label: "Cadastrar-se" },
+      { to: "/login", label: "Login" },
+    ]);
+  });
+
+  it("preserva todas as rotas do gerente de escritório", () => {
+    expect(getSidebarLinks("OFFICE").map(({ to }) => to)).toEqual([
+      "/office/dashboard",
+      "/office/consultants",
+      "/office/clients",
+      "/office/processes",
+      "/office/company",
+    ]);
+  });
+
+  it("não concede rotas privilegiadas a papel desconhecido", () => {
+    expect(getSidebarLinks("UNKNOWN" as UserRole)).toEqual([]);
+  });
+});

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -37,6 +37,12 @@ export const PUBLIC_SIDEBAR_LINKS: readonly NavigationItem[] = [
   { to: "/login", label: "Login", icon: "log-in" },
 ];
 
+const AUTHENTICATED_CATALOG_LINKS: readonly NavigationItem[] = [
+  { to: "/catalog/cars", label: "Carros", icon: "car" },
+  { to: "/catalog/boats", label: "Embarcações", icon: "ship" },
+  { to: "/catalog/aircrafts", label: "Aviões", icon: "plane" },
+];
+
 const ROLE_SIDEBAR_LINKS: Record<
   UserRole,
   readonly NavigationItem[]
@@ -49,7 +55,7 @@ const ROLE_SIDEBAR_LINKS: Record<
       label: "Meus Processos",
       icon: "file-pen",
     },
-    ...PUBLIC_CATALOG_LINKS,
+    ...AUTHENTICATED_CATALOG_LINKS,
   ],
   CONSULTANT: [
     {
@@ -67,7 +73,7 @@ const ROLE_SIDEBAR_LINKS: Record<
       label: "Processos",
       icon: "file-pen",
     },
-    ...PUBLIC_CATALOG_LINKS,
+    ...AUTHENTICATED_CATALOG_LINKS,
   ],
   SPECIALIST: [
     {

--- a/frontend/src/lib/navigation.ts
+++ b/frontend/src/lib/navigation.ts
@@ -1,0 +1,122 @@
+import type { UserRole } from "../types/types";
+
+export type NavigationIcon =
+  | "home"
+  | "dashboard"
+  | "building"
+  | "users"
+  | "user-cog"
+  | "car"
+  | "ship"
+  | "plane"
+  | "package"
+  | "file-pen"
+  | "settings"
+  | "percent"
+  | "database"
+  | "calculator"
+  | "clipboard-list"
+  | "user-plus"
+  | "log-in";
+
+export interface NavigationItem {
+  to: string;
+  label: string;
+  icon: NavigationIcon;
+}
+
+export const PUBLIC_CATALOG_LINKS: readonly NavigationItem[] = [
+  { to: "/catalog/cars", label: "Carros", icon: "car" },
+  { to: "/catalog/boats", label: "Embarcações", icon: "ship" },
+  { to: "/catalog/aircrafts", label: "Aeronaves", icon: "plane" },
+];
+
+export const PUBLIC_SIDEBAR_LINKS: readonly NavigationItem[] = [
+  ...PUBLIC_CATALOG_LINKS,
+  { to: "/register", label: "Cadastrar-se", icon: "user-plus" },
+  { to: "/login", label: "Login", icon: "log-in" },
+];
+
+const ROLE_SIDEBAR_LINKS: Record<
+  UserRole,
+  readonly NavigationItem[]
+> = {
+  CUSTOMER: [
+    { to: "/customer/home", label: "Home", icon: "home" },
+    { to: "/customer/consultoria", label: "Consultoria", icon: "users" },
+    {
+      to: "/customer/processes",
+      label: "Meus Processos",
+      icon: "file-pen",
+    },
+    ...PUBLIC_CATALOG_LINKS,
+  ],
+  CONSULTANT: [
+    {
+      to: "/consultant/dashboard",
+      label: "Dashboard",
+      icon: "dashboard",
+    },
+    {
+      to: "/consultant/clients",
+      label: "Meus Clientes",
+      icon: "users",
+    },
+    {
+      to: "/consultant/processes",
+      label: "Processos",
+      icon: "file-pen",
+    },
+    ...PUBLIC_CATALOG_LINKS,
+  ],
+  SPECIALIST: [
+    {
+      to: "/specialist/dashboard",
+      label: "Dashboard",
+      icon: "dashboard",
+    },
+    {
+      to: "/specialist/products",
+      label: "Meus produtos",
+      icon: "package",
+    },
+    {
+      to: "/specialist/processes",
+      label: "Meus processos",
+      icon: "file-pen",
+    },
+  ],
+  ADMIN: [
+    { to: "/admin/dashboard", label: "Dashboard", icon: "dashboard" },
+    { to: "/admin/companies", label: "Escritórios", icon: "building" },
+    { to: "/office/consultants", label: "Consultores", icon: "users" },
+    {
+      to: "/admin/specialists",
+      label: "Especialistas",
+      icon: "user-cog",
+    },
+    { to: "/admin/commissions", label: "Comissões", icon: "percent" },
+    { to: "/admin/calculator", label: "Calculadora", icon: "calculator" },
+    { to: "/admin/database", label: "Base de dados", icon: "database" },
+    { to: "/admin/settings", label: "Configurações", icon: "settings" },
+    { to: "/admin/my-company", label: "Minha Empresa", icon: "building" },
+  ],
+  OFFICE: [
+    { to: "/office/dashboard", label: "Dashboard", icon: "dashboard" },
+    { to: "/office/consultants", label: "Consultores", icon: "users" },
+    { to: "/office/clients", label: "Clientes", icon: "user-cog" },
+    {
+      to: "/office/processes",
+      label: "Processos",
+      icon: "clipboard-list",
+    },
+    { to: "/office/company", label: "Minha Empresa", icon: "building" },
+  ],
+};
+
+export function getSidebarLinks(
+  role: UserRole | null | undefined,
+): readonly NavigationItem[] {
+  if (role == null) return PUBLIC_SIDEBAR_LINKS;
+  return ROLE_SIDEBAR_LINKS[role] ?? [];
+}

--- a/frontend/src/utils/branding.test.ts
+++ b/frontend/src/utils/branding.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { CompanyBranding, UserProps } from "../types/types";
+import { getActiveCompany } from "./branding";
+
+function company(id: string): CompanyBranding {
+  return { id, name: `Empresa ${id}` };
+}
+
+function userWithCompany(value: CompanyBranding | null): UserProps {
+  return {
+    id: "user-1",
+    name: "Usuário",
+    surname: "Teste",
+    email: "usuario@example.com",
+    cpf: "00000000000",
+    rg: "000000000",
+    role: "OFFICE",
+    company: value,
+  };
+}
+
+describe("getActiveCompany", () => {
+  it("prioriza a empresa do usuário sobre o white-label em memória", () => {
+    const authenticatedCompany = company("authenticated");
+
+    expect(
+      getActiveCompany(
+        userWithCompany(authenticatedCompany),
+        company("whitelabel"),
+      ),
+    ).toBe(authenticatedCompany);
+  });
+
+  it("usa a empresa white-label quando não há usuário", () => {
+    const whitelabelCompany = company("whitelabel");
+
+    expect(getActiveCompany(null, whitelabelCompany)).toBe(whitelabelCompany);
+  });
+
+  it("retorna null sem empresa autenticada ou white-label", () => {
+    expect(getActiveCompany(null, null)).toBeNull();
+  });
+});

--- a/frontend/src/utils/branding.ts
+++ b/frontend/src/utils/branding.ts
@@ -9,6 +9,13 @@ export function getUserCompany(user: UserProps | null): CompanyBranding | null {
   return user?.company ?? user?.consultant?.company ?? null;
 }
 
+export function getActiveCompany(
+  user: UserProps | null,
+  whitelabelCompany: CompanyBranding | null,
+): CompanyBranding | null {
+  return getUserCompany(user) ?? whitelabelCompany;
+}
+
 export function getBrandColors(company: CompanyBranding | null) {
   const primary =
     company?.primary_color ?? company?.color_identity?.[0] ?? DEFAULT_BRAND_PRIMARY;


### PR DESCRIPTION
## Problema

No acesso mobile a um catálogo white-label, o drawer lateral exibia a marca padrão da BMF e não oferecia nenhum destino para visitantes sem sessão.

## Causa raiz

- O `Header` resolvia a empresa ativa pelo contexto white-label, mas a `Sidebar` considerava somente a empresa do usuário autenticado.
- A sidebar era renderizada para visitantes mobile, porém seus links eram criados apenas quando existia um usuário.
- A detecção inicial do viewport começava como desktop, permitindo um flash de layout incorreto no primeiro render.

## Solução

- Centraliza a precedência da marca ativa: empresa do usuário → empresa white-label → BMF.
- Compartilha as definições de navegação entre header e sidebar.
- Adiciona ao menu público mobile: Carros, Embarcações, Aeronaves, Cadastrar-se e Login.
- Preserva integralmente os menus autenticados de `CUSTOMER`, `CONSULTANT`, `SPECIALIST`, `ADMIN` e `OFFICE`.
- Torna o drawer acessível por teclado, com botão semântico, foco inicial, ciclo de Tab/Shift+Tab, Escape, retorno de foco, estado inerte fechado e bloqueio/restauração do scroll.
- Corrige a detecção inicial do viewport e fecha o drawer ao migrar para desktop.

## Validação

- `npm test -- --pool=forks --maxWorkers=2`: 15 arquivos e 73 testes aprovados.
- `npm run build`: build de produção aprovado.
- `npm run lint`: 0 erros; 124 warnings preexistentes fora deste escopo.
- Validação manual em viewport 390 × 844: marca consistente, cinco destinos públicos, fechamento por link/Escape, foco restaurado e trap de teclado.
- Revisão adversarial e revisão final independente concluídas sem achados críticos ou importantes pendentes.

## Escopo

- Alterações somente no frontend.
- Nenhuma alteração em backend, banco, deploy ou `main`.
- Nenhum documento ou artefato do fluxo Superpowers incluído.
